### PR TITLE
feat(jxsuite.com): light scheme + auto/light/dark switcher + accessibility pass

### DIFF
--- a/sites/jxsuite.com/components/cta-button.json
+++ b/sites/jxsuite.com/components/cta-button.json
@@ -27,7 +27,7 @@
         "fontWeight": "600",
         "fontSize": "0.9375rem",
         "transition": "background-color 0.15s, border-color 0.15s, color 0.15s",
-        "backgroundColor": "${state.isPrimary ? 'var(--color-accent)' : 'transparent'}",
+        "backgroundColor": "${state.isPrimary ? 'var(--color-accent-solid)' : 'transparent'}",
         "color": "${state.isPrimary ? 'white' : 'var(--color-text-secondary)'}",
         "border": "${state.isPrimary ? '1px solid transparent' : '1px solid var(--color-border)'}"
       },

--- a/sites/jxsuite.com/components/doc-tip.json
+++ b/sites/jxsuite.com/components/doc-tip.json
@@ -4,7 +4,7 @@
     "display": "block",
     "margin": "1.5rem 0",
     "padding": "0.875rem 1rem",
-    "borderLeft": "3px solid #059669",
+    "borderLeft": "3px solid var(--color-success)",
     "borderRadius": "0 8px 8px 0",
     "backgroundColor": "var(--color-bg-surface)",
     "fontSize": "0.9375rem",
@@ -20,7 +20,7 @@
         "fontWeight": "600",
         "textTransform": "uppercase",
         "letterSpacing": "0.08em",
-        "color": "#059669",
+        "color": "var(--color-success)",
         "marginBottom": "0.375rem"
       },
       "children": ["Tip"]

--- a/sites/jxsuite.com/components/doc-warning.json
+++ b/sites/jxsuite.com/components/doc-warning.json
@@ -4,7 +4,7 @@
     "display": "block",
     "margin": "1.5rem 0",
     "padding": "0.875rem 1rem",
-    "borderLeft": "3px solid #d97706",
+    "borderLeft": "3px solid var(--color-warning)",
     "borderRadius": "0 8px 8px 0",
     "backgroundColor": "var(--color-bg-surface)",
     "fontSize": "0.9375rem",
@@ -20,7 +20,7 @@
         "fontWeight": "600",
         "textTransform": "uppercase",
         "letterSpacing": "0.08em",
-        "color": "#d97706",
+        "color": "var(--color-warning)",
         "marginBottom": "0.375rem"
       },
       "children": ["Warning"]

