### PR TITLE
feat(studio): color-scheme canvas preview — Auto/Light/Dark tab-bar control

### DIFF
--- a/docs/studio/design/breakpoints.md
+++ b/docs/studio/design/breakpoints.md
@@ -39,7 +39,9 @@ Breakpoints belong to the whole site. To edit them, click the **Settings** gear 
 
 A single file can also carry breakpoints of its own: select the page root in [Layers](/docs/studio/design/layers) and open the **Media** section of the [Properties panel](/docs/studio/design/properties). There you set the file's **Base width** — how wide the Base canvas panel renders — and add breakpoints with a friendly name (Studio derives the stored name, "Tablet" becomes `--tablet`). File-level breakpoints add to the site's list for that file. More site-wide options live in **[Project settings](/docs/studio/projects/settings)**.
 
-Only width conditions get a canvas panel. A breakpoint with a different kind of condition — dark mode, reduced motion — appears instead as a toggle in the tab bar, so you can flip it on and see the canvas respond.
+Only width conditions get a canvas panel. A breakpoint with a different kind of condition — reduced motion, for example — appears instead as a toggle in the tab bar.
+
+A `prefers-color-scheme` breakpoint is special: it surfaces as an **Auto / Light / Dark** control in the tab bar instead of a generic toggle. Auto follows your OS preference; Light and Dark force that scheme on the canvas — exactly what a visitor's [color-scheme switcher](/docs/framework/concepts/color-schemes) does on the published site. The control appears only when the project declares a scheme breakpoint.
 
 :::doc-note
 Breakpoints are stored as a `$media` map — in `project.json` for the site, or at the top of a file for file-level ones. Per-breakpoint styles nest under the breakpoint's name inside each element's `style`, as described in **[Styling](/docs/framework/concepts/styling)**.

--- a/docs/studio/interface/tabs.md
+++ b/docs/studio/interface/tabs.md
@@ -54,6 +54,7 @@ Below the tab strip, a second row carries the controls for the active tab:
 - **Back** and a breadcrumb trail, when you've drilled from a page into one of its components — click any crumb to jump back up.
 - The zoom controls for the current mode, including **Fit** on the pannable canvases.
 - The **Preview** toggle, the **Layout** toggle, and the preview pickers described in [Modes and the preview toggle](/docs/studio/interface/modes).
+- The **Auto / Light / Dark** color-scheme control, when the project declares a `prefers-color-scheme` breakpoint — it forces the canvas into either scheme (or follows your OS in Auto) without re-rendering. See [Breakpoints](/docs/studio/design/breakpoints).
 - Mode-specific actions, like **Export** in **Code** mode.
 
 ## Next

--- a/packages/studio/src/canvas/iframe-entry.ts
+++ b/packages/studio/src/canvas/iframe-entry.ts
@@ -6,7 +6,11 @@
  */
 
 import { postMessageChannel } from "./iframe-channel";
