### PR TITLE
feat(parser): build-time syntax highlighting for markdown code fences

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,8 @@
       "dependencies": {
         "@jxsuite/markup": "workspace:^",
         "@jxsuite/schema": "workspace:^",
+        "@shikijs/langs": "^4.3.1",
+        "@shikijs/themes": "^4.3.1",
         "glob": "^13.0.6",
         "mdast-util-to-string": "^4.0.0",
         "remark-directive": "^4.0.0",
@@ -84,6 +86,7 @@
         "remark-parse": "^11.0.0",
         "remark-parse-frontmatter": "^1.0.3",
         "remark-stringify": "^11.0.0",
+        "shiki": "^4.3.1",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0",
         "yaml": "^2.9.0",
@@ -986,6 +989,22 @@
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.74.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA=="],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
+
+    "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@shoelace-style/animations": ["@shoelace-style/animations@1.2.0", "", {}, "sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw=="],
 
@@ -2075,6 +2094,10 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
@@ -2205,7 +2228,13 @@
 
     "regenerate-unicode-properties": ["regenerate-unicode-properties@10.2.2", "", { "dependencies": { "regenerate": "^1.4.2" } }, "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
     "regex-not": ["regex-not@1.0.2", "", { "dependencies": { "extend-shallow": "^3.0.2", "safe-regex": "^1.1.0" } }, "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "regexpp": ["regexpp@3.2.0", "", {}, "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="],
 
@@ -2304,6 +2333,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
 
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -1201,6 +1201,38 @@
     url = "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz";
     hash = "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==";
   };
+  "@shikijs/core@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz";
+    hash = "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==";
+  };
+  "@shikijs/engine-javascript@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz";
+    hash = "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==";
+  };
+  "@shikijs/engine-oniguruma@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz";
+    hash = "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==";
+  };
+  "@shikijs/langs@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz";
+    hash = "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==";
+  };
+  "@shikijs/primitive@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz";
+    hash = "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==";
+  };
+  "@shikijs/themes@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz";
+    hash = "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==";
+  };
+  "@shikijs/types@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz";
+    hash = "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==";
+  };
+  "@shikijs/vscode-textmate@10.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz";
+    hash = "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==";
+  };
   "@shoelace-style/animations@1.2.0" = fetchurl {
     url = "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.2.0.tgz";
     hash = "sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw==";
@@ -3669,6 +3701,14 @@
     url = "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz";
     hash = "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==";
   };
+  "oniguruma-parser@0.12.2" = fetchurl {
+    url = "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz";
+    hash = "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==";
+  };
+  "oniguruma-to-es@4.3.6" = fetchurl {
+    url = "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz";
+    hash = "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==";
+  };
   "optionator@0.9.4" = fetchurl {
     url = "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz";
     hash = "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==";
@@ -3965,6 +4005,18 @@
     url = "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz";
     hash = "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==";
   };
+  "regex-recursion@6.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz";
+    hash = "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==";
+  };
+  "regex-utilities@2.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz";
+    hash = "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==";
+  };
+  "regex@6.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz";
+    hash = "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==";
+  };
   "regexpp@3.2.0" = fetchurl {
     url = "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz";
     hash = "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==";
@@ -4192,6 +4244,10 @@
   "shebang-regex@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz";
     hash = "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==";
+  };
+  "shiki@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/shiki/-/shiki-4.3.1.tgz";
+    hash = "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==";
   };
   "side-channel-list@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz";

--- a/docs/framework/site/content-collections.md
+++ b/docs/framework/site/content-collections.md
@@ -119,6 +119,8 @@ Frontmatter and data fields live under `data` (`${state.post.data.title}`); for 
 
 Markdown headings in `$children` carry automatic anchor `id`s — the heading text lowercased, punctuation stripped, spaces hyphenated, with `-2`, `-3` suffixes deduplicating repeats in document order. The entry's table of contents (`_meta.toc`: `depth`, `text`, `id` per heading) uses the same ids, so TOC links, search results, and hand-written `#fragment` URLs all land on the rendered section.
 