--- a/sites/jxsuite.com/components/site-search.json
+++ b/sites/jxsuite.com/components/site-search.json
@@ -96,6 +96,7 @@
         "Search",
         {
           "tagName": "kbd",
+          "attributes": { "aria-hidden": "true" },
           "textContent": "⌘K",
           "style": {
             "fontFamily": "inherit",
@@ -120,7 +121,7 @@
         "backgroundColor": "var(--color-bg-secondary)",
         "border": "1px solid var(--color-border)",
         "borderRadius": "12px",
-        "boxShadow": "0 24px 64px rgba(0, 0, 0, 0.5)",
+        "boxShadow": "0 24px 64px var(--color-shadow-strong)",
         "opacity": "0",
         "transform": "translateY(-8px)",
         "transition": "opacity 0.15s ease, transform 0.15s ease, display 0.15s allow-discrete, overlay 0.15s allow-discrete",
@@ -134,6 +135,12 @@
         "@starting-style": {
           ":popover-open": { "opacity": "0", "transform": "translateY(-8px)" },
           "&:popover-open::backdrop": { "opacity": "0" }
+        },
+        "@(prefers-reduced-motion: reduce)": {
+          "transition": "none",
+          "transform": "none",
+          ":popover-open": { "transform": "none" },
+          "::backdrop": { "transition": "none" }
         }
       },
       "children": [
@@ -161,7 +168,12 @@
             "outline": "none",
             "color": "var(--color-text-primary)",
             "fontSize": "1rem",
-            "padding": "0.9rem 1.1rem"
+            "padding": "0.9rem 1.1rem",
+            ":focus-visible": {
+              "outline": "none",
+              "borderBottomColor": "var(--color-accent)",
+              "boxShadow": "inset 0 -1px 0 var(--color-accent)"
+            }
           }
         },
         {
@@ -207,7 +219,17 @@
                         {
                           "tagName": "a",
                           "attributes": { "href": "${item.url}", "class": "search-hit" },
-                          "textContent": "# ${item.heading}"
+                          "children": [
+                            {
+                              "tagName": "span",
+                              "attributes": { "aria-hidden": "true" },
+                              "textContent": "# "
+                            },
+                            {
+                              "tagName": "span",
+                              "textContent": "${item.heading}"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -218,6 +240,7 @@
             {
               "$title": "Empty State",
               "tagName": "div",
+              "attributes": { "role": "status" },
               "textContent": "${state.searchQuery && (!state.searchResults || state.searchResults.length === 0) ? (state.searchReady ? 'No results for \"' + state.searchQuery + '\"' : 'Loading index…') : ''}",
               "style": {
                 "color": "var(--color-text-secondary)",

--- a/sites/jxsuite.com/components/site-toolbar.json
+++ b/sites/jxsuite.com/components/site-toolbar.json
@@ -5,7 +5,7 @@
     "position": "sticky",
     "top": "0",
     "zIndex": "100",
-    "backgroundColor": "rgba(10, 10, 10, 0.8)",
+    "backgroundColor": "var(--color-backdrop)",
     "backdropFilter": "blur(12px)",
     "borderBottom": "1px solid var(--color-border)",
     "padding": "0 clamp(1rem, 3vw, 2rem)"
@@ -13,6 +13,7 @@
   "children": [
     {
       "tagName": "nav",
+      "attributes": { "aria-label": "Main" },
       "style": {
         "maxWidth": "var(--max-width)",
         "margin": "0 auto",
@@ -123,6 +124,7 @@
               "children": ["Docs"]
             },
             { "tagName": "site-search" },
+            { "tagName": "theme-toggle" },
             {
               "tagName": "a",
               "attributes": {
@@ -146,7 +148,7 @@
               "style": {
                 "display": "inline-flex",
                 "alignItems": "center",
-                "backgroundColor": "var(--color-accent)",
+                "backgroundColor": "var(--color-accent-solid)",
                 "color": "white",
                 "textDecoration": "none",
                 "fontSize": "0.875rem",
@@ -215,7 +217,7 @@
           "$title": "Mobile Menu Popover",
           "tagName": "nav",
           "id": "site-mobile-menu",
-          "attributes": { "popover": "" },
+          "attributes": { "popover": "", "aria-label": "Site menu" },
           "style": {
             "inset": "0 0 0 auto",
             "width": "min(300px, 80vw)",
@@ -225,7 +227,7 @@
             "border": "none",
             "margin": "0",
             "padding": "4.5rem 0 2rem",
-            "boxShadow": "-8px 0 24px rgba(0, 0, 0, 0.4)",
+            "boxShadow": "-8px 0 24px var(--color-shadow)",
             "display": "flex",
             "flexDirection": "column",
             "transform": "translateX(100%)",
@@ -240,6 +242,12 @@
             "@starting-style": {
               ":popover-open": { "transform": "translateX(100%)" },
               "&:popover-open::backdrop": { "opacity": "0" }
+            },
+            "@(prefers-reduced-motion: reduce)": {
+              "transition": "none",
+              "transform": "none",
+              ":popover-open": { "transform": "none" },
+              "::backdrop": { "transition": "none" }
             }
           },
           "children": [
@@ -382,6 +390,21 @@
               "children": ["GitHub"]
             },
             {
+              "$title": "Mobile Scheme Row",
+              "tagName": "div",
+              "style": {
+                "display": "flex",
+                "alignItems": "center",
+                "justifyContent": "space-between",
+                "padding": "0.9rem 1.5rem",
+                "color": "var(--color-text-primary)",
+                "fontSize": "1rem",
+                "fontWeight": "500",
+                "borderBottom": "1px solid var(--color-border-subtle)"
+              },
+              "children": ["Color scheme", { "tagName": "theme-toggle" }]
+            },
+            {
               "tagName": "a",
               "attributes": {
                 "href": "/download",
@@ -392,7 +415,7 @@
                 "display": "block",
                 "margin": "1.25rem 1.5rem 0",
                 "padding": "0.75rem 1.5rem",
-                "backgroundColor": "var(--color-accent)",
+                "backgroundColor": "var(--color-accent-solid)",
                 "color": "white",
                 "textDecoration": "none",
                 "fontSize": "1rem",

--- a/sites/jxsuite.com/components/theme-toggle.json
+++ b/sites/jxsuite.com/components/theme-toggle.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "../../../packages/schema/schema.json",
+  "$id": "ThemeToggle",
+  "$description": "Color-scheme switcher cycling auto → light → dark. Persists the forced scheme under the jx-color-scheme localStorage key and mirrors it onto the data-color-scheme attribute (spec §9.5); multiple instances stay in sync via a jx-color-scheme CustomEvent.",
+
+  "state": {
+    "scheme": "auto",
+    "cycle": {
+      "$prototype": "Function",
+      "arguments": ["state"],
+      "body": "const order = ['auto', 'light', 'dark']; const next = order[(order.indexOf(state.scheme) + 1) % 3]; state.scheme = next; try { if (next === 'auto') { localStorage.removeItem('jx-color-scheme'); } else { localStorage.setItem('jx-color-scheme', next); } } catch {} if (next === 'auto') { document.documentElement.removeAttribute('data-color-scheme'); } else { document.documentElement.setAttribute('data-color-scheme', next); } document.dispatchEvent(new CustomEvent('jx-color-scheme', { detail: next }));"
+    },
+    "onMount": {
+      "$prototype": "Function",
+      "arguments": ["state"],
+      "body": "state.scheme = document.documentElement.getAttribute('data-color-scheme') || 'auto'; document.addEventListener('jx-color-scheme', (e) => { state.scheme = e.detail; });"
+    }
+  },
+
+  "tagName": "theme-toggle",
+  "style": {
+    "display": "inline-flex"
+  },
+
+  "children": [
+    {
+      "$title": "Scheme Button",
+      "tagName": "button",
+      "attributes": {
+        "type": "button",
+        "aria-label": "Color scheme: ${state.scheme}. Activate for ${state.scheme === 'auto' ? 'light' : state.scheme === 'light' ? 'dark' : 'auto'}."
+      },
+      "onclick": { "$ref": "#/state/cycle" },
+      "style": {
+        "display": "inline-flex",
+        "alignItems": "center",
+        "justifyContent": "center",
+        "width": "2rem",
+        "height": "2rem",
+        "background": "var(--color-bg-surface)",
+        "border": "1px solid var(--color-border)",
+        "borderRadius": "var(--radius)",
+        "color": "var(--color-text-secondary)",
+        "cursor": "pointer",
+        "fontSize": "0.9375rem",
+        "lineHeight": "1",
+        "padding": "0",
+        "transition": "color 0.15s, border-color 0.15s",
+        ":hover": {
+          "color": "var(--color-text-primary)",
+          "borderColor": "var(--color-text-secondary)"
+        }
+      },
+      "children": [
+        {
+          "tagName": "span",
+          "attributes": { "aria-hidden": "true" },
+          "textContent": "${state.scheme === 'auto' ? '◐' : state.scheme === 'light' ? '☀' : '☾'}"
+        }
+      ]
+    },
+    {
+      "$title": "Scheme Announcement",
+      "tagName": "span",
+      "attributes": { "role": "status" },
+      "style": {
+        "position": "absolute",
+        "width": "1px",
+        "height": "1px",
+        "overflow": "hidden",
+        "clipPath": "inset(50%)",
+        "whiteSpace": "nowrap"
+      },
+      "textContent": "${'Color scheme: ' + state.scheme}"
+    }
+  ]
+}

--- a/sites/jxsuite.com/layouts/base.json
+++ b/sites/jxsuite.com/layouts/base.json
@@ -14,9 +14,30 @@
     { "$ref": "../components/site-footer.json" }
   ],
   "children": [
+    {
+      "$title": "Skip Link",
+      "tagName": "a",
+      "attributes": { "href": "#main-content" },
+      "style": {
+        "position": "absolute",
+        "left": "-9999px",
+        "zIndex": "200",
+        "padding": "0.75rem 1.25rem",
+        "backgroundColor": "var(--color-bg-surface)",
+        "color": "var(--color-text-primary)",
+        "borderRadius": "var(--radius)",
+        "textDecoration": "none",
+        ":focus": {
+          "left": "1rem",
+          "top": "1rem"
+        }
+      },
+      "children": ["Skip to content"]
+    },
     { "tagName": "site-toolbar" },
     {
       "tagName": "main",
+      "id": "main-content",
       "style": { "flex": "1" },
       "children": [{ "tagName": "slot" }]
     },

--- a/sites/jxsuite.com/layouts/docs.json
+++ b/sites/jxsuite.com/layouts/docs.json
@@ -22,6 +22,26 @@
     }
   },
   "children": [
+    {
+      "$title": "Skip Link",
+      "tagName": "a",
+      "attributes": { "href": "#main-content" },
+      "style": {
+        "position": "absolute",
+        "left": "-9999px",
+        "zIndex": "200",
+        "padding": "0.75rem 1.25rem",
+        "backgroundColor": "var(--color-bg-surface)",
+        "color": "var(--color-text-primary)",
+        "borderRadius": "var(--radius)",
+        "textDecoration": "none",
+        ":focus": {
+          "left": "1rem",
+          "top": "1rem"
+        }
+      },
+      "children": ["Skip to content"]
+    },
     { "tagName": "site-toolbar" },
     {
       "$title": "Docs Mobile Nav Trigger",
@@ -34,7 +54,7 @@
         "alignItems": "center",
         "gap": "0.5rem",
         "padding": "0.6rem clamp(1rem, 3vw, 2rem)",
-        "backgroundColor": "rgba(10, 10, 10, 0.9)",
+        "backgroundColor": "var(--color-backdrop-strong)",
         "backdropFilter": "blur(12px)",
         "borderBottom": "1px solid var(--color-border)",
         "@--md": { "display": "flex" }
@@ -43,8 +63,7 @@
         {
           "tagName": "button",
           "attributes": {
-            "popovertarget": "docs-mobile-nav",
-            "aria-label": "Open docs navigation"
+            "popovertarget": "docs-mobile-nav"
           },
           "style": {
             "display": "inline-flex",
@@ -58,7 +77,14 @@
             "padding": "0.4rem 0.75rem",
             "cursor": "pointer"
           },
-          "textContent": "☰  Docs menu"
+          "children": [
+            {
+              "tagName": "span",
+              "attributes": { "aria-hidden": "true" },
+              "textContent": "☰"
+            },
+            "Docs menu"
+          ]
         }
       ]
     },
@@ -73,7 +99,8 @@
       },
       "children": [
         {
-          "tagName": "aside",
+          "tagName": "nav",
+          "attributes": { "aria-label": "Docs navigation" },
           "style": {
             "width": "260px",
             "flexShrink": "0",
@@ -126,6 +153,7 @@
         },
         {
           "tagName": "main",
+          "id": "main-content",
           "style": {
             "flex": "1",
             "minWidth": "0",
@@ -139,7 +167,7 @@
       "$title": "Docs Mobile Nav Popover",
       "tagName": "nav",
       "id": "docs-mobile-nav",
-      "attributes": { "popover": "" },
+      "attributes": { "popover": "", "aria-label": "Docs navigation" },
       "style": {
         "inset": "0 auto 0 0",
         "width": "min(300px, 82vw)",
@@ -150,7 +178,7 @@
         "margin": "0",
         "padding": "4.5rem 0.5rem 2rem",
         "overflowY": "auto",
-        "boxShadow": "8px 0 24px rgba(0, 0, 0, 0.4)",
+        "boxShadow": "8px 0 24px var(--color-shadow)",
         "transform": "translateX(-100%)",
         "transition": "transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), display 0.3s allow-discrete, overlay 0.3s allow-discrete",
         ":popover-open": { "transform": "translateX(0)" },
@@ -163,6 +191,12 @@
         "@starting-style": {
           ":popover-open": { "transform": "translateX(-100%)" },
           "&:popover-open::backdrop": { "opacity": "0" }
+        },
+        "@(prefers-reduced-motion: reduce)": {
+          "transition": "none",
+          "transform": "none",
+          ":popover-open": { "transform": "none" },
+          "::backdrop": { "transition": "none" }
         }
       },
       "children": [

--- a/sites/jxsuite.com/pages/docs/[...slug].json
+++ b/sites/jxsuite.com/pages/docs/[...slug].json
@@ -44,6 +44,31 @@
           "border": "1px solid var(--color-border)",
           "borderBottomWidth": "2px",
           "borderRadius": "4px"
+        },
+        "& pre": {
+          "backgroundColor": "var(--color-bg-surface)",
+          "border": "1px solid var(--color-border)",
+          "borderRadius": "var(--radius)",
+          "padding": "1rem 1.25rem",
+          "overflowX": "auto",
+          "fontSize": "0.875rem",
+          "lineHeight": "1.6"
+        },
+        "& code": {
+          "fontFamily": "var(--font-mono)",
+          "fontSize": "0.875em"
+        },
+        "& p code": {
+          "backgroundColor": "var(--color-bg-surface)",
+          "border": "1px solid var(--color-border-subtle)",
+          "borderRadius": "4px",
+          "padding": "0.1rem 0.3rem"
+        },
+        "& li code": {
+          "backgroundColor": "var(--color-bg-surface)",
+          "border": "1px solid var(--color-border-subtle)",
+          "borderRadius": "4px",
+          "padding": "0.1rem 0.3rem"
         }
       },
       "children": "${state.page.$children ?? []}"

--- a/sites/jxsuite.com/pages/studio.json
+++ b/sites/jxsuite.com/pages/studio.json
@@ -103,7 +103,7 @@
                 "margin": "0 auto",
                 "border": "1px solid var(--color-border)",
                 "borderRadius": "var(--radius-lg)",
-                "boxShadow": "0 24px 64px rgba(0, 0, 0, 0.45)"
+                "boxShadow": "0 24px 64px var(--color-shadow-strong)"
               }
             }
           ]

--- a/sites/jxsuite.com/project.json
+++ b/sites/jxsuite.com/project.json
@@ -46,25 +46,62 @@
     "--": "1280px",
     "--lg": "(max-width: 1024px)",
     "--md": "(max-width: 768px)",
-    "--sm": "(max-width: 640px)"
+    "--sm": "(max-width: 640px)",
+    "--dark": "(prefers-color-scheme: dark)"
   },
   "style": {
-    "--color-bg-primary": "#0a0a0a",
-    "--color-bg-secondary": "#111111",
-    "--color-bg-surface": "#1a1a1a",
-    "--color-bg-surface-hover": "#222222",
-    "--color-border": "#222222",
-    "--color-border-subtle": "#1a1a1a",
-    "--color-text-primary": "#fafafa",
-    "--color-text-secondary": "#a1a1aa",
-    "--color-text-muted": "#71717a",
+    "--color-bg-primary": "#ffffff",
+    "--color-bg-secondary": "#fafafa",
+    "--color-bg-surface": "#f4f4f5",
+    "--color-bg-surface-hover": "#e4e4e7",
+    "--color-border": "#d4d4d8",
+    "--color-border-subtle": "#e4e4e7",
+    "--color-text-primary": "#18181b",
+    "--color-text-secondary": "#52525b",
+    "--color-text-muted": "#5f5f68",
     "--color-brand": "#1a1a2e",
-    "--color-accent": "#3b82f6",
-    "--color-accent-hover": "#60a5fa",
+    "--color-accent": "#2563eb",
+    "--color-accent-hover": "#1d4ed8",
+    "--color-accent-solid": "#2563eb",
+    "--color-backdrop": "rgba(255, 255, 255, 0.85)",
+    "--color-backdrop-strong": "rgba(255, 255, 255, 0.92)",
+    "--color-shadow": "rgba(0, 0, 0, 0.12)",
+    "--color-shadow-strong": "rgba(0, 0, 0, 0.18)",
+    "--color-success": "#047857",
+    "--color-warning": "#b45309",
+    "--color-highlight-bg": "#eef2ff",
+    "--color-highlight-text": "#1e1b4b",
+    "--color-highlight-border": "#c7d2fe",
     "--font-mono": "'JetBrains Mono', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace",
     "--radius": "8px",
     "--radius-lg": "12px",
     "--max-width": "1200px",
+    "@--dark": {
+      "--color-bg-primary": "#0a0a0a",
+      "--color-bg-secondary": "#111111",
+      "--color-bg-surface": "#1a1a1a",
+      "--color-bg-surface-hover": "#222222",
+      "--color-border": "#222222",
+      "--color-border-subtle": "#1a1a1a",
+      "--color-text-primary": "#fafafa",
+      "--color-text-secondary": "#a1a1aa",
+      "--color-text-muted": "#8b8b94",
+      "--color-accent": "#3b82f6",
+      "--color-accent-hover": "#60a5fa",
+      "--color-backdrop": "rgba(10, 10, 10, 0.8)",
+      "--color-backdrop-strong": "rgba(10, 10, 10, 0.9)",
+      "--color-shadow": "rgba(0, 0, 0, 0.4)",
+      "--color-shadow-strong": "rgba(0, 0, 0, 0.5)",
+      "--color-success": "#059669",
+      "--color-warning": "#d97706",
+      "--color-highlight-bg": "rgba(255, 255, 255, 0.97)",
+      "--color-highlight-text": "#1a1a2e",
+      "--color-highlight-border": "rgba(0, 0, 0, 0.08)"
+    },
+    ":focus-visible": {
+      "outline": "2px solid var(--color-accent)",
+      "outlineOffset": "2px"
+    },
     "margin": "0",
     "padding": "0",
     "fontFamily": "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
@@ -113,10 +150,10 @@
             "borderLeft": "none"
           },
           ":last-child": {
-            "color": "#1a1a2e",
+            "color": "var(--color-highlight-text)",
             "fontWeight": "600",
-            "borderLeftColor": "rgba(0, 0, 0, 0.08)",
-            "backgroundColor": "rgba(255, 255, 255, 0.97)"
+            "borderLeftColor": "var(--color-highlight-border)",
+            "backgroundColor": "var(--color-highlight-bg)"
           }
         },
         "th": {
@@ -129,10 +166,10 @@
             "borderLeft": "none"
           },
           ":last-child": {
-            "color": "#1a1a2e",
+            "color": "var(--color-highlight-text)",
             "fontWeight": "600",
-            "borderLeftColor": "rgba(0, 0, 0, 0.08)",
-            "backgroundColor": "rgba(255, 255, 255, 0.97)"
+            "borderLeftColor": "var(--color-highlight-border)",
+            "backgroundColor": "var(--color-highlight-bg)"
           }
         }
       }


### PR DESCRIPTION
The site was hardcoded dark-only. Light tokens (WCAG AA-checked) are now the base and the previous dark values moved verbatim into an @--dark block, so dark-OS visitors see no change while light-OS visitors get a native light scheme; a new theme-toggle island in the toolbar (desktop + mobile menu) cycles auto → light → dark via the spec §9.5 contract.

- palette: new tokens for backdrop, shadow, success/warning callouts, and the compare-table highlight column (previously baked light-on-white literals); --color-accent-solid keeps white-on-accent buttons at AA in both schemes (previously 3.68:1); dark --color-text-muted bumped #71717a → #8b8b94 (previously 4.10:1 on the dark background).
- tokenization sweep: toolbar backdrop, popover shadows, doc-tip/doc-warning accents, search modal shadow, studio page shadow, cta-button primary.
- a11y: skip links + main-content targets in both layouts, global :focus-visible outline, search-input focus style (outline:none previously unreplaced), aria-hidden decorative glyphs (☰, # prefix, ⌘K), labeled nav landmarks, role=status on search empty state, prefers-reduced-motion guards on all three popovers.
- docs polish: code fences get surface background, border, and overflow-x scrolling (previously unstyled and overflowing on mobile); inline code chips.