-import { installCanvasImageRetry, renderResolvedDocument } from "./iframe-render";
+import {
+  applyPreviewColorScheme,
+  installCanvasImageRetry,
+  renderResolvedDocument,
+} from "./iframe-render";
 import { measureHits, startInteraction } from "./iframe-interaction";
 import {
   AUTO_SCROLL_STEP,
@@ -482,9 +486,15 @@ export function startCanvasIframe(opts: {
       clearIframeDrag();
       return;
     }
+    if (msg.kind === "setColorScheme") {
+      // Document-level attribute flip — deliberately patch-free (no render, no gen).
+      applyPreviewColorScheme(container.ownerDocument, msg.scheme);
+      return;
+    }
     if (msg.kind !== "render" || msg.gen < latestGen) {
       return;
     }
+    applyPreviewColorScheme(container.ownerDocument, msg.colorScheme ?? null);
     // A render replaces the DOM under a live edit session — COMMIT it first (never discard). The
     // Resulting editCommit/editEnd post synchronously here, so on the FIFO channel they precede
     // This render's renderComplete and the parent routes them by the host's not-yet-flipped tab

--- a/packages/studio/src/canvas/iframe-host.ts
+++ b/packages/studio/src/canvas/iframe-host.ts
@@ -1370,6 +1370,7 @@ export async function mountIframeCanvas(
   // oxlint-disable-next-line unicorn/prefer-structured-clone
   const cloneableShadow = JSON.parse(JSON.stringify(doc)) as unknown;
   const message: ParentToIframe = {
+    colorScheme: activeSchemeWire(),
     doc: cloneableDoc,
     docBase: resolved.docBase ?? `${canvasBaseOrigin()}/`,
     gen,
@@ -1419,6 +1420,7 @@ export function mountStylebookCanvas(
   // oxlint-disable-next-line unicorn/prefer-structured-clone
   const cloneableShadow = JSON.parse(JSON.stringify(generated.doc)) as unknown;
   const message: ParentToIframe = {
+    colorScheme: activeSchemeWire(),
     doc: cloneableDoc,
     docBase: `${canvasBaseOrigin()}/`,
     gen,
@@ -1440,6 +1442,28 @@ export function mountStylebookCanvas(
     state.channel.post(message);
   } else {
     state.pending = message;
+  }
+}
+
+/** The active tab's forced preview scheme as wire data (auto → null). */
+function activeSchemeWire(): "light" | "dark" | null {
+  const s = activeTab.value?.session.ui.previewColorScheme;
+  return s === "light" || s === "dark" ? s : null;
+}
+
+/**
+ * Flip the color-scheme preview on every ready host (page and stylebook alike — both render
+ * scheme-aware CSS). A pure attribute write iframe-side: no render, no patch, no gen.
+ */
+export function postColorSchemeToLiveHosts(scheme: "light" | "dark" | null): void {
+  for (const host of liveHosts) {
+    if (!host.iframe.isConnected) {
+      liveHosts.delete(host);
+      continue;
+    }
+    if (host.ready) {
+      host.channel.post({ kind: "setColorScheme", scheme });
+    }
   }
 }
 

--- a/packages/studio/src/canvas/iframe-protocol.ts
+++ b/packages/studio/src/canvas/iframe-protocol.ts
@@ -61,8 +61,14 @@ export type ParentToIframe =
       docBase: string;
       mapperCtx: WireMapperCtx;
       siteStyle: Record<string, unknown> | null;
+      // Forced color-scheme preview (spec §9.5): "light"/"dark" sets data-color-scheme on the
+      // Iframe root, null clears it (auto — follow the OS).
+      colorScheme: "light" | "dark" | null;
       gen: number;
     }
+  // Flip the forced color-scheme preview on the iframe root without re-rendering — a document-level
+  // Idempotent attribute write, deliberately gen-less (like endEdit).
+  | { kind: "setColorScheme"; scheme: "light" | "dark" | null }
   // Ask the iframe to measure the given document paths and post their current rects back. Used to
   // Draw the selection overlay regardless of where the selection change originated (canvas click,
   // Layers panel, keyboard) — the parent can't measure iframe nodes itself (cross-origin bridge).

--- a/packages/studio/src/canvas/iframe-render.ts
+++ b/packages/studio/src/canvas/iframe-render.ts
@@ -24,6 +24,7 @@ import {
   transposeCanvasUnits,
 } from "@jxsuite/runtime";
 import { classifyRenderNode, serializeJxPath } from "./path-mapping";
+import { SITE_STYLE_ID, buildSiteStyleCSS } from "./site-style-css";
 import type { CanvasMode } from "./iframe-protocol";
 import type { JxDocument } from "@jxsuite/schema/types";
 import type { PathMapCtx } from "./path-mapping";
@@ -294,22 +295,42 @@ export function syncStylebookCss(doc: Document, mode: CanvasMode): void {
   doc.head.append(style);
 }
 
-/** Apply the project's site style: custom properties on :root, plain properties on <body>. */
-export function applySiteStyle(siteStyle: Record<string, unknown> | null | undefined): void {
+/**
+ * Apply the project's site style as a real stylesheet (replace-in-place): custom properties on
+ * `:root`, plain properties on `body`, conditional blocks dual-emitted per the forced-scheme
+ * contract. A stylesheet — not inline root properties — so `:root[data-color-scheme]` override
+ * selectors can win (spec §9.5), and so removed tokens can't linger on reused iframes.
+ */
+export function applySiteStyle(
+  siteStyle: Record<string, unknown> | null | undefined,
+  mediaQueries: Record<string, string> = {},
+): void {
+  const existing = document.head.querySelector(`#${SITE_STYLE_ID}`);
   if (!siteStyle || typeof siteStyle !== "object") {
+    existing?.remove();
     return;
   }
-  const rootStyle = document.documentElement.style;
-  const bodyStyle = document.body.style as unknown as Record<string, string>;
-  for (const [key, value] of Object.entries(siteStyle)) {
-    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-      continue;
-    }
-    if (key.startsWith("--")) {
-      rootStyle.setProperty(key, transposeCanvasUnits(String(value)));
-    } else {
-      bodyStyle[key] = transposeCanvasUnits(String(value));
-    }
+  const css = buildSiteStyleCSS(siteStyle, mediaQueries, transposeCanvasUnits);
+  if (existing) {
+    existing.textContent = css;
+    return;
+  }
+  const tag = document.createElement("style");
+  tag.id = SITE_STYLE_ID;
+  tag.textContent = css;
+  document.head.append(tag);
+}
+
+/**
+ * Force or clear the color-scheme preview on the iframe's root element (the platform's
+ * data-color-scheme contract, spec §9.5). Survives re-renders and patches — renders only replace
+ * the container's children, never the root element.
+ */
+export function applyPreviewColorScheme(doc: Document, scheme: "light" | "dark" | null): void {
+  if (scheme) {
+    doc.documentElement.dataset.colorScheme = scheme;
+  } else {
+    delete doc.documentElement.dataset.colorScheme;
   }
 }
 
@@ -443,7 +464,7 @@ export async function renderResolvedDocument(opts: {
   // Iframe clears it (page-level templates are inert in design/edit via prepareForEditMode, so only
   // Component internals get stamped).
   setStampPropBindings(opts.mode === "design" || opts.mode === "edit");
-  applySiteStyle(opts.siteStyle);
+  applySiteStyle(opts.siteStyle, (opts.doc as { $media?: Record<string, string> }).$media ?? {});
   injectHead(opts.doc);
   syncEditModeCss(opts.container.ownerDocument, opts.mode);
   syncStylebookCss(opts.container.ownerDocument, opts.mode);

--- a/packages/studio/src/canvas/site-style-css.ts
+++ b/packages/studio/src/canvas/site-style-css.ts
@@ -1,0 +1,121 @@
+/// <reference lib="dom" />
+/**
+ * Site-style stylesheet builder — pure functions extracted for testability.
+ *
+ * The canvas iframe injects the project's `style` as a real stylesheet instead of inline properties
+ * on the root element: inline custom properties would defeat the forced-scheme override selectors
+ * (`:root[data-color-scheme]`, spec §9.5), and object-valued `@--name` blocks used to be dropped
+ * entirely. Scheme-query blocks dual-emit through the runtime's schemeSelectors so the canvas
+ * honors both the OS preference and the preview toggle.
+ */
+
+import { pureSchemeOf, schemeSelectors, camelToKebab } from "@jxsuite/runtime";
+
+/** Id of the injected site-style tag (replace-in-place, never accumulate). */
+export const SITE_STYLE_ID = "jx-site-style";
+
+/** Serialize scalar declarations, kebab-casing property names and transposing values. */
+function toDecls(props: Record<string, unknown>, transpose: (value: string) => string): string {
+  return Object.entries(props)
+    .map(([key, value]) => `${camelToKebab(key)}: ${transpose(String(value))}`)
+    .join("; ");
+}
+
+/**
+ * Build the site-style sheet text: custom properties on `:root`, plain properties on `body`,
+ * conditional `@`-blocks resolved against `mediaQueries` (scheme queries dual-emitted per the
+ * forced-scheme contract), and `color-scheme: light dark` declared when a scheme query exists.
+ *
+ * @param {Record<string, unknown>} siteStyle
+ * @param {Record<string, string>} mediaQueries
+ * @param {(value: string) => string} transpose - Unit transposer (canvas vh→cqh etc.)
+ * @returns {string}
+ */
+export function buildSiteStyleCSS(
+  siteStyle: Record<string, unknown>,
+  mediaQueries: Record<string, string>,
+  transpose: (value: string) => string,
+): string {
+  const rules: string[] = [];
+  const rootProps: Record<string, unknown> = {};
+  const bodyProps: Record<string, unknown> = {};
+  const condBlocks: [string, Record<string, unknown>][] = [];
+
+  for (const [key, value] of Object.entries(siteStyle)) {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      if (key.startsWith("@")) {
+        condBlocks.push([key, value as Record<string, unknown>]);
+      }
+      // Non-@ objects (nested element selectors) are page-content styling — the resolved doc's
+      // Own style pass covers those; the site sheet handles tokens + conditional overrides.
+      continue;
+    }
+    if (key.startsWith(":") || key.startsWith(".") || key.startsWith("[") || key.startsWith("@")) {
+      continue;
+    }
+    if (key.startsWith("--")) {
+      rootProps[key] = value;
+    } else {
+      bodyProps[key] = value;
+    }
+  }
+
+  const rootCSS = toDecls(rootProps, transpose);
+  if (rootCSS) {
+    rules.push(`:root { ${rootCSS} }`);
+  }
+  const bodyCSS = toDecls(bodyProps, transpose);
+  if (bodyCSS) {
+    rules.push(`body { ${bodyCSS} }`);
+  }
+
+  for (const [atKey, block] of condBlocks) {
+    const query = atKey.startsWith("@--")
+      ? (mediaQueries[atKey.slice(1)] ?? atKey.slice(1))
+      : atKey.startsWith("@(")
+        ? atKey.slice(1)
+        : null;
+    if (query === null) {
+      continue;
+    }
+    const scheme = pureSchemeOf(query);
+    const emit = (selector: string, props: string) => {
+      if (!props) {
+        return;
+      }
+      if (scheme) {
+        const { auto, forced } = schemeSelectors(selector, scheme);
+        rules.push(`@media ${query} { ${auto} { ${props} } }`, `${forced} { ${props} }`);
+      } else {
+        rules.push(`@media ${query} { ${selector} { ${props} } }`);
+      }
+    };
+    const condRoot: Record<string, unknown> = {};
+    const condBody: Record<string, unknown> = {};
+    const condSubs: [string, Record<string, unknown>][] = [];
+    for (const [k, v] of Object.entries(block)) {
+      if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+        if (!k.startsWith("@")) {
+          condSubs.push([k, v as Record<string, unknown>]);
+        }
+        continue;
+      }
+      if (k.startsWith("--")) {
+        condRoot[k] = v;
+      } else {
+        condBody[k] = v;
+      }
+    }
+    emit(":root", toDecls(condRoot, transpose));
+    emit("body", toDecls(condBody, transpose));
+    for (const [sel, sub] of condSubs) {
+      emit(sel, toDecls(sub, transpose));
+    }
+  }
+
+  if (Object.values(mediaQueries).some((q) => pureSchemeOf(q) !== null)) {
+    rules.push(":root { color-scheme: light dark }");
+  }
+
+  return rules.join("\n");
+}

--- a/packages/studio/src/panels/tab-bar.ts
+++ b/packages/studio/src/panels/tab-bar.ts
@@ -15,6 +15,7 @@ import { effect, effectScope } from "../reactivity";
 import { activeTab } from "../workspace/workspace";
 import { applyTransform, fitToScreen, resetZoom, setEditZoom } from "../canvas/canvas-utils";
 import { getEffectiveLayoutPath, getEffectiveMedia } from "../site-context";
+import { isSchemeQuery } from "../utils/canvas-media";
 import { dynamicRouteParams, loadParamValues, pagePathsDef } from "../page-params";
 import { componentPropEntries, isComponentDoc } from "../component-props";
 import { mediaDisplayName } from "./shared";
@@ -75,6 +76,7 @@ export function mount(host: HTMLElement, ctx: TabBarCtx) {
         void tab.session.ui.editingFunction;
         void tab.session.ui.featureToggles;
         void tab.session.ui.preview;
+        void tab.session.ui.previewColorScheme;
         void tab.session.ui.previewParams;
         void tab.session.ui.previewProps;
         void tab.session.ui.showLayout;
@@ -308,13 +310,46 @@ function tabBarTemplate(ctx: TabBarCtx): TemplateResult | typeof nothing {
     }
   }
 
-  // ── Right region: media feature toggles ──
+  // ── Right region: color-scheme preview (projects that declare a scheme query, spec §9.5) ──
+  // One switch per tab: drives the canvas data-color-scheme attribute and (in the style
+  // Sidebar) which scheme layer edits target. Ungated — works in every canvas mode.
   const { featureQueries } = ctx.parseMediaEntries(getEffectiveMedia(S.document?.$media));
+  const schemeQueries = featureQueries.filter(({ query }) => isSchemeQuery(query));
+  const plainQueries = featureQueries.filter(({ query }) => !isSchemeQuery(query));
+  const scheme = S.ui.previewColorScheme ?? "auto";
+  const schemeTpl =
+    schemeQueries.length > 0
+      ? html`
+          <sp-action-group compact size="s" class="tb-scheme">
+            ${(
+              [
+                ["auto", "Auto", "Follow the OS color scheme"],
+                ["light", "Light", "Force the light scheme"],
+                ["dark", "Dark", "Force the dark scheme"],
+              ] as const
+            ).map(
+              ([value, label, title]) => html`
+                <sp-action-button
+                  toggles
+                  size="s"
+                  title=${title}
+                  ?selected=${scheme === value}
+                  @click=${() => updateUi("previewColorScheme", value)}
+                >
+                  ${label}
+                </sp-action-button>
+              `,
+            )}
+          </sp-action-group>
+        `
+      : nothing;
+
+  // ── Right region: media feature toggles (non-scheme queries) ──
   const togglesTpl =
-    featureQueries.length > 0
+    plainQueries.length > 0
       ? html`
           <sp-action-group compact size="s">
-            ${featureQueries.map(
+            ${plainQueries.map(
               ({ name, query }: { name: string; query: string }) => html`
                 <sp-action-button
                   toggles
@@ -352,7 +387,7 @@ function tabBarTemplate(ctx: TabBarCtx): TemplateResult | typeof nothing {
     <div class="tab-bar">
       ${navTpl} ${zoomTpl}
       <div class="tb-spacer"></div>
-      ${settingsTpl} ${togglesTpl} ${exportTpl}
+      ${settingsTpl} ${schemeTpl} ${togglesTpl} ${exportTpl}
     </div>
   `;
 }

--- a/packages/studio/src/studio.ts
+++ b/packages/studio/src/studio.ts
@@ -48,6 +48,7 @@ import { consumePatchedDocument, initCanvasPatcher } from "./canvas/canvas-patch
 import {
   commitActiveEditSession,
   getEditSnapshot,
+  postColorSchemeToLiveHosts,
   setCanvasContextMenuHandler,
   setCanvasSlashHandler,
   setIframePatchEscalation,
@@ -580,6 +581,12 @@ effect(() => {
     void tab.session.ui.stylebookCustomizedOnly;
   }
   scheduleCanvasRender();
+});
+// Color-scheme preview is a document-level attribute flip inside the iframe — deliberately its
+// Own effect, never part of the ui-effect above: flipping the scheme must not re-render.
+effect(() => {
+  const s = activeTab.value?.session.ui.previewColorScheme;
+  postColorSchemeToLiveHosts(s === "light" || s === "dark" ? s : null);
 });
 
 rightPanelMod.mount({

--- a/packages/studio/src/tabs/tab.ts
+++ b/packages/studio/src/tabs/tab.ts
@@ -43,6 +43,12 @@ export interface TabUi {
   /** Full-screen formula workspace target ($expression editing); editingFunction wins if both set. */
   editingFormula: FormulaEditDef | null;
   featureToggles: Record<string, boolean>;
+  /**
+   * Canvas color-scheme preview: follow the OS ("auto") or force a scheme. Drives the
+   * data-color-scheme attribute on the canvas iframe root (spec §9.5) and, in the style sidebar,
+   * which scheme layer edits target.
+   */
+  previewColorScheme: "auto" | "light" | "dark";
   styleSections: Record<string, boolean>;
   inspectorSections: Record<string, boolean>;
   styleShorthands: Record<string, boolean>;
@@ -156,6 +162,7 @@ function createDefaultUi(canvasMode: string, preview = false) {
     inspectorSections: {},
     pendingInlineEdit: null,
     preview,
+    previewColorScheme: "auto" as const,
     previewParams: {},
     previewProps: null,
     rightTab: "properties",

--- a/packages/studio/src/utils/canvas-media.ts
+++ b/packages/studio/src/utils/canvas-media.ts
@@ -2,6 +2,29 @@
 /// <reference lib="dom.iterable" />
 /** Canvas media/breakpoint utilities — pure functions extracted for testability. */
 
+import { pureSchemeOf } from "@jxsuite/runtime";
+
+/**
+ * True when a feature query participates in the forced-scheme contract (spec §9.5) — a pure
+ * prefers-color-scheme query. These surface as the Auto/Light/Dark control, not generic toggles.
+ *
+ * @param {string} query
+ * @returns {boolean}
+ */
+export function isSchemeQuery(query: string): boolean {
+  return pureSchemeOf(query) !== null;
+}
+
+/**
+ * The scheme a feature query targets ("light" | "dark"), or null for non-scheme queries.
+ *
+ * @param {string} query
+ * @returns {"light" | "dark" | null}
+ */
+export function schemeOfQuery(query: string): "light" | "dark" | null {
+  return pureSchemeOf(query);
+}
+
 /**
  * Classify $media entries into size breakpoints (get a canvas each) and feature queries (rendered
  * as toolbar toggles).

--- a/packages/studio/tests/canvas-media.test.ts
+++ b/packages/studio/tests/canvas-media.test.ts
@@ -1,6 +1,27 @@
 import "./with-dom.js";
 import { describe, expect, test } from "bun:test";
-import { activeBreakpointsForWidth, parseMediaEntries } from "../src/utils/canvas-media";
+import {
+  activeBreakpointsForWidth,
+  isSchemeQuery,
+  parseMediaEntries,
+  schemeOfQuery,
+} from "../src/utils/canvas-media";
+
+// ─── Scheme-query classification ────────────────────────────────────────────
+
+describe("isSchemeQuery / schemeOfQuery", () => {
+  test("recognizes pure prefers-color-scheme queries", () => {
+    expect(isSchemeQuery("(prefers-color-scheme: dark)")).toBe(true);
+    expect(schemeOfQuery("(prefers-color-scheme: dark)")).toBe("dark");
+    expect(schemeOfQuery("(prefers-color-scheme: light)")).toBe("light");
+  });
+
+  test("rejects compound and non-scheme queries", () => {
+    expect(isSchemeQuery("(prefers-color-scheme: dark) and (min-width: 768px)")).toBe(false);
+    expect(isSchemeQuery("(prefers-reduced-motion: reduce)")).toBe(false);
+    expect(schemeOfQuery("(min-width: 768px)")).toBeNull();
+  });
+});
 
 // ─── parseMediaEntries ──────────────────────────────────────────────────────
 

--- a/packages/studio/tests/iframe-entry.test.ts
+++ b/packages/studio/tests/iframe-entry.test.ts
@@ -15,6 +15,7 @@ const WIRE_CTX: WireMapperCtx = {
 
 function renderMsg(gen: number, doc: unknown, shadowDoc: unknown = doc): ParentToIframe {
   return {
+    colorScheme: null,
     doc,
     docBase: "http://localhost:3000/",
     gen,
@@ -53,6 +54,42 @@ describe("startCanvasIframe", () => {
 
     expect((container.querySelector("h1") as HTMLElement)?.dataset.jxPath).toBe('["children",0]');
     expect(fromIframe).toContainEqual({ gen: 1, kind: "renderComplete" });
+  });
+
+  test("setColorScheme flips the root attribute without a render", async () => {
+    const pair = fakeChannelPair<ParentToIframe, IframeToParent>();
+    const fromIframe: IframeToParent[] = [];
+    pair.parent.onMessage((m) => fromIframe.push(m));
+    const container = document.createElement("div");
+    document.body.append(container);
+    teardown = startCanvasIframe({ channel: pair.iframe, container });
+    pair.flush();
+
+    pair.parent.post({ kind: "setColorScheme", scheme: "dark" });
+    pair.flush();
+    expect(document.documentElement.dataset.colorScheme).toBe("dark");
+    // No render was triggered — only the ready announcement crossed back.
+    expect(fromIframe.map((m) => m.kind)).toEqual(["ready"]);
+
+    pair.parent.post({ kind: "setColorScheme", scheme: null });
+    pair.flush();
+    expect(document.documentElement.dataset.colorScheme).toBeUndefined();
+  });
+
+  test("a render message applies its colorScheme to the root", async () => {
+    const pair = fakeChannelPair<ParentToIframe, IframeToParent>();
+    const container = document.createElement("div");
+    document.body.append(container);
+    teardown = startCanvasIframe({ channel: pair.iframe, container });
+    pair.flush();
+
+    const msg = renderMsg(1, { children: [{ children: ["Hi"], tagName: "h1" }], tagName: "div" });
+    (msg as { colorScheme: "light" | "dark" | null }).colorScheme = "light";
+    pair.parent.post(msg);
+    pair.flush();
+    await flush();
+    expect(document.documentElement.dataset.colorScheme).toBe("light");
+    delete document.documentElement.dataset.colorScheme;
   });
 
   test("posts a serialized dataScope right AFTER renderComplete (resolved $defs cross to the parent)", async () => {

--- a/packages/studio/tests/iframe-host.test.ts
+++ b/packages/studio/tests/iframe-host.test.ts
@@ -87,6 +87,7 @@ const {
   mountStylebookCanvas,
   panToStylebookTag,
   postApplyFormat,
+  postColorSchemeToLiveHosts,
   postDragMessage,
   postPatchToHosts,
   postStyleUpdateToStylebookHosts,
@@ -130,6 +131,36 @@ describe("mountIframeCanvas", () => {
     channels[0]!.deliver({ kind: "ready" });
     expect(channels[0]!.posts).toHaveLength(1);
     expect(channels[0]!.posts[0]).toMatchObject({ gen: 1, kind: "render", mode: "design" });
+  });
+
+  test("the render message carries the active tab's forced preview scheme (auto → null)", async () => {
+    resetWorkspaceWithTab();
+    const canvasEl = document.createElement("div");
+    document.body.append(canvasEl);
+    await mountIframeCanvas(1, { tagName: "div" } as never, canvasEl);
+    channels[0]!.deliver({ kind: "ready" });
+    expect(channels[0]!.posts[0]).toMatchObject({ colorScheme: null, kind: "render" });
+
+    activeTab.value!.session.ui.previewColorScheme = "dark";
+    await mountIframeCanvas(2, { tagName: "div" } as never, canvasEl);
+    expect(channels[0]!.posts[1]).toMatchObject({ colorScheme: "dark", kind: "render" });
+  });
+
+  test("postColorSchemeToLiveHosts posts setColorScheme to ready hosts only", async () => {
+    const canvasEl = document.createElement("div");
+    document.body.append(canvasEl);
+    await mountIframeCanvas(1, { tagName: "div" } as never, canvasEl);
+
+    // Not ready yet — nothing posts.
+    postColorSchemeToLiveHosts("dark");
+    expect(channels[0]!.posts).toHaveLength(0);
+
+    channels[0]!.deliver({ kind: "ready" });
+    postColorSchemeToLiveHosts("dark");
+    expect(channels[0]!.posts.at(-1)).toEqual({ kind: "setColorScheme", scheme: "dark" });
+
+    postColorSchemeToLiveHosts(null);
+    expect(channels[0]!.posts.at(-1)).toEqual({ kind: "setColorScheme", scheme: null });
   });
 
   test("uses the platform's canvasUrl when set, default otherwise", async () => {

--- a/packages/studio/tests/iframe-render.test.ts
+++ b/packages/studio/tests/iframe-render.test.ts
@@ -6,6 +6,7 @@ import {
   setStampPropBindings,
 } from "@jxsuite/runtime";
 import {
+  applyPreviewColorScheme,
   applySiteStyle,
   EDIT_PLACEHOLDER_CSS,
   EDIT_PLACEHOLDER_STYLE_ID,
@@ -215,17 +216,18 @@ describe("canvas transpose + anchor de-link flags", () => {
   test("applySiteStyle transposes viewport units to container units", () => {
     setCanvasViewportTranspose(true);
     applySiteStyle({ "--hero-h": "50vw", minHeight: "100vh" });
-    // Plain property goes on <body>, with vh → cqh.
-    expect(document.body.style.minHeight).toContain("cqh");
-    expect(document.body.style.minHeight).toBe("100cqh");
-    // `--`-prefixed var goes on documentElement (:root), with vw → cqw.
-    expect(document.documentElement.style.getPropertyValue("--hero-h")).toBe("50cqw");
+    const css = document.head.querySelector("#jx-site-style")!.textContent!;
+    // Plain property goes in the body rule, with vh → cqh.
+    expect(css).toContain("body { min-height: 100cqh }");
+    // `--`-prefixed var goes in the :root rule, with vw → cqw.
+    expect(css).toContain(":root { --hero-h: 50cqw }");
   });
 
   test("applySiteStyle leaves viewport units untouched when the flag is off", () => {
     // Flag defaults to false here (reset in afterEach); no transpose should happen.
     applySiteStyle({ minHeight: "100vh" });
-    expect(document.body.style.minHeight).toBe("100vh");
+    const css = document.head.querySelector("#jx-site-style")!.textContent!;
+    expect(css).toContain("body { min-height: 100vh }");
   });
 
   test("renderResolvedDocument de-links <a href> in edit mode but keeps it live in preview", async () => {
@@ -428,21 +430,60 @@ describe("component-definition root vs a registered custom element (cross-tab re
 
 describe("applySiteStyle", () => {
   afterEach(() => {
-    document.documentElement.removeAttribute("style");
-    document.body.removeAttribute("style");
+    document.head.querySelector("#jx-site-style")?.remove();
+    delete document.documentElement.dataset.colorScheme;
   });
 
-  test("sets custom properties on :root and plain properties on <body>", () => {
+  test("emits a stylesheet: custom properties on :root, plain properties on body", () => {
     applySiteStyle({ "--brand": "#0f0", color: "red", margin: {} as unknown });
-    expect(document.documentElement.style.getPropertyValue("--brand")).toBe("#0f0");
-    expect(document.body.style.color).toBe("red");
-    // Nested object values (selector rules) are skipped.
-    expect(document.body.style.margin).toBe("");
+    const css = document.head.querySelector("#jx-site-style")!.textContent!;
+    expect(css).toContain(":root { --brand: #0f0 }");
+    expect(css).toContain("body { color: red }");
+    // Nested non-@ object values are page-content styling — not part of the site sheet.
+    expect(css).not.toContain("margin");
   });
 
-  test("is a no-op for null/non-object", () => {
+  test("replaces the sheet in place — stale tokens cannot linger", () => {
+    applySiteStyle({ "--brand": "#0f0" });
+    applySiteStyle({ "--accent": "#00f" });
+    const tags = document.head.querySelectorAll("#jx-site-style");
+    expect(tags).toHaveLength(1);
+    expect(tags[0]!.textContent).toContain("--accent: #00f");
+    expect(tags[0]!.textContent).not.toContain("--brand");
+  });
+
+  test("dual-emits scheme blocks and declares color-scheme", () => {
+    applySiteStyle(
+      { "--bg": "#fff", "@--dark": { "--bg": "#000" } },
+      { "--dark": "(prefers-color-scheme: dark)" },
+    );
+    const css = document.head.querySelector("#jx-site-style")!.textContent!;
+    expect(css).toContain(
+      "@media (prefers-color-scheme: dark) { :root:where(:not([data-color-scheme])) { --bg: #000 } }",
+    );
+    expect(css).toContain(':root:where([data-color-scheme="dark"]) { --bg: #000 }');
+    expect(css).toContain(":root { color-scheme: light dark }");
+  });
+
+  test("removes the sheet for null/non-object", () => {
+    applySiteStyle({ "--brand": "#0f0" });
     expect(() => applySiteStyle(null)).not.toThrow();
-    expect(document.documentElement.getAttribute("style")).toBeNull();
+    expect(document.head.querySelector("#jx-site-style")).toBeNull();
+  });
+});
+
+describe("applyPreviewColorScheme", () => {
+  afterEach(() => {
+    delete document.documentElement.dataset.colorScheme;
+  });
+
+  test("sets and clears the forced-scheme attribute on the root element", () => {
+    applyPreviewColorScheme(document, "dark");
+    expect(document.documentElement.dataset.colorScheme).toBe("dark");
+    applyPreviewColorScheme(document, "light");
+    expect(document.documentElement.dataset.colorScheme).toBe("light");
+    applyPreviewColorScheme(document, null);
+    expect(document.documentElement.dataset.colorScheme).toBeUndefined();
   });
 });
 

--- a/packages/studio/tests/site-style-css.test.ts
+++ b/packages/studio/tests/site-style-css.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { SITE_STYLE_ID, buildSiteStyleCSS } from "../src/canvas/site-style-css";
+
+const id = (v: string) => v;
+
+// ─── buildSiteStyleCSS ──────────────────────────────────────────────────────
+
+describe("buildSiteStyleCSS", () => {
+  test("splits custom properties to :root and plain props to body", () => {
+    const css = buildSiteStyleCSS({ "--brand": "#0f0", color: "red", margin: "0" }, {}, id);
+    expect(css).toContain(":root { --brand: #0f0 }");
+    expect(css).toContain("body { color: red; margin: 0 }");
+  });
+
+  test("applies the transpose hook to values", () => {
+    const css = buildSiteStyleCSS({ minHeight: "100vh" }, {}, (v) => v.replace("vh", "cqh"));
+    expect(css).toContain("body { min-height: 100cqh }");
+  });
+
+  test("resolves @--name blocks against mediaQueries, tokens on :root", () => {
+    const css = buildSiteStyleCSS(
+      { "--pad": "1rem", "@--md": { "--pad": "2rem", margin: "0" } },
+      { "--md": "(min-width: 768px)" },
+      id,
+    );
+    expect(css).toContain("@media (min-width: 768px) { :root { --pad: 2rem } }");
+    expect(css).toContain("@media (min-width: 768px) { body { margin: 0 } }");
+    expect(css.indexOf(":root { --pad: 1rem")).toBeLessThan(css.indexOf("@media"));
+    expect(css).not.toContain("color-scheme");
+  });
+
+  test("dual-emits scheme blocks with the §9.5 selector contract", () => {
+    const css = buildSiteStyleCSS(
+      { "--bg": "#fff", "@--dark": { "--bg": "#000", ".card": { borderColor: "#333" } } },
+      { "--dark": "(prefers-color-scheme: dark)" },
+      id,
+    );
+    // Pin the exact selector contract shared with the compiler/runtime emission.
+    expect(css).toContain(
+      "@media (prefers-color-scheme: dark) { :root:where(:not([data-color-scheme])) { --bg: #000 } }",
+    );
+    expect(css).toContain(':root:where([data-color-scheme="dark"]) { --bg: #000 }');
+    expect(css).toContain(':where(:root[data-color-scheme="dark"]) .card { border-color: #333 }');
+    expect(css).toContain(":root { color-scheme: light dark }");
+  });
+
+  test("literal @(query) blocks work; unresolvable at-keys are skipped", () => {
+    const css = buildSiteStyleCSS(
+      {
+        "@(prefers-color-scheme: light)": { "--fg": "#111" },
+        "@supports (gap: 1px)": { gap: "1" },
+      },
+      {},
+      id,
+    );
+    expect(css).toContain(':root:where([data-color-scheme="light"]) { --fg: #111 }');
+    expect(css).not.toContain("@supports");
+  });
+
+  test("declares color-scheme when the media map has a scheme query even without blocks", () => {
+    const css = buildSiteStyleCSS(
+      { "--bg": "#fff" },
+      { "--dark": "(prefers-color-scheme: dark)" },
+      id,
+    );
+    expect(css).toContain(":root { color-scheme: light dark }");
+  });
+
+  test("empty style with no scheme query produces no rules", () => {
+    expect(buildSiteStyleCSS({}, {}, id)).toBe("");
+  });
+
+  test("exports the stable style-tag id", () => {
+    expect(SITE_STYLE_ID).toBe("jx-site-style");
+  });
+});

--- a/packages/studio/tests/tab-bar.test.ts
+++ b/packages/studio/tests/tab-bar.test.ts
@@ -530,7 +530,7 @@ describe("export", () => {
 // ─── Media feature toggles ──────────────────────────────────────────────────────
 
 describe("media feature toggles", () => {
-  test("render from media queries and flip session toggles", async () => {
+  test("a scheme query renders the Auto/Light/Dark control, not a generic toggle", async () => {
     const tab = openTestTab();
     const ctx = makeCtx({
       parseMediaEntries: mock(() => ({
@@ -542,30 +542,63 @@ describe("media feature toggles", () => {
     tabBar.mount(root, ctx);
     await flush();
 
+    // No generic toggle for the scheme query
+    expect(root.querySelector("sp-action-button[title='(prefers-color-scheme: dark)']")).toBeNull();
+
+    const group = root.querySelector(".tb-scheme") as HTMLElement;
+    expect(group).not.toBeNull();
+    const labels = [...group.querySelectorAll("sp-action-button")].map((b) =>
+      b.textContent?.trim(),
+    );
+    expect(labels).toEqual(["Auto", "Light", "Dark"]);
+
+    const schemeBtn = (label: string) =>
+      [...group.querySelectorAll("sp-action-button")].find(
+        (b) => b.textContent?.trim() === label,
+      ) as HTMLElement;
+    expect(schemeBtn("Auto").hasAttribute("selected")).toBe(true);
+
+    pointer(schemeBtn("Dark"), "click");
+    await flush();
+    expect(tab.session.ui.previewColorScheme).toBe("dark");
+    expect(schemeBtn("Dark").hasAttribute("selected")).toBe(true);
+    expect(schemeBtn("Auto").hasAttribute("selected")).toBe(false);
+
+    pointer(schemeBtn("Auto"), "click");
+    await flush();
+    expect(tab.session.ui.previewColorScheme).toBe("auto");
+  });
+
+  test("non-scheme feature queries keep their generic toggles", async () => {
+    const tab = openTestTab();
+    const ctx = makeCtx({
+      parseMediaEntries: mock(() => ({
+        baseWidth: 1200,
+        featureQueries: [
+          { name: "--dark-mode", query: "(prefers-color-scheme: dark)" },
+          { name: "--reduced-motion", query: "(prefers-reduced-motion: reduce)" },
+        ],
+        sizeBreakpoints: [],
+      })),
+    });
+    tabBar.mount(root, ctx);
+    await flush();
+
     const toggle = root.querySelector(
-      "sp-action-button[title='(prefers-color-scheme: dark)']",
+      "sp-action-button[title='(prefers-reduced-motion: reduce)']",
     ) as HTMLElement;
-    expect(toggle.textContent).toContain("Dark Mode");
-    expect(toggle.hasAttribute("selected")).toBe(false);
+    expect(toggle.textContent).toContain("Reduced Motion");
 
     pointer(toggle, "click");
     await flush();
-    expect(tab.session.ui.featureToggles["--dark-mode"]).toBe(true);
-    expect(
-      root
-        .querySelector("sp-action-button[title='(prefers-color-scheme: dark)']")
-        ?.hasAttribute("selected"),
-    ).toBe(true);
-
-    pointer(root.querySelector("sp-action-button[title='(prefers-color-scheme: dark)']")!, "click");
-    await flush();
-    expect(tab.session.ui.featureToggles["--dark-mode"]).toBe(false);
+    expect(tab.session.ui.featureToggles["--reduced-motion"]).toBe(true);
   });
 
-  test("no media toggle group when the document has no feature queries", async () => {
+  test("no scheme group and no toggles when the document has no feature queries", async () => {
     openTestTab();
     tabBar.mount(root, makeCtx());
     await flush();
+    expect(root.querySelector(".tb-scheme")).toBeNull();
     // Only the settings-cluster Preview toggle remains — no media feature toggles.
     const toggles = [...root.querySelectorAll("sp-action-button[toggles]")];
     expect(toggles.map((b) => b.textContent?.trim())).toEqual(["Preview"]);

--- a/specs/studio-ui-guidelines.md
+++ b/specs/studio-ui-guidelines.md
@@ -187,15 +187,16 @@ When a property has an explicit value, show a small accent dot to the left of th
 
 ### 4.3 Input Components
 
-| Component              | When to Use                                                    |
-| ---------------------- | -------------------------------------------------------------- |
-| `sp-textfield`         | Free-text string values                                        |
-| `sp-number-field`      | Numeric values with optional min/max/step                      |
-| `sp-picker`            | Fixed option sets (enums)                                      |
-| `sp-checkbox`          | Boolean toggles                                                |
-| `sp-switch`            | On/off feature toggles                                         |
-| `jx-styled-combobox`   | Hybrid: fixed options with styled preview + free-text fallback |
-| `textarea.field-input` | Multi-line text (code, JSON, expressions)                      |
+| Component                                   | When to Use                                                                                      |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `sp-textfield`                              | Free-text string values                                                                          |
+| `sp-number-field`                           | Numeric values with optional min/max/step                                                        |
+| `sp-picker`                                 | Fixed option sets (enums)                                                                        |
+| `sp-checkbox`                               | Boolean toggles                                                                                  |
+| `sp-switch`                                 | On/off feature toggles                                                                           |
+| `sp-action-group` (compact, toggle buttons) | Small mutually-exclusive mode sets in bar chrome (e.g. the Auto/Light/Dark color-scheme preview) |
+| `jx-styled-combobox`                        | Hybrid: fixed options with styled preview + free-text fallback                                   |
+| `textarea.field-input`                      | Multi-line text (code, JSON, expressions)                                                        |
 
 ### 4.4 Debounce Pattern
 

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -131,6 +131,10 @@ When navigating between components, pages, and layouts within a project, the sit
 
 The canvas renders the current document using `@jxsuite/runtime`. It shows exactly what the component looks like at runtime — no simulation or approximation. When a site context is active (§3.6), the canvas applies the site's global styles, CSS custom properties, and media breakpoints so that every file is rendered in its true site context.
 
+Site style is injected into the canvas as a real stylesheet (custom properties in a `:root` rule, direct properties in a `body` rule, conditional `@--name` blocks resolved and — for scheme queries — dual-emitted per spec.md §9.5), never as inline root properties, so forced-scheme override selectors can win the cascade.
+
+**Color-scheme preview.** When the effective `$media` declares a pure `prefers-color-scheme` query, the tab bar shows an Auto/Light/Dark control (one per tab; available in edit, design, and stylebook modes). Light/Dark force the scheme by setting `data-color-scheme` on the canvas iframe's root element — a patch-free document-level attribute flip that never re-renders; Auto removes the attribute and follows the OS. Scheme queries no longer render as generic feature toggles. The same tri-state also selects which scheme layer style-sidebar edits target (§6.2).
+
 ### 4.2 Modes
 
 | Mode      | Description                                   |


### PR DESCRIPTION
Feature-query toggles were inert on the canvas: resolveCanvasDocument never read them, and applySiteStyle wrote site tokens as inline root properties — which would also have defeated any forced-scheme selector. This wires the §9.5 contract end to end in the editor:

- tab bar: a pure prefers-color-scheme query in effective $media now surfaces as a compact Auto/Light/Dark action group (edit, design, and stylebook modes; one switch per tab) instead of a generic inert toggle; non-scheme queries keep their toggles. New TabUi.previewColorScheme tri-state.
- canvas: new setColorScheme bridge message + colorScheme on render messages; the iframe sets/clears data-color-scheme on its root element — a patch-free attribute flip driven by a dedicated effect (never the render-scheduling ui-effect), so flipping never re-renders.
- applySiteStyle now injects a real replace-in-place stylesheet built by the new pure site-style-css module: tokens on :root, body props in a body rule, @--name blocks resolved (previously object blocks were silently dropped and stale tokens lingered on reused iframes), scheme blocks dual-emitted via the runtime's shared schemeSelectors, color-scheme declared.
- helpers: isSchemeQuery/schemeOfQuery in canvas-media, built on the runtime's pureSchemeOf — single source of truth for the selector contract.

Specs: studio.md §4.1 (canvas scheme forcing + site-style sheet), studio-ui-guidelines.md §4.3 (compact toggle action-group row). Docs: studio breakpoints + tabs pages document the control.