+Fenced code blocks in `$children` arrive syntax-highlighted: recognized languages become token spans carrying `--shiki-light`/`--shiki-dark` color variables that follow the site's [color scheme](/docs/framework/concepts/color-schemes). See [Jx Markdown](/docs/framework/site/jx-markdown) for the language set.
+
 ## Schema validation
 
 Every entry is validated against its content type's `schema` when collections load — at build time and on the dev server. Missing required fields and type mismatches are reported with the content type and entry id, so a bad frontmatter key fails loudly instead of rendering an empty spot. The same schema drives Studio's [frontmatter forms](/docs/studio/editing/frontmatter) and the content-type builder's field editor.

--- a/docs/framework/site/jx-markdown.md
+++ b/docs/framework/site/jx-markdown.md
@@ -6,6 +6,7 @@ spec:
 code:
   - extensions/parser/src/transpile.ts
   - extensions/parser/src/serialize.ts
+  - extensions/parser/src/highlight.ts
 ---
 
 # Jx Markdown
@@ -140,6 +141,8 @@ An [array repeater](/docs/studio/design/repeaters) has no `tagName`, so it seria
 ## Standard Markdown
 
 Plain Markdown maps to the elements you'd expect: headings to `h1`–`h6`, paragraphs to `p`, emphasis to `em`/`strong`, links to `a`, images to `img`, lists to `ul`/`ol` + `li`, fenced code to `pre` > `code`, tables to `table` structures. Mixing prose and directives in one file is the normal case, not a special one.
+
+Fenced code with a recognized language tag (`json`, `ts`, `js`, `bash`, `html`, `css`, `yaml`, `md`, and their aliases) is syntax-highlighted at build time: each token becomes a `span` carrying its light and dark colors as `--shiki-light`/`--shiki-dark` CSS variables, so highlighting follows the site's [color scheme](/docs/framework/concepts/color-schemes) automatically. Unknown languages fall back to plain text — no fence ever breaks.
 
 :::doc-note
 These docs are themselves Jx Markdown: every aside like this one is a container directive (`:::doc-note`, `:::doc-tip`, `:::doc-warning`) rendered by a component the docs site registers via `$elements` on its content collection.

