### PR TITLE
fix(studio): register cloud platform inside studio.js for single-yjs collab

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,7 +17,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.1-draft  | Partial     | 2026-07-22 |
 | `collab.md`               | 0.1.1-draft  | Partial     | 2026-07-22 |
 | `compiler.md`             | 0.1.22-draft | Partial     | 2026-07-23 |
-| `desktop.md`              | 0.2.6-draft  | Pending     | 2026-07-24 |
+| `desktop.md`              | 0.2.7-draft  | Pending     | 2026-07-24 |
 | `extensions.md`           | 0.2.8-draft  | Partial     | 2026-07-23 |
 | `imports.md`              | 0.1.6-draft  | Partial     | 2026-07-22 |
 | `jx-markdown.md`          | 0.1.7-draft  | Partial     | 2026-07-22 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -50,6 +50,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.2.7-draft** (2026-07-24) — Cloud platform registers inside studio.js via a window.__jxCloud signal (single yjs for collab).
 - **0.2.6-draft** (2026-07-24) — Document packaged static-data staging into app/bun (create templates, starters) and postBuild bundle verification.
 - **0.2.5-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.2.4-draft** (2026-07-22) — Machine-readable spec status vocabulary + generated status page (`79daba23`).

--- a/packages/studio/src/files/files.ts
+++ b/packages/studio/src/files/files.ts
@@ -52,7 +52,7 @@ import type { TemplateResult } from "lit-html";
 import type { JxMutableNode } from "@jxsuite/schema/types";
 import type { StudioState } from "../state.js";
 import type { Tab } from "../tabs/tab.js";
-import type { RenameResult } from "../types";
+import type { DirEntry, RenameResult } from "../types";
 import { rectOf } from "../utils/geometry";
 
 // ─── File icon map ────────────────────────────────────────────────────────────
@@ -215,19 +215,33 @@ export async function openProject({
   }
 }
 
