### PR TITLE
Studio: Open Project repo picker + ship the editor shell in the npm package

### DIFF
--- a/docs/studio/interface/welcome-screen.md
+++ b/docs/studio/interface/welcome-screen.md
@@ -30,6 +30,8 @@ The full walkthrough is in **[Create a project](/docs/studio/projects/create)**.
 
 Studio opens the project and adds it to **Recent** for next time.
 
+On **studio.jxsuite.com**, projects live in GitHub repositories instead of local folders, so **Open Project…** opens a repository picker: it lists the GitHub repositories you have write access to (Jx projects first), with a filter field to narrow the list. Click one and Studio opens it at `/edit/owner/repo@branch`. Repositories without a `project.json` show an inline explanation instead of opening.
+
 ## Clone a git repository
 
 This entry appears when your Studio setup can run git.

--- a/docs/studio/projects.md
+++ b/docs/studio/projects.md
@@ -30,7 +30,7 @@ What each kind of file is for — and when to reach for which — is covered in 
 There are three ways to end up with a project open in Studio, all available from the [Welcome screen](/docs/studio/interface/welcome-screen):
 
 1. **Create a new one.** Click **New Project…** and pick a template or a complete starter site. The whole modal is walked through in **[Create a project](/docs/studio/projects/create)**.
-2. **Open an existing folder.** Click **Open Project…** and point Studio at a Jx project already on your machine. Recently opened projects also appear on the Welcome screen for one-click reopening.
+2. **Open an existing folder.** Click **Open Project…** and point Studio at a Jx project already on your machine. On studio.jxsuite.com the same button lists the GitHub repositories you can write to instead — pick one and Studio opens it. Recently opened projects also appear on the Welcome screen for one-click reopening.
 3. **Clone a repository.** Click **Clone Git Repository…** and paste a repository URL — Studio downloads the project and opens it. On platforms linked to a GitHub account, **Add Existing Repository…** lets you pick from your repositories instead of pasting a URL.
 
 :::doc-note

--- a/packages/studio/index.html
+++ b/packages/studio/index.html
@@ -3084,6 +3084,10 @@
         font-size: var(--spectrum-font-size-75, 12px);
         color: var(--fg-dim);
       }