--- a/extensions/parser/package.json
+++ b/extensions/parser/package.json
@@ -50,6 +50,8 @@
   "dependencies": {
     "@jxsuite/markup": "workspace:^",
     "@jxsuite/schema": "workspace:^",
+    "@shikijs/langs": "^4.3.1",
+    "@shikijs/themes": "^4.3.1",
     "glob": "^13.0.6",
     "mdast-util-to-string": "^4.0.0",
     "remark-directive": "^4.0.0",
@@ -58,6 +60,7 @@
     "remark-parse": "^11.0.0",
     "remark-parse-frontmatter": "^1.0.3",
     "remark-stringify": "^11.0.0",
+    "shiki": "^4.3.1",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "yaml": "^2.9.0"

--- a/extensions/parser/src/highlight.ts
+++ b/extensions/parser/src/highlight.ts
@@ -1,0 +1,112 @@
+/**
+ * Build-time syntax highlighting for fenced code blocks (node-only).
+ *
+ * A synchronous Shiki core (JavaScript regex engine — no WASM, no async) tokenizes a fixed
+ * grammar set against a light + dark GitHub theme pair. Tokens are emitted as span elements
+ * carrying both colors as CSS custom properties (--shiki-light / --shiki-dark); the page's
+ * stylesheet decides which one paints, so highlighting follows the color-scheme contract
+ * (spec §9.5) for auto and forced schemes alike.
+ *
+ * Lives outside the browser-safe transpile module: only the compile-time markdown path
+ * (processMarkdown in md.ts) pays for the grammars.
+ *
+ * @docs framework/site/jx-markdown
+ * @module @jxsuite/parser/highlight
+ * @license MIT
+ */
+
+import { createHighlighterCoreSync } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import githubDark from "@shikijs/themes/github-dark-default";
+import githubLight from "@shikijs/themes/github-light-default";
+import css from "@shikijs/langs/css";
+import html from "@shikijs/langs/html";
+import javascript from "@shikijs/langs/javascript";
+import json from "@shikijs/langs/json";
+import markdown from "@shikijs/langs/markdown";
+import shellscript from "@shikijs/langs/shellscript";
+import typescript from "@shikijs/langs/typescript";
+import yaml from "@shikijs/langs/yaml";
+import type { JxElement } from "@jxsuite/schema/types";
+import type { HighlighterCore } from "shiki/core";
+
+const THEMES = { dark: "github-dark-default", light: "github-light-default" } as const;
+
+let _highlighter: HighlighterCore | null = null;
+
+/** Lazy singleton — grammar/theme setup only runs when a fence is actually highlighted. */
+function getHighlighter(): HighlighterCore {
+  _highlighter ??= createHighlighterCoreSync({
+    engine: createJavaScriptRegexEngine(),
+    langs: [json, typescript, javascript, markdown, html, shellscript, css, yaml],
+    themes: [githubLight, githubDark],
+  });
+  return _highlighter;
+}
+
+/**
+ * Tokenize a fenced code block into span elements with dual-theme color variables. Returns null for
+ * unknown languages (callers keep the plain-text fallback).
+ *
+ * @param {string} code
+ * @param {string} lang - Fence info string (grammar name or registered alias)
+ * @returns {(JxElement | string)[] | null}
+ */
+export function highlightFence(code: string, lang: string): (JxElement | string)[] | null {
+  const h = getHighlighter();
+  if (!h.getLoadedLanguages().includes(lang)) {
+    return null;
+  }
+  const { tokens } = h.codeToTokens(code, { defaultColor: false, lang, themes: THEMES });
+  const out: (JxElement | string)[] = [];
+  for (const [i, line] of tokens.entries()) {
+    if (i > 0) {
+      out.push("\n");
+    }
+    for (const token of line) {
+      const span: JxElement = { tagName: "span", textContent: token.content };
+      if (token.htmlStyle && Object.keys(token.htmlStyle).length > 0) {
+        span.style = token.htmlStyle as Record<string, string>;
+      }
+      out.push(span);
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk a transpiled Jx tree and highlight every `pre > code.language-*` block in place. Unknown
+ * languages and bare fences keep their plain textContent.
+ *
+ * @param {(JxElement | string)[]} nodes
+ */
+export function highlightCodeBlocks(nodes: (JxElement | string)[]): void {
+  for (const node of nodes) {
+    if (!node || typeof node !== "object") {
+      continue;
+    }
+    if (node.tagName === "pre" && Array.isArray(node.children)) {
+      for (const child of node.children) {
+        if (!child || typeof child !== "object" || child.tagName !== "code") {
+          continue;
+        }
+        const lang = /^language-(\S+)/.exec(child.className ?? "")?.[1];
+        const code = child.textContent;
+        if (!lang || typeof code !== "string" || code.length === 0) {
+          continue;
+        }
+        const spans = highlightFence(code, lang);
+        if (!spans) {
+          continue;
+        }
+        delete child.textContent;
+        child.children = spans;
+        child.className = `${child.className} shiki`;
+      }
+      continue;
+    }
+    if (Array.isArray(node.children)) {
+      highlightCodeBlocks(node.children as (JxElement | string)[]);
+    }
+  }
+}

--- a/extensions/parser/src/md.ts
+++ b/extensions/parser/src/md.ts
@@ -21,6 +21,7 @@ import { readFileSync } from "node:fs";
 import { basename, extname, relative, resolve as resolvePath } from "node:path";
 import { globSync } from "glob";
 import { assignHeadingIds, mdastNodeToJx } from "./transpile.ts";
+import { highlightCodeBlocks } from "./highlight.ts";
 import type { MarkdownFileResult, MdastNode, UnifiedProcessor } from "./types.ts";
 import type { JxElement } from "@jxsuite/schema/types";
 
@@ -185,6 +186,9 @@ export function processMarkdown(
     | JxElement
     | string
   )[];
+
+  // Build-time syntax highlighting: fence text becomes dual-theme token spans in place.
+  highlightCodeBlocks($children);
 
   // One walk assigns deduplicated heading ids AND builds $toc, so rendered anchors and the
   // Table of contents agree by construction (specs/parser.md).

--- a/extensions/parser/tests/highlight.test.ts
+++ b/extensions/parser/tests/highlight.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+
+import { highlightCodeBlocks, highlightFence } from "../src/highlight";
+import { processMarkdown } from "../src/md";
+import type { JxElement } from "@jxsuite/schema/types";
+
+// ─── highlightFence ───────────────────────────────────────────────────────────
+
+describe("highlightFence", () => {
+  test("tokenizes a known language into spans with dual-theme variables", () => {
+    const spans = highlightFence('{ "a": 1 }', "json")!;
+    expect(spans.length).toBeGreaterThan(1);
+    const first = spans[0] as JxElement;
+    expect(first.tagName).toBe("span");
+    expect(typeof first.textContent).toBe("string");
+    expect(first.style).toHaveProperty("--shiki-light");
+    expect(first.style).toHaveProperty("--shiki-dark");
+    const joined = spans
+      .map((s) => (typeof s === "string" ? s : ((s as JxElement).textContent ?? "")))
+      .join("");
+    expect(joined).toBe('{ "a": 1 }');
+  });
+
+  test("joins lines with newline strings, preserving the source text", () => {
+    const code = '{\n  "a": 1\n}';
+    const spans = highlightFence(code, "json")!;
+    expect(spans.filter((s) => s === "\n")).toHaveLength(2);
+    const joined = spans
+      .map((s) => (typeof s === "string" ? s : ((s as JxElement).textContent ?? "")))
+      .join("");
+    expect(joined).toBe(code);
+  });
+
+  test("resolves registered grammar aliases (bash → shellscript, ts → typescript)", () => {
+    expect(highlightFence("echo hi", "bash")).not.toBeNull();
+    expect(highlightFence("const x: number = 1;", "ts")).not.toBeNull();
+    expect(highlightFence("# Title", "md")).not.toBeNull();
+  });
+
+  test("returns null for unknown languages", () => {
+    expect(highlightFence("PRINT 1", "cobol")).toBeNull();
+    expect(highlightFence("x", "not-a-language")).toBeNull();
+  });
+});
+
+// ─── highlightCodeBlocks ──────────────────────────────────────────────────────
+
+describe("highlightCodeBlocks", () => {
+  const fence = (lang: string | null, text: string): JxElement => ({
+    children: [
+      {
+        tagName: "code",
+        textContent: text,
+        ...(lang ? { className: `language-${lang}` } : {}),
+      },
+    ],
+    tagName: "pre",
+  });
+
+  test("replaces fence text with token spans and marks the code element", () => {
+    const tree: (JxElement | string)[] = [fence("json", '{ "a": 1 }')];
+    highlightCodeBlocks(tree);
+    const code = (tree[0] as JxElement).children![0] as JxElement;
+    expect(code.className).toBe("language-json shiki");
+    expect(code.textContent).toBeUndefined();
+    expect(Array.isArray(code.children)).toBe(true);
+    expect((code.children![0] as JxElement).tagName).toBe("span");
+  });
+
+  test("leaves unknown languages and bare fences untouched", () => {
+    const unknown = fence("cobol", "PRINT 1");
+    const bare = fence(null, "plain text");
+    highlightCodeBlocks([unknown, bare]);
+    expect((unknown.children![0] as JxElement).textContent).toBe("PRINT 1");
+    expect((bare.children![0] as JxElement).textContent).toBe("plain text");
+  });
+
+  test("recurses into nested containers", () => {
+    const tree: (JxElement | string)[] = [
+      { children: ["intro", fence("json", "{}")], tagName: "div" },
+    ];
+    highlightCodeBlocks(tree);
+    const pre = (tree[0] as JxElement).children![1] as JxElement;
+    const code = pre.children![0] as JxElement;
+    expect(code.className).toContain("shiki");
+  });
+
+  test("ignores strings and empty code elements", () => {
+    const empty = fence("json", "");
+    highlightCodeBlocks(["hello", empty]);
+    expect((empty.children![0] as JxElement).textContent).toBe("");
+  });
+});
+
+// ─── processMarkdown integration ──────────────────────────────────────────────
+
+describe("processMarkdown highlighting", () => {
+  test("fenced blocks come out highlighted, prose untouched", () => {
+    const source = ["Some prose.", "", "```json", '{ "a": 1 }', "```", ""].join("\n");
+    const result = processMarkdown(source, "/x.md");
+    expect(result.$children[0]).toEqual({ tagName: "p", textContent: "Some prose." });
+    const pre = result.$children[1] as JxElement;
+    expect(pre.tagName).toBe("pre");
+    const code = pre.children![0] as JxElement;
+    expect(code.className).toBe("language-json shiki");
+    expect((code.children![0] as JxElement).style).toHaveProperty("--shiki-light");
+  });
+
+  test("unknown fence languages keep plain text output", () => {
+    const source = ["```cobol", "PRINT 1", "```", ""].join("\n");
+    const result = processMarkdown(source, "/x.md");
+    const code = (result.$children[0] as JxElement).children![0] as JxElement;
+    expect(code.className).toBe("language-cobol");
+    expect(code.textContent).toBe("PRINT 1");
+  });
+});

--- a/sites/jxsuite.com/pages/docs/[...slug].json
+++ b/sites/jxsuite.com/pages/docs/[...slug].json
@@ -54,6 +54,12 @@
           "fontSize": "0.875rem",
           "lineHeight": "1.6"
         },
+        "& pre span": {
+          "color": "var(--shiki-light)"
+        },
+        "@--dark": {
+          "& pre span": { "color": "var(--shiki-dark)" }
+        },
         "& code": {
           "fontFamily": "var(--font-mono)",
           "fontSize": "0.875em"

--- a/specs/jx-markdown.md
+++ b/specs/jx-markdown.md
@@ -363,6 +363,17 @@ Standard markdown nodes map to Jx elements:
 | `---`          | `hr`                                         |
 | Table          | `table` > `thead`/`tbody` > `tr` > `th`/`td` |
 
+Fenced code with a known language tag is syntax-highlighted at compile time in the node-side
+markdown path (`processMarkdown`): the `code` element's text is replaced by token `span`
+children, each carrying its light and dark colors as `--shiki-light` / `--shiki-dark` CSS
+custom properties, and the `code` element gains a `shiki` class alongside `language-<lang>`.
+The page stylesheet chooses which variable paints (typically via the color-scheme contract,
+spec.md §9.5). Grammars: json, typescript, javascript, markdown, html, shellscript, css, yaml
+(plus their registered aliases — `ts`, `js`, `bash`, `sh`, `md`, `yml`, …). Unknown languages
+and bare fences keep plain `textContent`. The browser-safe transpile module
+(`@jxsuite/parser/transpile`) never highlights — Studio and other browser callers see plain
+fences.
+
 ## Limitations
 
 1. **No runtime format** — `.md` always transpiles to JSON before compilation or rendering


### PR DESCRIPTION
Docs code blocks previously rendered as unstyled plain <pre><code>. The node-only markdown path (processMarkdown) now tokenizes fenced code through a synchronous Shiki core (JavaScript regex engine — no WASM) with the github-light/dark-default theme pair. Each token becomes a span carrying its colors as --shiki-light/--shiki-dark custom properties, so the page stylesheet picks the paint color and highlighting rides the §9.5 color-scheme contract for auto and forced schemes alike (jxsuite.com docs article CSS added here).

Grammars: json, typescript, javascript, markdown, html, shellscript, css, yaml + registered aliases. Unknown languages keep plain text. The browser-safe transpile module is untouched — Studio's bundle pays nothing.

Spec: jx-markdown.md element-mapping section documents the emission. Docs: jx-markdown page updated (+ highlight.ts in its code frontmatter).