-export async function openHomePage() {
-  const platform = getPlatform();
+/**
+ * The project's home page path (`pages/index.<page-ext>` or `pages/index.json`), or null if none.
+ * Lists `pages/` once and matches by name — a directory read returns 200 with `[]` for a missing
+ * dir, so this never provokes the console 404s a blind per-candidate read would.
+ */
+export async function findHomePage(): Promise<string | null> {
   await loadFormats();
-  const candidates = [
-    ...documentExtensions("page").map((ext) => `pages/index${ext}`),
-    "pages/index.json",
-  ];
-  for (const path of candidates) {
-    try {
-      await platform.readFile(path);
-      await openFileInTab(path);
-      return;
-    } catch {}
+  const exts = [...documentExtensions("page"), ".json"];
+  let entries: DirEntry[];
+  try {
+    entries = await getPlatform().listDirectory("pages");
+  } catch {
+    return null;
+  }
+  const files = new Set(entries.filter((e) => e.type === "file").map((e) => e.name));
+  for (const ext of exts) {
+    if (files.has(`index${ext}`)) {
+      return `pages/index${ext}`;
+    }
+  }
+  return null;
+}
+
+export async function openHomePage() {
+  const home = await findHomePage();
+  if (home) {
+    await openFileInTab(home);
   }
 }
 

--- a/packages/studio/src/packages/pull-package-sync.ts
+++ b/packages/studio/src/packages/pull-package-sync.ts
@@ -273,8 +273,20 @@ async function recoverAfterFailedPull(original: unknown): Promise<void> {
   await discardPullAndSync(plan);
 }
 
+/**
+ * Snapshot the package files (aligned to PKG_PATHS). Lists the root once and reads only the files
+ * that exist, so absent lockfiles (cloud projects don't commit one) never trigger a console 404
+ * from a blind read. Listing failure falls back to probing all paths.
+ */
 async function snapshotPackageFiles(): Promise<(string | null)[]> {
-  return Promise.all(PKG_PATHS.map((path) => tryRead(path)));
+  let present: Set<string>;
+  try {
+    const entries = await getPlatform().listDirectory("");
+    present = new Set(entries.filter((e) => e.type === "file").map((e) => e.name));
+  } catch {
+    present = new Set(PKG_PATHS);
+  }
+  return Promise.all(PKG_PATHS.map((path) => (present.has(path) ? tryRead(path) : null)));
 }
 
 /**

--- a/packages/studio/src/packages/pull-package-sync.ts
+++ b/packages/studio/src/packages/pull-package-sync.ts
@@ -278,6 +278,11 @@ async function recoverAfterFailedPull(original: unknown): Promise<void> {
  * that exist, so absent lockfiles (cloud projects don't commit one) never trigger a console 404
  * from a blind read. Listing failure falls back to probing all paths.
  */
+/**
+ * Snapshot the package files (aligned to PKG_PATHS). Lists the root once and reads only the files
+ * that exist, so absent lockfiles (cloud projects don't commit one) never trigger a console 404
+ * from a blind read. Listing failure falls back to probing all paths.
+ */
 async function snapshotPackageFiles(): Promise<(string | null)[]> {
   let present: Set<string>;
   try {
@@ -286,7 +291,9 @@ async function snapshotPackageFiles(): Promise<(string | null)[]> {
   } catch {
     present = new Set(PKG_PATHS);
   }
-  return Promise.all(PKG_PATHS.map((path) => (present.has(path) ? tryRead(path) : null)));
+  return Promise.all(
+    PKG_PATHS.map((path) => (present.has(path) ? tryRead(path) : Promise.resolve(null))),
+  );
 }
 
 /**

--- a/packages/studio/src/platforms/default-platform.ts
+++ b/packages/studio/src/platforms/default-platform.ts
@@ -1,0 +1,27 @@
+/// <reference lib="dom" />
+/**
+ * Chooses the default PAL adapter when no platform was pre-registered on `window.__jxPlatform`.
+ *
+ * The cloud shell (the platform repo's `web/edit-init.ts`) publishes a `window.__jxCloud` signal
+ * _instead of_ constructing the adapter itself, so the cloud adapter — and its collab WebSocket
+ * client, which owns the shared `Y.Doc` — is created HERE, inside the studio bundle, sharing
+ * studio's single `yjs` instance. Creating it in the shell bundle loads a SECOND `yjs`, which
+ * breaks collab's cross-module `instanceof` checks (the Y↔JxDocOp conversion silently stops
+ * reconciling). The dev server sends no signal and falls back to the dev-server adapter; desktop
+ * pre-registers its own adapter on `__jxPlatform`, so this resolver never runs there.
+ */
+import type { StudioPlatform } from "../types";
+import type { CloudProject } from "./cloud";
+import { createCloudPlatform } from "./cloud";
+import { createDevServerPlatform } from "./devserver";
+
+/** Cloud shell handshake: presence signals cloud; `project` is null for the /studio hub. */
+export interface CloudSignal {
+  project: CloudProject | null;
+}
+
+/** Returns the cloud adapter when the shell signalled cloud, else the dev-server adapter. */
+export function resolveDefaultPlatform(): StudioPlatform {
+  const cloud = (globalThis as unknown as { __jxCloud?: CloudSignal }).__jxCloud;
+  return cloud ? createCloudPlatform(cloud.project) : createDevServerPlatform();
+}

--- a/packages/studio/src/studio.ts
+++ b/packages/studio/src/studio.ts
@@ -68,7 +68,6 @@ import {
 } from "./panels/statusbar";
 import { exportFile, parseSourceForPath, saveFile, serializeDocument } from "./files/file-ops";
 import {
-  documentExtensions,
   formatForPath,
   loadFormats,
   refreshExtensionUi,
@@ -78,6 +77,7 @@ import {
   loadProject as _loadProject,
   openProject as _openProject,
   renderFilesTemplate as _renderFilesTemplate,
+  findHomePage,
   loadDirectory,
   openFileInTab,
   openHomePage,
@@ -102,7 +102,7 @@ import { openConnectorGrid } from "./grid/grid-open";
 
 import { getPlatform, hasPlatform, registerPlatform } from "./platform";
 import { parseMediaEntries } from "./utils/canvas-media";
-import { createDevServerPlatform } from "./platforms/devserver";
+import { resolveDefaultPlatform } from "./platforms/default-platform";
 import { mountResizeEdges } from "./resize-edges";
 import { codeService } from "./services/code-services";
 import { defBadgeLabel, defCategory, renderSignalsTemplate } from "./panels/signals-panel";
@@ -389,9 +389,11 @@ initCssData(webdata);
 
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 
-// Register the dev server platform adapter (PAL) as default if none pre-registered
+// Register the default platform adapter (PAL) if none was pre-registered (desktop registers its own
+// On window.__jxPlatform). resolveDefaultPlatform picks cloud when the shell signalled it, creating
+// The cloud adapter inside THIS bundle so collab shares studio's single yjs, else the dev server.
 if (!hasPlatform()) {
-  registerPlatform(createDevServerPlatform());
+  registerPlatform(resolveDefaultPlatform());
 }
 
 // Screenshot/automation runners (scripts/screenshots/) await window.__jxAutomation right after
@@ -785,25 +787,9 @@ if (_projectParam) {
         const _fileParam = _urlParams.get("file");
         let fileRelPath = _fileParam || siteCtx.fileRelPath || _projectParam;
 
-        // When opening project.json, default to home page instead
+        // When opening project.json, default to home page instead (listing-based, no 404 probes).
         if (fileRelPath === "project.json" || fileRelPath.endsWith("/project.json")) {
-          let opened = false;
-          await loadFormats();
-          const homeCandidates = [
-            ...documentExtensions("page").map((ext) => `pages/index${ext}`),
-            "pages/index.json",
-          ];
-          for (const candidate of homeCandidates) {
-            try {
-              await platform.readFile(candidate);
-              fileRelPath = candidate;
-              opened = true;
-              break;
-            } catch {}
-          }
-          if (!opened) {
-            fileRelPath = "project.json";
-          }
+          fileRelPath = (await findHomePage()) ?? "project.json";
         }
 
         const content = await platform.readFile(fileRelPath);

--- a/packages/studio/tests/default-platform.test.ts
+++ b/packages/studio/tests/default-platform.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for resolveDefaultPlatform (src/platforms/default-platform.ts): it picks the cloud adapter
+ * when the cloud shell published a `window.__jxCloud` signal, else the dev-server adapter. This is
+ * what keeps the cloud adapter — and its collab client's single yjs — inside the studio bundle.
+ */
+import "./with-dom.js";
+import { afterEach, describe, expect, test } from "bun:test";
+import { resolveDefaultPlatform } from "../src/platforms/default-platform";
+import type { CloudProject } from "../src/platforms/cloud";
+
+const g = globalThis as unknown as { __jxCloud?: { project: CloudProject | null } };
+
+afterEach(() => {
+  delete g.__jxCloud;
+});
+
+describe("resolveDefaultPlatform", () => {
+  test("returns the dev-server adapter when no cloud signal is present", () => {
+    delete g.__jxCloud;
+    expect(resolveDefaultPlatform().id).toBe("devserver");
+  });
+
+  test("returns the cloud adapter bound to the signalled project", () => {
+    g.__jxCloud = { project: { owner: "acme", repo: "site", branch: "main" } };
+    const platform = resolveDefaultPlatform();
+    expect(platform.id).toBe("cloud");
+    expect(platform.projectRoot).toBe("acme/site");
+  });
+
+  test("returns the cloud adapter for the project-less hub (null project)", () => {
+    g.__jxCloud = { project: null };
+    const platform = resolveDefaultPlatform();
+    expect(platform.id).toBe("cloud");
+    expect(platform.projectRoot).toBe("");
+  });
+});

--- a/packages/studio/tests/files.test.ts
+++ b/packages/studio/tests/files.test.ts
@@ -10,6 +10,7 @@ import { createState, requireProjectState, setProjectState, projectState } from 
 import { activeTab, closeAllTabs, openTab, workspace } from "../src/workspace/workspace";
 import { MARKDOWN_FORMAT, mockFormatAction, seedMarkdownFormat } from "./format-fixture";
 import {
+  findHomePage,
   loadDirectory,
   loadProject,
   openFileFromTree,
@@ -264,6 +265,45 @@ describe("openHomePage", () => {
     await openHomePage();
 
     expect(activeTab.value).toBeNull();
+  });
+});
+
+// ─── findHomePage (listing-based; never provokes per-candidate 404s) ────────────
+
+describe("findHomePage", () => {
+  test("prefers a format page candidate over index.json", async () => {
+    installFsPlatform({ "pages/index.json": "{}", "pages/index.md": "# Home" });
+    siteState();
+
+    expect(await findHomePage()).toBe("pages/index.md");
+  });
+
+  test("falls back to pages/index.json when no format candidate exists", async () => {
+    installFsPlatform({ "pages/index.json": "{}" });
+    siteState();
+
+    expect(await findHomePage()).toBe("pages/index.json");
+  });
+
+  test("returns null when no index page exists", async () => {
+    installFsPlatform({ "readme.md": "# hi" });
+    siteState();
+
+    expect(await findHomePage()).toBeNull();
+  });
+
+  test("returns null when the pages listing fails", async () => {
+    installFsPlatform(
+      { "pages/index.json": "{}" },
+      {
+        listDirectory: async () => {
+          throw new Error("offline");
+        },
+      },
+    );
+    siteState();
+
+    expect(await findHomePage()).toBeNull();
   });
 });
 

--- a/packages/studio/tests/harness.ts
+++ b/packages/studio/tests/harness.ts
@@ -81,7 +81,9 @@ export interface MockPlatformState {
 }
 
 function dirEntriesFor(files: Map<string, string>, dir: string): DirEntry[] {
-  const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+  // Root ("" or ".") maps to an empty prefix, matching the real backends (a root listing returns
+  // Top-level entries, not a synthetic "/" prefix). Non-root dirs get a trailing-slash prefix.
+  const prefix = dir === "" || dir === "." ? "" : dir.endsWith("/") ? dir : `${dir}/`;
   const seen = new Map<string, DirEntry>();
   for (const path of files.keys()) {
     if (!path.startsWith(prefix)) {

--- a/packages/studio/tests/pull-package-sync.test.ts
+++ b/packages/studio/tests/pull-package-sync.test.ts
@@ -329,6 +329,31 @@ describe("pullWithPackageSync — post-pull sync", () => {
 
     expect(progressCard()?.textContent).toContain("lockfile corrupt");
   });
+
+  test("falls back to reading all package files when the root listing fails", async () => {
+    let installed = false;
+    const { state } = installMockPlatform(
+      {
+        gitPull: async () => {
+          state.files.set("package.json", PKG_AUTOMATED);
+        },
+        gitStatus: async () => gitStatusOf(),
+        installDependencies: async () => {
+          installed = true;
+          return { ok: true };
+        },
+        listDirectory: async () => {
+          throw new Error("listing unavailable");
+        },
+      },
+      { "package.json": PKG_HEAD },
+    );
+
+    await pullWithPackageSync();
+    await flush();
+
+    expect(installed).toBe(true);
+  });
 });
 
 // ─── Reactive fallback ───────────────────────────────────────────────────────

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,7 +2,7 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.2.6-draft
+**Version:** 0.2.7-draft
 **Status:** Pending
 **Updated:** 2026-07-24
 **License:** MIT
@@ -120,16 +120,19 @@ export function hasPlatform() {
 }
 ```
 
-Each deployment target calls `registerPlatform()` before Studio initializes. The desktop init bundle registers the RPC-backed adapter; the studio entry itself registers the dev-server adapter only when nothing else has:
+Each deployment target either pre-registers its adapter before Studio initializes, or hands Studio a signal to build one itself. The desktop init bundle pre-registers the RPC-backed adapter on `__jxPlatform`. The cloud shell (the platform repo's `edit-init`) instead publishes a `window.__jxCloud` signal — the bound project, or `null` for the project-less hub — and lets the studio entry construct the adapter, so the cloud adapter (and the collab WebSocket client's `yjs` instance) lives **inside** the studio bundle rather than the shell; a second bundled `yjs` in the shell would break collab's cross-module `instanceof` checks. When nothing pre-registered, the studio entry resolves the default adapter — cloud when `__jxCloud` was signalled, else the dev server:
 
 ```javascript
-// Desktop (init bundle, loaded before studio.js)
+// Desktop (init bundle, loaded before studio.js) — pre-registers its adapter
 import { registerPlatform } from "@jxsuite/studio/platform";
 registerPlatform(createDesktopPlatform());
 
-// Studio entry (studio.ts) — dev-server fallback
+// Cloud shell (edit-init, loaded before studio.js) — publishes a signal, not an adapter
+globalThis.__jxCloud = { project }; // project: CloudProject | null
+
+// Studio entry (studio.ts) — build the default adapter when none was pre-registered
 if (!hasPlatform()) {
-  registerPlatform(createDevServerPlatform());
+  registerPlatform(resolveDefaultPlatform()); // cloud when __jxCloud is set, else dev server
 }
 ```
 
@@ -717,6 +720,7 @@ Ensure desktop app matches dev-mode capabilities:
 
 ## Changelog
 
+- **0.2.7-draft** (2026-07-24) — Cloud platform registers inside studio.js via a window.__jxCloud signal (single yjs for collab).
 - **0.2.6-draft** (2026-07-24) — Document packaged static-data staging into app/bun (create templates, starters) and postBuild bundle verification.
 - **0.2.5-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.2.4-draft** (2026-07-22) — Machine-readable spec status vocabulary + generated status page (`79daba23`).
@@ -734,4 +738,4 @@ Ensure desktop app matches dev-mode capabilities:
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.2.6-draft_
+_Jx Studio Desktop Architecture Specification v0.2.7-draft_


### PR DESCRIPTION
The cloud PAL adapter was constructed in the platform repo's edit-init bundle, so its collab WebSocket client bundled a SECOND copy of yjs. Studio's op-conversion (@jxsuite/collab, in studio.js) then ran against Y.Docs created by that other yjs instance, failing cross-module instanceof checks — so with collab enabled it would connect but never reconcile edits (and log "Yjs was already imported").

Register the cloud adapter from inside studio.js instead, exactly like the dev-server adapter already does: the shell publishes a window.__jxCloud signal and resolveDefaultPlatform builds the adapter within the studio bundle, so collab shares studio's single yjs. (The platform repo's edit-init.js drops from ~100KB to ~600B once it no longer pulls in collab/yjs.)

Also switch the home-page and package-file existence probes to list-then-read (findHomePage lists pages/ once; snapshotPackageFiles lists root once), so absent files — cloud lockfiles, a missing pages/index.* — no longer emit console 404s. The mock harness's root directory listing now matches the real backends (root maps to an empty prefix).

Spec: desktop.md §3.3 registration (0.2.6-draft → 0.2.7-draft).