+      .add-repo-install {
+        color: var(--accent, #1473e6);
+        text-decoration: underline;
+      }
       .new-project-tabs {
         padding: 0 16px;
         border-bottom: 1px solid var(--border);

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -11,7 +11,10 @@
   "files": [
     "*.js",
     "src",
-    "dist"
+    "dist",
+    "index.html",
+    "canvas.html",
+    "fonts"
   ],
   "type": "module",
   "exports": {

--- a/packages/studio/src/new-project/add-repo-modal.ts
+++ b/packages/studio/src/new-project/add-repo-modal.ts
@@ -1,20 +1,29 @@
 /// <reference lib="dom" />
 /**
- * Add Existing Repository modal — a filterable picker over `platform.listRepos` (every repo the
- * platform's account link can reach, personal and organization). Choosing a repo runs
- * `platform.importProject`, which adopts it as a Jx project (probes project.json, tags + catalogues
- * it) and resolves with the catalogue root key; the caller opens it through the same path as a
- * recent project. Repos without a project.json fail with the backend's structured message, shown
- * inline.
+ * Repository picker modal — a filterable picker over `platform.listRepos` (every repo the
+ * platform's account link can reach, personal and organization). Two modes share the dialog:
+ *
+ * - "add" (Add Existing Repository): the unfiltered adoption path.
+ * - "open" (Open Project on `openProjectPicker: "repo-list"` platforms): only write-access
+ *   repositories, Jx-tagged ones first.
+ *
+ * Choosing a repo runs `platform.importProject`, which adopts it as a Jx project (probes
+ * project.json, tags + catalogues it) and resolves with the catalogue root key; the caller opens it
+ * through the same path as a recent project. Repos without a project.json fail with the backend's
+ * structured message, shown inline.
  */
 
 import { html, nothing } from "lit-html";
 import { errorMessage } from "@jxsuite/schema/parse";
+import { getAccountStatus, needsAppInstall } from "../account-status";
 import { getPlatform } from "../platform";
 import { openModal } from "../ui/layers";
 import type { RepoInfo } from "../types";
 
+type PickerMode = "add" | "open";
+
 let _handle: ReturnType<typeof openModal> | null = null;
+let _mode: PickerMode = "add";
 let _repos: RepoInfo[] | null = null;
 let _filter = "";
 let _error = "";
@@ -28,11 +37,29 @@ export function platformSupportsAddRepo(): boolean {
   return typeof platform.listRepos === "function" && typeof platform.importProject === "function";
 }
 
-/** Open the picker. Resolves with the imported project's catalogue root key, or null when cancelled. */
+/** True when the active platform routes Open Project through this repo picker. */
+export function platformUsesRepoPicker(): boolean {
+  return getPlatform().openProjectPicker === "repo-list" && platformSupportsAddRepo();
+}
+
+/**
+ * Open the adoption picker. Resolves with the imported project's catalogue root key, or null when
+ * cancelled.
+ */
 export function openAddRepoModal(): Promise<{ root: string } | null> {
+  return openPicker("add");
+}
+
+/** Open Project as a repo picker (write-access repositories only). Null when cancelled. */
+export function openProjectPickerModal(): Promise<{ root: string } | null> {
+  return openPicker("open");
+}
+
+function openPicker(mode: PickerMode): Promise<{ root: string } | null> {
   if (_handle) {
     return Promise.resolve(null);
   }
+  _mode = mode;
   _repos = null;
   _filter = "";
   _error = "";
@@ -104,7 +131,13 @@ async function chooseRepo(repo: RepoInfo) {
 
 function visibleRepos(): RepoInfo[] {
   const query = _filter.trim().toLowerCase();
-  const repos = _repos ?? [];
+  let repos = _repos ?? [];
+  if (_mode === "open") {
+    // Open Project offers only repos the user can write to; Jx-tagged repos surface first.
+    // The topic is an accelerator, not ground truth — untagged repos still open via importProject.
+    const writable = repos.filter((r) => r.permission === "admin" || r.permission === "write");
+    repos = [...writable.filter((r) => r.isJxProject), ...writable.filter((r) => !r.isJxProject)];
+  }
   return query ? repos.filter((r) => r.fullName.toLowerCase().includes(query)) : repos;
 }
 
@@ -129,17 +162,43 @@ function repoRowTpl(repo: RepoInfo) {
   `;
 }
 
+function emptyTpl() {
+  if (_filter) {
+    return html`<div class="add-repo-empty">No repositories match the filter.</div>`;
+  }
+  if (_mode === "open" && (_repos ?? []).length > 0) {
+    return html`<div class="add-repo-empty">
+      No repositories with write access. Widen the Jx Suite GitHub App's repository access, or ask a
+      repository admin for write access.
+    </div>`;
+  }
+  if (needsAppInstall()) {
+    return html`<div class="add-repo-empty">
+      No repositories are reachable yet.
+      <a
+        class="add-repo-install"
+        href=${getAccountStatus()?.appInstallUrl ?? "#"}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Install the Jx Suite GitHub App
+      </a>
+      to grant repository access, then reopen this dialog.
+    </div>`;
+  }
+  return html`<div class="add-repo-empty">
+    No repositories are reachable. Install the GitHub App (or widen its repository access) and try
+    again.
+  </div>`;
+}
+
 function bodyTpl() {
   if (_repos === null) {
     return html`<div class="add-repo-empty">Loading repositories…</div>`;
   }
   const repos = visibleRepos();
   if (repos.length === 0) {
-    return html`<div class="add-repo-empty">
-      ${_filter
-        ? "No repositories match the filter."
-        : "No repositories are reachable. Install the GitHub App (or widen its repository access) and try again."}
-    </div>`;
+    return emptyTpl();
   }
   return html`<div class="add-repo-list">${repos.map((repo) => repoRowTpl(repo))}</div>`;
 }
@@ -156,7 +215,9 @@ function renderModal() {
       }}
     >
       <div class="new-project-modal-header">
-        <h2 class="new-project-modal-title">Add existing repository</h2>
+        <h2 class="new-project-modal-title">
+          ${_mode === "open" ? "Open Project" : "Add existing repository"}
+        </h2>
         <sp-action-button quiet size="s" @click=${closeAddRepoModal} title="Close">
           <sp-icon-close slot="icon"></sp-icon-close>
         </sp-action-button>

--- a/packages/studio/src/platforms/cloud.ts
+++ b/packages/studio/src/platforms/cloud.ts
@@ -209,6 +209,9 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
     id: "cloud",
     projectRoot: root,
     canvasUrl: "/canvas.html",
+    /* Open Project routes through Studio's repo picker (write-access repos via listRepos +
+       importProject) — sessions are URL-bound, so openProject() below never opens a dialog. */
+    openProjectPicker: "repo-list",
 
     async activate() {
       if (!project) {
@@ -377,9 +380,8 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
 
     /**
      * The project's format registry, served by the session gateway (the dev server's `GET
-     * /__studio/formats` under this session's base path). Part-4 cleanup: the cloud ProjectSession
-     * does not serve the route yet, so this degrades to an empty registry (only .json documents
-     * open) until the backend lands it.
+     * /__studio/formats` under this session's base path). Degrades to an empty registry (only .json
+     * documents open) against backends that predate the route.
      */
     async listFormats() {
       try {

--- a/packages/studio/src/studio.ts
+++ b/packages/studio/src/studio.ts
@@ -155,7 +155,11 @@ import { hydrateProjectList } from "./project-list";
 import { addRecentProject, hydrateRecentProjects, removeRecentProject } from "./recent-projects";
 import { hydrateSettings } from "./services/settings-store";
 import { initWelcome } from "./panels/welcome-screen";
-import { openAddRepoModal } from "./new-project/add-repo-modal";
+import {
+  openAddRepoModal,
+  openProjectPickerModal,
+  platformUsesRepoPicker,
+} from "./new-project/add-repo-modal";
 import { openNewProjectModal } from "./new-project/new-project-modal";
 import type { DocumentStackEntry, GitDiffState } from "./types";
 import type { Tab } from "./tabs/tab";
@@ -888,6 +892,19 @@ function loadProject() {
   return _loadProject();
 }
 async function openProject() {
+  // Repo-list platforms (cloud) pick from the user's writable repositories instead of a
+  // Backend dialog; the choice opens through the same path as a recent project.
+  if (platformUsesRepoPicker()) {
+    const picked = await openProjectPickerModal();
+    if (picked) {
+      // The catalogue may have gained an entry; refresh it before navigating into the project.
+      void hydrateProjectList().then(() => {
+        render();
+      });
+      void openRecentProject(picked.root);
+    }
+    return;
+  }
   const result = await _openProject({
     renderActivityBar: () => renderActivityBar(),
     renderLeftPanel,

--- a/packages/studio/src/types.ts
+++ b/packages/studio/src/types.ts
@@ -127,6 +127,14 @@ export interface StudioPlatform {
     config: ProjectConfig;
     handle: { root: string; name: string; projectConfig: ProjectConfig };
   } | null>;
+  /**
+   * How "Open Project" picks a project. Absent: `openProject()` owns picking (native dialog /
+   * showDirectoryPicker). `"repo-list"`: Studio shows its repository picker over `listRepos` +
+   * `importProject` (write-access repositories) and opens the choice through the recent-projects
+   * path — `openProject()` is never called. Cloud sets this: its sessions are URL-bound, so there
+   * is no backend dialog to delegate to.
+   */
+  openProjectPicker?: "repo-list";
   probeRootProject: () => Promise<{
     meta: { root: string; name: string };
     info: {

--- a/packages/studio/tests/add-repo-modal.test.ts
+++ b/packages/studio/tests/add-repo-modal.test.ts
@@ -1,14 +1,21 @@
 /**
- * Add Existing Repository modal tests — drives the real picker through the layer system: repo list
+ * Repository picker modal tests — drives the real picker through the layer system: repo list
  * rendering with badges, filtering, import success resolving the catalogue root key, the structured
- * not_jx_project failure staying inline, and dismissal.
+ * not_jx_project failure staying inline, dismissal, and the Open Project mode (write-access
+ * filtering, Jx-first ordering, install-App empty state).
  */
 import { flush, installMockPlatform } from "./harness";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { RepoInfo } from "../src/types";
 
-const { closeAddRepoModal, openAddRepoModal, platformSupportsAddRepo } =
-  await import("../src/new-project/add-repo-modal");
+const {
+  closeAddRepoModal,
+  openAddRepoModal,
+  openProjectPickerModal,
+  platformSupportsAddRepo,
+  platformUsesRepoPicker,
+} = await import("../src/new-project/add-repo-modal");
+const { hydrateAccountStatus, resetAccountStatus } = await import("../src/account-status");
 const { initLayers } = await import("../src/ui/layers");
 
 document.body.innerHTML = `
@@ -53,6 +60,7 @@ function errorText(): string | null {
 
 afterEach(() => {
   closeAddRepoModal();
+  resetAccountStatus();
 });
 
 describe("platformSupportsAddRepo", () => {
@@ -66,6 +74,25 @@ describe("platformSupportsAddRepo", () => {
       listRepos: () => Promise.resolve(REPOS),
     });
     expect(platformSupportsAddRepo()).toBe(true);
+  });
+});
+
+describe("platformUsesRepoPicker", () => {
+  test("requires the repo-list marker on top of listRepos + importProject", () => {
+    installMockPlatform({
+      importProject: () => Promise.resolve({ root: "octocat/site@main" }),
+      listRepos: () => Promise.resolve(REPOS),
+    });
+    expect(platformUsesRepoPicker()).toBe(false);
+    installMockPlatform({
+      importProject: () => Promise.resolve({ root: "octocat/site@main" }),
+      listRepos: () => Promise.resolve(REPOS),
+      openProjectPicker: "repo-list",
+    });
+    expect(platformUsesRepoPicker()).toBe(true);
+    // The marker alone is not enough without the backing capabilities.
+    installMockPlatform({ openProjectPicker: "repo-list" });
+    expect(platformUsesRepoPicker()).toBe(false);
   });
 });
 
@@ -141,6 +168,132 @@ describe("openAddRepoModal", () => {
     await flush();
     expect(rows()).toHaveLength(0);
     expect(errorText()).toContain("GitHub authorization expired");
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("add mode shows read-only repos (no write filter)", async () => {
+    installMockPlatform({
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () => Promise.resolve([READ_ONLY_REPO]),
+    });
+    const promise = openAddRepoModal();
+    await flush();
+    expect(rows()).toHaveLength(1);
+    expect(rows()[0]!.textContent).toContain("acme/docs");
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+});
+
+const READ_ONLY_REPO: RepoInfo = {
+  defaultBranch: "main",
+  fullName: "acme/docs",
+  isJxProject: true,
+  name: "docs",
+  owner: "acme",
+  permission: "read",
+  private: false,
+};
+
+const UNTAGGED_WRITABLE_REPO: RepoInfo = {
+  defaultBranch: "main",
+  fullName: "acme/newsletter",
+  isJxProject: false,
+  name: "newsletter",
+  owner: "acme",
+  permission: "write",
+  private: false,
+};
+
+describe("openProjectPickerModal", () => {
+  test("shows only writable repos, Jx-tagged first, under the Open Project title", async () => {
+    installMockPlatform({
+      importProject: () => Promise.resolve({ root: "octocat/site@main" }),
+      listRepos: () => Promise.resolve([UNTAGGED_WRITABLE_REPO, READ_ONLY_REPO, ...REPOS]),
+      openProjectPicker: "repo-list",
+    });
+    const promise = openProjectPickerModal();
+    await flush();
+    const title = document.querySelector("#layer-modal .new-project-modal-title");
+    expect(title?.textContent?.trim()).toBe("Open Project");
+    const names = rows().map((row) => row.title);
+    // Read-only acme/docs is absent; Jx-tagged octocat/site precedes the untagged writable repos.
+    expect(names).toEqual(["octocat/site", "acme/newsletter", "acme/marketing"]);
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("selection imports the repo and resolves its catalogue root key", async () => {
+    const importProject = mock((opts: { owner: string; name: string }) =>
+      Promise.resolve({ root: `${opts.owner}/${opts.name}@main` }),
+    );
+    installMockPlatform({
+      importProject: importProject as never,
+      listRepos: () => Promise.resolve(REPOS),
+      openProjectPicker: "repo-list",
+    });
+    const promise = openProjectPickerModal();
+    await flush();
+    rows()[0]!.dispatchEvent(new Event("click", { bubbles: true }));
+    await flush();
+    expect(importProject).toHaveBeenCalledWith({ name: "site", owner: "octocat" });
+    expect(await promise).toEqual({ root: "octocat/site@main" });
+  });
+
+  test("an untagged repo's import failure stays inline", async () => {
+    installMockPlatform({
+      importProject: () =>
+        Promise.reject(
+          Object.assign(new Error("acme/newsletter has no readable project.json"), {
+            code: "not_jx_project",
+          }),
+        ),
+      listRepos: () => Promise.resolve([UNTAGGED_WRITABLE_REPO]),
+      openProjectPicker: "repo-list",
+    });
+    const promise = openProjectPickerModal();
+    await flush();
+    rows()[0]!.dispatchEvent(new Event("click", { bubbles: true }));
+    await flush();
+    expect(modal()).toBeTruthy();
+    expect(errorText()).toContain("no readable project.json");
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("repos without write access get the widen-access empty state", async () => {
+    installMockPlatform({
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () => Promise.resolve([READ_ONLY_REPO]),
+      openProjectPicker: "repo-list",
+    });
+    const promise = openProjectPickerModal();
+    await flush();
+    expect(rows()).toHaveLength(0);
+    const empty = document.querySelector("#layer-modal .add-repo-empty");
+    expect(empty?.textContent).toContain("No repositories with write access");
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("no reachable repos prompts a GitHub App install link", async () => {
+    installMockPlatform({
+      getAccountStatus: () =>
+        Promise.resolve({
+          appInstallUrl: "https://github.com/apps/jx-suite/installations/new",
+          installations: [],
+        }),
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () => Promise.resolve([]),
+      openProjectPicker: "repo-list",
+    });
+    await hydrateAccountStatus();
+    const promise = openProjectPickerModal();
+    await flush();
+    const link = document.querySelector("#layer-modal .add-repo-install") as HTMLAnchorElement;
+    expect(link).toBeTruthy();
+    expect(link.href).toBe("https://github.com/apps/jx-suite/installations/new");
     closeAddRepoModal();
     expect(await promise).toBeNull();
   });

--- a/packages/studio/tests/cloud-platform.test.ts
+++ b/packages/studio/tests/cloud-platform.test.ts
@@ -85,6 +85,11 @@ describe("project binding", () => {
     expect(opened?.handle.root).toBe("octocat/my-site");
   });
 
+  test("open-project picking routes through the studio repo picker in both modes", () => {
+    expect(createCloudPlatform(PROJECT).openProjectPicker).toBe("repo-list");
+    expect(createCloudPlatform(null).openProjectPicker).toBe("repo-list");
+  });
+
   test("probeRootProject reports a non-jx repo as not a site project", async () => {
     mockFetch({
       "/project-info": {

--- a/packages/studio/tests/studio-shell.test.ts
+++ b/packages/studio/tests/studio-shell.test.ts
@@ -75,6 +75,8 @@ let consumePatchedReturn = false;
 const consumePatchedMock = mock((_doc: object) => consumePatchedReturn);
 let newProjectResult: { root: string } | null = null;
 let addRepoResult: { root: string } | null = null;
+let pickerEnabled = false;
+let pickerResult: { root: string } | null = null;
 
 void mock.module("../src/services/monaco-setup.js", () => ({}));
 
@@ -171,7 +173,9 @@ void mock.module("../src/new-project/new-project-modal.ts", () => ({
 void mock.module("../src/new-project/add-repo-modal.ts", () => ({
   closeAddRepoModal: mock(() => {}),
   openAddRepoModal: mock(async () => addRepoResult),
+  openProjectPickerModal: mock(async () => pickerResult),
   platformSupportsAddRepo: mock(() => true),
+  platformUsesRepoPicker: mock(() => pickerEnabled),
 }));
 
 // Capture the left-panel mount ctx (setGitDiffState / renderCanvas / cloneRepository arrows).
@@ -786,6 +790,35 @@ describe("project open delegates", () => {
     await toolbarCtx.openProject();
     const after = state.calls.filter((c) => c[0] === "openProject").length;
     expect(after).toBe(before + 1);
+  });
+
+  test("repo-list platforms route openProject through the picker, bypassing the backend dialog", async () => {
+    pickerEnabled = true;
+    pickerResult = { root: "/picked/repo" };
+    const before = state.calls.filter((c) => c[0] === "openProject").length;
+    try {
+      await toolbarCtx.openProject();
+      await waitFor(() => statusMessages.includes("Opened project: Recent Project"));
+    } finally {
+      pickerEnabled = false;
+      pickerResult = null;
+    }
+    expect(state.calls.filter((c) => c[0] === "openProject")).toHaveLength(before);
+    expect(platform.projectRoot).toBe("/picked/repo");
+    expect(statusMessages).toContain("Opened project: Recent Project");
+  });
+
+  test("a cancelled repo picker is a no-op", async () => {
+    pickerEnabled = true;
+    pickerResult = null;
+    const before = state.calls.filter((c) => c[0] === "openProject").length;
+    try {
+      await toolbarCtx.openProject();
+    } finally {
+      pickerEnabled = false;
+    }
+    expect(state.calls.filter((c) => c[0] === "openProject")).toHaveLength(before);
+    expect(statusMessages).toHaveLength(0);
   });
 
   test("welcome openNewProject does nothing when the modal is cancelled", async () => {

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -76,18 +76,18 @@ The PAL is a plain JavaScript object conforming to a `StudioPlatform` interface.
 
 The canonical `StudioPlatform` interface is `packages/studio/src/types.ts` — roughly 70 members today. This spec deliberately does not duplicate it; the summary below names the member families and the model that governs them. The transport-level view of the same contract is the `STUDIO_ROUTES` table in `@jxsuite/protocol` (§5.1).
 
-| Family                   | Representative members                                                                                                                                            |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Session / project**    | `id`, `projectRoot`, `activate`, `openProject`, `probeRootProject`, `createProject`, `listStarters?`, `importSite?`, `listProjects?`, recent-projects persistence |
-| **Filesystem**           | `listDirectory`, `readFile`, `writeFile`, `uploadFile`, `deleteFile`, `renameFile`, `createDirectory`, `locateFile`, `searchFiles`, `subscribeFileEvents?`        |
-| **Documents / formats**  | `discoverComponents`, `listFormats?`, `listExtensions?`, `fetchProjectSchemas?`, `formatAction?`, `fetchPluginSchema`                                             |
-| **Packages**             | `listPackages`, `addPackage`, `removePackage`, `installDependencies?`, `outdatedPackages?`, `setPackageVersions?`                                                 |
-| **Git**                  | `gitStatus`, `gitCommit`, `gitPush`, `gitPull`, `gitDiff`, `gitCheckout`, `gitClone?`, `createPullRequest?`, …                                                    |
-| **Collab**               | `collab?` (realtime co-editing handle per document)                                                                                                               |
-| **Data / secrets**       | `dataConnections?`, `dataRows?`, row CRUD, `dataPush?`, `listSecrets?`, `setSecrets?`                                                                             |
-| **Publish / identity**   | `getUser?`, `getAccountStatus?`, `listRepos?`, `importProject?`, `cfConnection?`, `cfApi?`                                                                        |
-| **Code services / AI**   | `codeService` (§5.3), `resolveClass?`, `aiChatUrl`                                                                                                                |
-| **Multi-window / shell** | `openProjectInNewWindow?`, `newWindow?`, `setWindowProject?`, `getProjectRoot?`, `getAppInfo?`, backend-persisted settings                                        |
+| Family                   | Representative members                                                                                                                                                                  |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Session / project**    | `id`, `projectRoot`, `activate`, `openProject`, `openProjectPicker?`, `probeRootProject`, `createProject`, `listStarters?`, `importSite?`, `listProjects?`, recent-projects persistence |
+| **Filesystem**           | `listDirectory`, `readFile`, `writeFile`, `uploadFile`, `deleteFile`, `renameFile`, `createDirectory`, `locateFile`, `searchFiles`, `subscribeFileEvents?`                              |
+| **Documents / formats**  | `discoverComponents`, `listFormats?`, `listExtensions?`, `fetchProjectSchemas?`, `formatAction?`, `fetchPluginSchema`                                                                   |
+| **Packages**             | `listPackages`, `addPackage`, `removePackage`, `installDependencies?`, `outdatedPackages?`, `setPackageVersions?`                                                                       |
+| **Git**                  | `gitStatus`, `gitCommit`, `gitPush`, `gitPull`, `gitDiff`, `gitCheckout`, `gitClone?`, `createPullRequest?`, …                                                                          |
+| **Collab**               | `collab?` (realtime co-editing handle per document)                                                                                                                                     |
+| **Data / secrets**       | `dataConnections?`, `dataRows?`, row CRUD, `dataPush?`, `listSecrets?`, `setSecrets?`                                                                                                   |
+| **Publish / identity**   | `getUser?`, `getAccountStatus?`, `listRepos?`, `importProject?`, `cfConnection?`, `cfApi?`                                                                                              |
+| **Code services / AI**   | `codeService` (§5.3), `resolveClass?`, `aiChatUrl`                                                                                                                                      |
+| **Multi-window / shell** | `openProjectInNewWindow?`, `newWindow?`, `setWindowProject?`, `getProjectRoot?`, `getAppInfo?`, backend-persisted settings                                                              |
 
 **Core vs. optional, and degradation.** Required members are the minimal backend every platform implements. Optional members (marked `?` in the interface) each back an optional protocol route; Studio feature-detects them and degrades gracefully when they are absent — hiding the corresponding UI or falling back to a client-side path. Each optional route's `degradation` note in `STUDIO_ROUTES` records exactly what turns off (e.g. no `collab` → Studio edits solo with file-level saves; no `importSite` → the New Project modal hides its Import tab).
 
@@ -139,8 +139,8 @@ if (!hasPlatform()) {
    - If a project was previously open and the handle is still valid, reopen it
    - Otherwise, show the welcome state ("Open a project to get started")
 3. When the user triggers "Open Project":
-   - Studio calls `getPlatform().openProject()`
-   - The platform presents its native project opening flow
+   - With `openProjectPicker: "repo-list"` (cloud), Studio shows its own repository picker over `listRepos` + `importProject` (write-access repositories only) and opens the choice through the recent-projects path — `openProject()` is never called
+   - Otherwise Studio calls `getPlatform().openProject()` and the platform presents its native project opening flow
    - On success, Studio receives `{ config, handle }` and initializes the file tree
 
 ---
@@ -153,7 +153,7 @@ A project is identified by its `project.json` file. This is the single point of 
 
 - **Desktop:** User selects `project.json` via native file dialog. The parent directory becomes the project root.
 - **Dev server:** User selects the folder containing `project.json` via `showDirectoryPicker()`. Studio reads `project.json` from the directory to validate it.
-- **Cloud:** User selects a project from a project list. The cloud backend locates the project's `project.json` equivalent in its data store.
+- **Cloud:** User picks from a repository list (`openProjectPicker: "repo-list"` — GitHub repositories with write access, Jx-tagged repos first). Selection runs `importProject`, which probes the repository's `project.json` and resolves the catalogue root key Studio navigates to.
 
 The `project.json` file is **required** for project-level features. Studio can still open individual `.json` files for standalone component editing (see §4.3).
 
@@ -162,16 +162,18 @@ The `project.json` file is **required** for project-level features. Studio can s
 ```
 User clicks "Open Project"
         │
+        ├─── openProjectPicker: "repo-list" (Cloud): Studio's repository picker
+        │    → listRepos → write-access repos, Jx-tagged first → user picks
+        │    → importProject → { root } → opens via the recent-projects path
+        │    (openProject() is never called)
         ▼
 platform.openProject()
         │
         ├─── Desktop: Utils.openFileDialog({ allowedFileTypes: "json", canChooseFiles: true })
         │    → user picks project.json → read + parse → derive project root from parent dir
         │
-        ├─── Dev server: showDirectoryPicker()
+        └─── Dev server: showDirectoryPicker()
         │    → user picks folder → read project.json from dir → parse + validate
-        │
-        └─── Cloud: fetch project list → user picks → fetch project.json from storage
         │
         ▼
 Returns { config, handle } or null

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -80,16 +80,16 @@ Immutable state with undo/redo history (100 entries). All mutations produce a ne
 
 Studio uses a platform abstraction (`platform.js`) to decouple UI from backend:
 
-| Method                 | Description                      |
-| ---------------------- | -------------------------------- |
-| `listFiles(dir)`       | List directory contents          |
-| `readFile(path)`       | Read file content                |
-| `writeFile(path, c)`   | Write file content               |
-| `deleteFile(path)`     | Delete file                      |
-| `renameFile(old,new)`  | Rename/move file                 |
-| `discoverComponents()` | Scan project for custom elements |
-| `openProject()`        | Open project picker              |
-| `probeRootProject()`   | Auto-detect project at startup   |
+| Method                 | Description                                                                                                |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `listFiles(dir)`       | List directory contents                                                                                    |
+| `readFile(path)`       | Read file content                                                                                          |
+| `writeFile(path, c)`   | Write file content                                                                                         |
+| `deleteFile(path)`     | Delete file                                                                                                |
+| `renameFile(old,new)`  | Rename/move file                                                                                           |
+| `discoverComponents()` | Scan project for custom elements                                                                           |
+| `openProject()`        | Open project picker (unless `openProjectPicker: "repo-list"` routes it through Studio's repository picker) |
+| `probeRootProject()`   | Auto-detect project at startup                                                                             |
 
 Three platform targets:
 


### PR DESCRIPTION
Two cloud-studio gaps, one release:

## Open Project repo picker (`openProjectPicker: "repo-list"`)

Cloud sessions are URL-bound, so "Open Project" had nothing useful to do on studio.jxsuite.com. A new optional PAL marker — set only by the cloud adapter, in both bound and project-less modes — routes the Open Project action through Studio's own repository picker instead of `platform.openProject()`:

- The add-repo modal gains an "open" mode: only repositories the user can **write** to (`admin|write`), Jx-tagged repos first, filter field, widen-access empty state, and an Install-the-GitHub-App link when no repos are reachable.
- Selection runs `platform.importProject` (server verifies `project.json` + default branch) and opens the resolved root through the recent-projects path; repos without a `project.json` show the structured error inline.
- The marker is explicit rather than inferred from `listRepos` presence so desktop can gain repo listing later without hijacking its native dialog. Desktop/devserver behavior unchanged (covered by regression tests).
- Zero backend changes: `GET /api/v1/repos` already returns `permission`/`isJxProject`/`defaultBranch`.

## Ship the editor shell in the npm package

`files` now includes `index.html`, `canvas.html`, `fonts/` so the cloud platform can stage the editor page from `node_modules/@jxsuite/studio` instead of a vendored copy — the stale-shell drift that hid the chat sidebar on studio.jxsuite.com becomes structurally impossible (platform follow-up: jxsuite/platform#4).

## Specs & docs

`specs/desktop.md` §3.1/§3.4/§4.1/§4.2 and `specs/studio.md` §3.4 document the repo-list picking mode and degradation; `docs/studio/interface/welcome-screen.md` and `docs/studio/projects.md` describe the cloud repository picker. `bun run docs:check` and `bun run docs:sync` green.

## Verification

- Full studio suite: 4684 tests green (`bun test --isolate`), coverage thresholds + manifest green, typecheck + lint green.
- New tests: marker gating, write-only filtering, Jx-first ordering, selection → import → root, inline 422, both empty states, add-mode regression, shell-level picker delegation (bypasses `platform.openProject`, cancel = no-op), cloud adapter marker in both modes.
- End-to-end recipe: `cd ../platform && bun scripts/build-assets.ts --link ../jx && bun run dev` → `/studio` → **Open Project** → dialog lists writable repos → selection navigates to `/edit/owner/repo@branch`.

After merge: release-please cuts `studio-v1.4.1` → npm publish → jxsuite/platform#4 activates the durable shell pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)