### PR TITLE
feat(studio)!: require a user-chosen destination for new projects

### DIFF
--- a/docs/extending/embedding/platform-adapter.md
+++ b/docs/extending/embedding/platform-adapter.md
@@ -25,7 +25,7 @@ Core members are required on every adapter. Grouped by family:
 | Family          | Members                                                                                                                                                                                                        |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Identity        | `id`, `projectRoot` (get/set), `canvasUrl?`                                                                                                                                                                    |
-| Session/project | `activate`, `openProject`, `probeRootProject`, `createProject`, `resolveSiteContext`                                                                                                                           |
+| Session/project | `activate`, `openProject`, `probeRootProject`, `createDestination`, `createProject`, `resolveSiteContext`                                                                                                      |
 | Filesystem      | `listDirectory`, `readFile`, `writeFile`, `uploadFile`, `deleteFile`, `renameFile`, `createDirectory`, `locateFile`, `searchFiles`, `discoverComponents`                                                       |
 | Git             | `gitStatus`, `gitBranches`, `gitLog`, `gitStage`, `gitUnstage`, `gitCommit`, `gitPush`, `gitPull`, `gitFetch`, `gitCheckout`, `gitCreateBranch`, `gitDiff`, `gitShow`, `gitDiscard`, `gitInit`, `gitAddRemote` |
 | Packages        | `listPackages`, `addPackage`, `removePackage`                                                                                                                                                                  |
@@ -33,22 +33,26 @@ Core members are required on every adapter. Grouped by family:
 
 All paths passed into adapter methods are project-relative; translating them to whatever the backend expects (a server-root prefix, an absolute path, a repo path) is the adapter's job. A core member may still answer "not available" through its return type — `codeService` resolves `null` on platforms without code tooling — but the member itself must exist.
 
+`createDestination` is a declaration, not a method: set it to `"path"` if your backend writes projects to a filesystem, or `"repo"` if a project is a remote repository. Studio uses it to decide which destination fields the New Project modal collects, and hands the answer back to `createProject` as `opts.destination`. **Your adapter must honor that destination and must not substitute one of its own** — a create with no usable destination is an error, not a cue to fall back to a default directory or account.
+
 ### Optional members and degradation
 
 Everything else on the interface is optional, and each optional member maps to an optional protocol route whose `degradation` field describes exactly what Studio does without it. Omit what your backend can't support:
 
-| Family             | Members                                                                                                      | When absent                                                       |
-| ------------------ | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| Live sync          | `subscribeFileEvents`, `collab`                                                                              | Sidebar is manual-refresh; editing is solo with file-level saves  |
-| Install pipeline   | `installDependencies`, `dependenciesNeedInstall`, `outdatedPackages`, `setPackageVersions`                   | Install/update affordances hide; manifest-only edits still work   |
-| Catalogue/scaffold | `listProjects`, `listStarters`, `importSite`, `pickDirectory`, `gitClone`                                    | Welcome-screen catalogue, starters, import, and clone flows hide  |
-| Formats/schemas    | `listFormats`, `listExtensions`, `fetchProjectSchemas`, `formatAction`, `resolveClass`                       | Only `.json` documents open; editors fall back to bundled schemas |
-| Data + secrets     | `dataConnections`, `dataConnectionTest`, `dataPush`, `dataRows`, row CRUD, `listSecrets`, `setSecrets`       | The Data grid and connection/push/secret controls hide            |
-| Publish            | `cfConnection`, `cfConnect`, `cfApi`, `createPullRequest`                                                    | Publish panel explains git-push publishing; PRs go via user token |
-| Desktop shell      | `getAppInfo`, `openProjectInNewWindow`, `newWindow`, `setWindowProject`, `getProjectRoot`, recents, settings | Single-window; recents and settings persist in `localStorage`     |
-| Cloud identity     | `getUser`, `getAccountStatus`, `listRepos`, `importProject`                                                  | No signed-in identity or repository picker                        |
+| Family             | Members                                                                                                      | When absent                                                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Live sync          | `subscribeFileEvents`, `collab`                                                                              | Sidebar is manual-refresh; editing is solo with file-level saves                                                                              |
+| Install pipeline   | `installDependencies`, `dependenciesNeedInstall`, `outdatedPackages`, `setPackageVersions`                   | Install/update affordances hide; manifest-only edits still work                                                                               |
+| Catalogue/scaffold | `listProjects`, `listStarters`, `importSite`, `pickDirectory`, `gitClone`                                    | Welcome-screen catalogue, starters, import, and clone flows hide; without `pickDirectory` the New Project **Location** field is typed by hand |
+| Formats/schemas    | `listFormats`, `listExtensions`, `fetchProjectSchemas`, `formatAction`, `resolveClass`                       | Only `.json` documents open; editors fall back to bundled schemas                                                                             |
+| Data + secrets     | `dataConnections`, `dataConnectionTest`, `dataPush`, `dataRows`, row CRUD, `listSecrets`, `setSecrets`       | The Data grid and connection/push/secret controls hide                                                                                        |
+| Publish            | `cfConnection`, `cfConnect`, `cfApi`, `createPullRequest`                                                    | Publish panel explains git-push publishing; PRs go via user token                                                                             |
+| Desktop shell      | `getAppInfo`, `openProjectInNewWindow`, `newWindow`, `setWindowProject`, `getProjectRoot`, recents, settings | Single-window; recents and settings persist in `localStorage`                                                                                 |
+| Cloud identity     | `getUser`, `getAccountStatus`, `listRepos`, `importProject`                                                  | No signed-in identity or repository picker                                                                                                    |
 
 Studio always checks for presence before calling an optional member, so an omitted member is never an error. The [protocol route reference](/docs/extending/reference/studio-routes) is the complete degradation catalogue.
+
+A browser-hosted adapter can still offer `pickDirectory`: `@jxsuite/studio/directory-picker` exports `canPickDirectory()` and `pickDirectoryPath(locate)`, which drive `showDirectoryPicker()` and hand you the picked folder's `name` plus the random id it wrote into a hidden `.jx-loc-id` there — your `locate` callback resolves that pair to an absolute path (the dev server does it with `GET /__studio/locate-directory`). Omit the member when `canPickDirectory()` is false rather than defining one that always returns null, so Studio hides the button instead of showing a dead one.
 
 ## Registration
 

--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,18 +17,18 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.1-draft  | Partial     | 2026-07-22 |
 | `collab.md`               | 0.1.1-draft  | Partial     | 2026-07-22 |
 | `compiler.md`             | 0.1.23-draft | Partial     | 2026-07-24 |
-| `desktop.md`              | 0.2.7-draft  | Pending     | 2026-07-24 |
+| `desktop.md`              | 0.3.0-draft  | Pending     | 2026-07-25 |
 | `extensions.md`           | 0.3.1-draft  | Partial     | 2026-07-25 |
 | `imports.md`              | 0.1.6-draft  | Partial     | 2026-07-22 |
 | `jx-markdown.md`          | 0.1.7-draft  | Partial     | 2026-07-22 |
 | `parser.md`               | 0.2.4-draft  | Partial     | 2026-07-23 |
 | `relationships.md`        | 0.1.3-draft  | Partial     | 2026-07-22 |
 | `schema.md`               | 0.2.8-draft  | Partial     | 2026-07-22 |
-| `server.md`               | 0.1.9        | Implemented | 2026-07-23 |
+| `server.md`               | 0.2.0        | Implemented | 2026-07-25 |
 | `site-architecture.md`    | 0.1.37-draft | Pending     | 2026-07-24 |
 | `spec.md`                 | 0.4.24-draft | Partial     | 2026-07-24 |
 | `studio-ui-guidelines.md` | 0.1.6        | Implemented | 2026-07-22 |
-| `studio.md`               | 0.1.25-draft | Partial     | 2026-07-22 |
+| `studio.md`               | 0.1.26-draft | Partial     | 2026-07-25 |
 
 ## Sections not yet implemented
 

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -51,6 +51,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.3.0-draft** (2026-07-25) — New Project requires a user-chosen destination: StudioPlatform gains the required createDestination declaration, createProject takes a required destination (path parent or repo owner/name/visibility), and §4.5 defines the create flow. No backend picks a location.
 - **0.2.7-draft** (2026-07-24) — Cloud platform registers inside studio.js via a window.__jxCloud signal (single yjs for collab).
 - **0.2.6-draft** (2026-07-24) — Document packaged static-data staging into app/bun (create templates, starters) and postBuild bundle verification.
 - **0.2.5-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
@@ -144,6 +145,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `server.md`
 
+- **0.2.0** (2026-07-25) — POST /__studio/create-project requires an explicit absolute destination parent — the server no longer falls back to its own root. Adds assertCreatableParent (root, allowedRoots, or home; absolute only), remembers created roots for a following activate, and returns an absolute root for projects outside the server root.
 - **0.1.9** (2026-07-23) — Serve extension asset mounts ahead of the project root in the static-file chain (§3).
 - **0.1.8** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.1.7** (2026-07-22) — Fix failing tests (`56e073f8`).
@@ -252,6 +254,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `studio.md`
 
+- **0.1.26-draft** (2026-07-25) — PAL table records the destination members: createDestination, createProject's user-chosen destination, and pickDirectory.
 - **0.1.25-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.1.24-draft** (2026-07-22) — Machine-readable spec status vocabulary + generated status page (`79daba23`).
 - **0.1.23-draft** (2026-07-17) — Scheme-variant editing — token overrides, scheme-layer routing, live feedback (`49f0c525`).

--- a/docs/extending/reference/studio-routes.md
+++ b/docs/extending/reference/studio-routes.md
@@ -12,17 +12,18 @@ The canonical Studio Backend Protocol route table (protocol version 1), from `@j
 
 ## Session / project
 
-| Route           | Method | Path                       | Summary                                                                         | Optional | Degradation                                           |
-| --------------- | ------ | -------------------------- | ------------------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
-| `activate`      | POST   | `/__studio/activate`       | Bind the backend to a project root                                              | no       | —                                                     |
-| `project`       | GET    | `/__studio/project`        | Root project metadata {name, root}                                              | no       | —                                                     |
-| `projectInfo`   | GET    | `/__studio/project-info`   | Probe a directory: {isSiteProject, projectConfig?, directories?}                | no       | —                                                     |
-| `resolveSite`   | GET    | `/__studio/resolve-site`   | Resolve the owning site of a file path {sitePath, projectConfig?, fileRelPath?} | no       | —                                                     |
-| `sites`         | GET    | `/__studio/sites`          | Enumerate site projects [{config, path}] (backs listProjects)                   | yes      | The welcome screen's Projects catalogue stays hidden. |
-| `findProject`   | GET    | `/__studio/find-project`   | Locate a project directory by name outside the root                             | yes      | openProject falls back to config-matching only.       |
-| `createProject` | POST   | `/__studio/create-project` | Scaffold a project → {root, config}                                             | no       | —                                                     |
-| `starters`      | GET    | `/__studio/starters`       | Starter templates (StarterInfo[])                                               | yes      | The New Project picker offers only blank/templates.   |
-| `importSite`    | POST   | `/__studio/import-site`    | Clone a live website into a project; streams NDJSON progress                    | yes      | The New Project Import tab is unavailable.            |
+| Route             | Method | Path                         | Summary                                                                                 | Optional | Degradation                                                                   |
+| ----------------- | ------ | ---------------------------- | --------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
+| `activate`        | POST   | `/__studio/activate`         | Bind the backend to a project root                                                      | no       | —                                                                             |
+| `project`         | GET    | `/__studio/project`          | Root project metadata {name, root}                                                      | no       | —                                                                             |
+| `projectInfo`     | GET    | `/__studio/project-info`     | Probe a directory: {isSiteProject, projectConfig?, directories?}                        | no       | —                                                                             |
+| `resolveSite`     | GET    | `/__studio/resolve-site`     | Resolve the owning site of a file path {sitePath, projectConfig?, fileRelPath?}         | no       | —                                                                             |
+| `sites`           | GET    | `/__studio/sites`            | Enumerate site projects [{config, path}] (backs listProjects)                           | yes      | The welcome screen's Projects catalogue stays hidden.                         |
+| `findProject`     | GET    | `/__studio/find-project`     | Locate a project directory by name outside the root                                     | yes      | openProject falls back to config-matching only.                               |
+| `locateDirectory` | GET    | `/__studio/locate-directory` | Resolve the absolute path of a showDirectoryPicker() folder by the id in its .jx-loc-id | yes      | The New Project Location field loses its Browse… button and is typed by hand. |
+| `createProject`   | POST   | `/__studio/create-project`   | Scaffold a project at a caller-chosen destination → {root, config}                      | no       | —                                                                             |
+| `starters`        | GET    | `/__studio/starters`         | Starter templates (StarterInfo[])                                                       | yes      | The New Project picker offers only blank/templates.                           |
+| `importSite`      | POST   | `/__studio/import-site`      | Clone a live website into a project; streams NDJSON progress                            | yes      | The New Project Import tab is unavailable.                                    |
 
 ## Filesystem
 

--- a/docs/start/first-project.md
+++ b/docs/start/first-project.md
@@ -13,7 +13,7 @@ Download the desktop app for [macOS, Windows, or Linux](/docs/start/install) —
 
 ## 2. Create a project
 
-In Studio, choose **New Project**. Give it a name and a folder, set your production URL, and pick a **deployment adapter** — Static, Cloudflare Pages, Node, or Bun. **Static** suits a site that's purely pages and content; if it will have a database, sign-ins, or server functions, pick one of the others — those hosts can run the small worker Jx builds for them. You can change this later in [project settings](/docs/studio/projects/settings).
+In Studio, choose **New Project**. Give it a name, choose the **Location** to create it in — **Browse…** opens your system's folder picker — name the folder, set your production URL, and pick a **deployment adapter** — Static, Cloudflare Pages, Node, or Bun. **Static** suits a site that's purely pages and content; if it will have a database, sign-ins, or server functions, pick one of the others — those hosts can run the small worker Jx builds for them. You can change this later in [project settings](/docs/studio/projects/settings).
 
 Then pick a **template**. Start from **Blank** for an empty project, or clone one of the [starter sites](/templates) — a restaurant, shop, portfolio, SaaS landing, blog, and more. Each one is a complete, themed site (pages, components, content, and images) you can reshape into your own. Studio copies it in as plain files and opens it on the canvas.
 

--- a/docs/studio/ai.md
+++ b/docs/studio/ai.md
@@ -19,7 +19,7 @@ Open it with the **Toggle Assistant** chat-bubble button at the right end of the
 
 ## What it can do
 
-**With nothing open** — the assistant bootstraps. Describe a site and it creates a project for you: name, folders, starter pages, and a design quickstart (colors and fonts) derived from your description, then keeps building inside it. The **[New Project](/docs/studio/projects/create)** dialog's **Agent** tab is the same idea as a form: describe the site you want, and the assistant builds it in the editor while you watch.
+**With nothing open** — the assistant bootstraps. Describe a site and it creates a project for you: name, folders, starter pages, and a design quickstart (colors and fonts) derived from your description, then keeps building inside it. It will ask you where to put the project before creating anything — tell it a folder (or, on the cloud, a GitHub account or organization). The **[New Project](/docs/studio/projects/create)** dialog's **Agent** tab is the same idea as a form: describe the site you want, and the assistant builds it in the editor while you watch.
 
 **With a project open** — the assistant works across files. It can list and read any project file, find files by name, create new pages and components, and rewrite files whole. Anything it writes as a Jx document is validated before it touches disk. It can also open a page on the canvas to continue there.
 

--- a/docs/studio/interface/welcome-screen.md
+++ b/docs/studio/interface/welcome-screen.md
@@ -16,8 +16,8 @@ When Jx Studio starts with no project open, the canvas area shows the welcome sc
 
 1. Click **New Project…**.
 2. Pick where to start from: a built-in **Template**, a **Starter Site**, an **Import** of an existing site, or an **Agent** prompt describing what you want.
-3. Click **Next**, name the project, and adjust the design quickstart (colors, fonts, logo).
-4. Click **Create Project** — Studio writes the files and opens the project.
+3. Click **Next**, name the project, choose the **Location** to create it in, and adjust the design quickstart (colors, fonts, logo).
+4. Click **Create Project** — Studio writes the files where you pointed it and opens the project.
 
 ![The New Project dialog with the template gallery and project parameters](../../images/new-project-modal.png)
 

--- a/docs/studio/projects.md
+++ b/docs/studio/projects.md
@@ -29,7 +29,7 @@ What each kind of file is for — and when to reach for which — is covered in 
 
 There are three ways to end up with a project open in Studio, all available from the [Welcome screen](/docs/studio/interface/welcome-screen):
 
-1. **Create a new one.** Click **New Project…** and pick a template or a complete starter site — or jump straight to the starter gallery with **Start from an Example…**. The whole modal is walked through in **[Create a project](/docs/studio/projects/create)**.
+1. **Create a new one.** Click **New Project…** and pick a template or a complete starter site — or jump straight to the starter gallery with **Start from an Example…**. You choose the folder it's created in (on studio.jxsuite.com, the GitHub repository); Studio never picks one for you. The whole modal is walked through in **[Create a project](/docs/studio/projects/create)**.
 2. **Open an existing folder.** Click **Open Project…** and point Studio at a Jx project already on your machine. On studio.jxsuite.com the same button lists the GitHub repositories you can write to instead — pick one and Studio opens it. Recently opened projects also appear on the Welcome screen for one-click reopening.
 3. **Clone a repository.** Click **Clone Git Repository…** and paste a repository URL — Studio downloads the project and opens it. On platforms linked to a GitHub account, **Add Existing Repository…** lets you pick from your repositories instead of pasting a URL.
 

--- a/docs/studio/projects/create.md
+++ b/docs/studio/projects/create.md
@@ -5,6 +5,7 @@ code:
   - packages/studio/src/new-project/new-project-modal.ts
   - packages/studio/src/new-project/templates.ts
   - packages/studio/src/new-project/design-fields.ts
+  - packages/studio/src/new-project/location-fields.ts
   - packages/studio/src/new-project/import-tab.ts
 ---
 
@@ -34,12 +35,25 @@ Pick a source and click **Next**.
 The second screen — **New Project Parameters** — shows which source you picked, then the project's identity:
 
 1. **Project Name** (required) — the human-readable name, e.g. "My Site".
-2. **Directory** — the folder name for the project. Studio derives it from the name as you type (`My Site` becomes `my-site`); edit it to take over.
-3. **Description** — a short line about the site.
-4. **Production URL** — where the site will live once published, e.g. `https://example.com`.
-5. **Deployment Adapter** — how the build packages the site for your host: **Static**, **Cloudflare Pages**, **Node**, or **Bun**. **Static** emits plain files for any host that serves them, which is all a site of pages and content needs. Pick one of the others if the site will have a database, sign-ins, or server functions: those adapters also package the small server that answers those requests. A database or sign-ins make that mandatory — the build refuses to run on **Static**. Server functions still build there; they just never get served. The choice isn't final — change it later in **[Project settings](/docs/studio/projects/settings)**.
+2. **Location** (required) — the existing folder to create the project folder inside, e.g. `/home/you/Sites`. **Browse…** opens your system's folder picker. In a browser that has no folder-picking support, the button is hidden and you type the path instead.
+3. **Directory** — the folder name for the project. Studio derives it from the name as you type (`My Site` becomes `my-site`); edit it to take over.
+4. **Description** — a short line about the site.
+5. **Production URL** — where the site will live once published, e.g. `https://example.com`.
+6. **Deployment Adapter** — how the build packages the site for your host: **Static**, **Cloudflare Pages**, **Node**, or **Bun**. **Static** emits plain files for any host that serves them, which is all a site of pages and content needs. Pick one of the others if the site will have a database, sign-ins, or server functions: those adapters also package the small server that answers those requests. A database or sign-ins make that mandatory — the build refuses to run on **Static**. Server functions still build there; they just never get served. The choice isn't final — change it later in **[Project settings](/docs/studio/projects/settings)**.
 
-On the Import tab, this step shows only the name and directory plus the import's progress — the remaining fields and the design quickstart don't apply.
+Under **Location** and **Directory**, Studio shows exactly where the project will land — `/home/you/Sites/my-site` — before you commit to it.
+
+On the Import tab, this step shows only the name, location, and directory plus the import's progress — the remaining fields and the design quickstart don't apply.
+
+### On Jx Cloud
+
+Cloud projects are GitHub repositories, so the same step asks for a **repository location** instead of a folder:
+
+1. **Owner** (required) — the account the repository is created under: your personal account, or any organization you've installed the Jx Suite app on.
+2. **Repository** — the repository name, derived from the project name the same way the directory is. Studio warns you if that name is already taken under the chosen owner.
+3. **Visibility** — **Private** (the default) or **Public**.
+
+The preview line shows the repository that will be created, e.g. `acme/my-site`.
 
 ## The design quickstart
 
@@ -54,10 +68,14 @@ Below the parameters sits a creation-time subset of the design settings. Every f
 
 Click **Create Project** (or **Create & Start Agent** on the Agent tab). Studio writes the project folder and opens it. **Back** returns to the source step without losing what you've typed.
 
-If the **Project Name** is missing, the error appears directly under that field. If creation itself fails, the message appears just above the footer buttons, so it stays visible however far the form is scrolled.
+If the **Project Name** is missing, the error appears directly under that field. A missing or non-absolute **Location** (or, on the cloud, a missing **Owner**) is reported under the destination fields. If creation itself fails, the message appears just above the footer buttons, so it stays visible however far the form is scrolled.
 
 :::doc-note
 Studio creates the folder you named, with `pages/`, `components/`, and a `project.json` carrying your name, URL, adapter, and design choices. The full folder anatomy is documented in [Site architecture](/docs/framework/site).
+:::
+
+:::doc-warning
+There is no default location. Studio never picks a folder for you and never falls back to whatever directory it happens to be running in — if the **Location** is empty, nothing is created.
 :::
 
 ## Next

--- a/packages/desktop/src/chromium/index.ts
+++ b/packages/desktop/src/chromium/index.ts
@@ -132,6 +132,7 @@ const handlers: Record<string, (params: unknown) => Promise<unknown>> = {
         url?: string;
         adapter?: string;
         directory: string;
+        destination: { kind: "path"; parent: string };
         starter?: string;
         template?: string;
         design?: {

--- a/packages/desktop/src/chromium/platform.ts
+++ b/packages/desktop/src/chromium/platform.ts
@@ -85,6 +85,10 @@ export function createDesktopPlatform(): StudioPlatform {
   return {
     id: "desktop" as const,
 
+    /* New projects go where the user says: the modal's Location field, with Browse… backed by the
+       XDG portal dialog below. The backend refuses a create without one. */
+    createDestination: "path" as const,
+
     projectRoot: "",
 
     // The chromium project server serves the canvas iframe doc under /__studio__/. Only chromium
@@ -398,6 +402,7 @@ export function createDesktopPlatform(): StudioPlatform {
       url?: string;
       adapter?: string;
       directory: string;
+      destination: { kind: "path"; parent: string };
       starter?: string;
       template?: string;
       design?: {
@@ -420,25 +425,30 @@ export function createDesktopPlatform(): StudioPlatform {
       return request("listStarters") as Promise<StarterInfo[]>;
     },
 
+    /**
+     * Folder chooser for the New Project modal. This build has a real native dialog — the XDG
+     * desktop portal, driven from the Bun side — which returns a filesystem path directly. It is
+     * deliberately used in preference to Chrome's `showDirectoryPicker()`, whose handle carries no
+     * path and would have to be placed by writing a marker file and scanning for it (§8.2.1). That
+     * fallback exists only for the plain dev-server browser session, which has no native option at
+     * all.
+     */
     async pickDirectory() {
       const result = (await request("pickDirectory")) as { path: string | null };
       return result.path;
     },
 
-    // AI-guided site import: streams NDJSON progress from the token-gated loopback endpoint. A
-    // Relative directory (the modal's slug) is resolved under a natively-picked parent folder.
+    // AI-guided site import: streams NDJSON progress from the token-gated loopback endpoint. The
+    // Modal resolves the destination before calling (specs/desktop.md §4.5), so `directory` is
+    // Already absolute — a relative one means a caller skipped the Location field.
     async importSite(
       opts: ImportSiteOptions,
       onProgress: (evt: ImportProgressEvent) => void,
       signal?: AbortSignal,
     ) {
-      let { directory } = opts;
+      const { directory } = opts;
       if (!/^(?:[a-zA-Z]:[\\/]|\/)/.test(directory)) {
-        const parentResult = (await request("pickDirectory")) as { path: string | null };
-        if (!parentResult.path) {
-          throw new Error("No destination folder was selected.");
-        }
-        directory = `${parentResult.path}/${directory}`;
+        throw new Error("A destination folder is required.");
       }
       return streamImport(
         `/__studio__/import-site?token=${encodeURIComponent(token)}`,

--- a/packages/desktop/src/platform.ts
+++ b/packages/desktop/src/platform.ts
@@ -200,6 +200,10 @@ export function createDesktopPlatform(): StudioPlatform {
   const platform = {
     id: "desktop" as const,
 
+    /* New projects go where the user says: the modal's Location field, with Browse… backed by the
+       native dialog below. The backend refuses a create without one. */
+    createDestination: "path" as const,
+
     projectRoot: "",
 
     /**
@@ -575,6 +579,7 @@ export function createDesktopPlatform(): StudioPlatform {
       url?: string;
       adapter?: string;
       directory: string;
+      destination: { kind: "path"; parent: string };
       starter?: string;
       template?: string;
       design?: {
@@ -602,23 +607,20 @@ export function createDesktopPlatform(): StudioPlatform {
       return result.path;
     },
 
-    // AI-guided site import: streams NDJSON progress from the token-gated shared local server. A
-    // Relative directory (the modal's slug) is resolved under a natively-picked parent folder.
+    // AI-guided site import: streams NDJSON progress from the token-gated shared local server. The
+    // Modal resolves the destination before calling (specs/desktop.md §4.5), so `directory` is
+    // Already absolute — a relative one means a caller skipped the Location field.
     async importSite(
       opts: ImportSiteOptions,
       onProgress: (evt: ImportProgressEvent) => void,
       signal?: AbortSignal,
     ) {
-      let { directory } = opts;
+      const { directory } = opts;
       if (!/^(?:[a-zA-Z]:[\\/]|\/)/.test(directory)) {
-        const parent = await rpc.request.pickDirectory();
-        if (!parent.path) {
-          throw new Error("No destination folder was selected.");
-        }
-        directory = `${parent.path}/${directory}`;
+        throw new Error("A destination folder is required.");
       }
       const endpoint = (await rpc.request.importSiteUrl()) as string;
-      return streamImport(endpoint, { ...opts, directory }, onProgress, signal);
+      return streamImport(endpoint, opts, onProgress, signal);
     },
 
     updater: {

--- a/packages/desktop/src/project-session.ts
+++ b/packages/desktop/src/project-session.ts
@@ -9,7 +9,7 @@
  */
 
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { handleResolve, handleServerFunction } from "@jxsuite/server/resolve";
 import {
@@ -557,6 +557,7 @@ export function createProjectSession(initialRoot: string | null) {
     url?: string;
     adapter?: string;
     directory: string;
+    destination: { kind: "path"; parent: string };
     starter?: string;
     template?: string;
     design?: {
@@ -569,15 +570,22 @@ export function createProjectSession(initialRoot: string | null) {
       logo?: { name: string; base64: string };
     };
   }): Promise<{ root: string; config: SiteConfig }> {
-    if (!directoryDialogFn) {
-      throw new Error("No directory dialog configured");
-    }
     if (!opts.name || !opts.directory) {
       throw new Error("name and directory are required");
     }
-    const parent = await directoryDialogFn();
-    if (!parent) {
-      throw new Error("No destination folder was selected.");
+    // `directory` names the project FOLDER, not a path: a separator or dot-segment would walk out
+    // Of the parent the user chose below.
+    if (/[/\\]/.test(opts.directory) || opts.directory === "." || opts.directory === "..") {
+      throw new Error("Directory must be a folder name, not a path");
+    }
+    // The destination is the caller's to choose (specs/desktop.md §4.5) — the backend never opens
+    // A dialog of its own, so a scripted or AI-driven create is never ambushed by one.
+    const parent = opts.destination?.parent;
+    if (opts.destination?.kind !== "path" || !parent) {
+      throw new Error("A destination folder is required.");
+    }
+    if (!isAbsolute(parent)) {
+      throw new Error(`Destination folder must be an absolute path: ${parent}`);
     }
     const destPath = resolve(parent, opts.directory);
 

--- a/packages/desktop/src/rpc-schema.ts
+++ b/packages/desktop/src/rpc-schema.ts
@@ -373,6 +373,8 @@ export interface StudioRPC {
           url?: string;
           adapter?: string;
           directory: string;
+          /** Chosen by the user in the New Project modal; the backend never picks one. */
+          destination: { kind: "path"; parent: string };
           starter?: string;
           template?: string;
           design?: {

--- a/packages/desktop/tests/chromium-index.test.ts
+++ b/packages/desktop/tests/chromium-index.test.ts
@@ -444,10 +444,17 @@ describe("chromium launcher RPC dispatch", () => {
     expect(await rpc("getProjectRoot")).toEqual({ root: projectRootValue });
   });
 
-  test("createProject dispatches to the createProject handler", async () => {
-    const result = await rpc("createProject", { directory: "n", name: "New" });
+  test("createProject dispatches to the createProject handler with the caller's destination", async () => {
+    // The launcher is a pass-through: the destination the modal chose reaches the handler unchanged
+    // (the handler, not this route, is what refuses a create without one).
+    const params = {
+      destination: { kind: "path", parent: "/home/dev/Sites" },
+      directory: "n",
+      name: "New",
+    };
+    const result = await rpc("createProject", params);
     expect(result).toEqual({ config: { name: "New" }, root: "/new" });
-    expect(handlerMocks.createProject).toHaveBeenCalledWith({ directory: "n", name: "New" });
+    expect(handlerMocks.createProject).toHaveBeenCalledWith(params);
   });
 
   test("listStarters dispatches to the real starter registry", async () => {

--- a/packages/desktop/tests/chromium-platform-gaps.test.ts
+++ b/packages/desktop/tests/chromium-platform-gaps.test.ts
@@ -186,11 +186,18 @@ describe("chromium platform: search, formats and packages", () => {
     expect(packages).toEqual([{ name: "left-pad", version: "^1.0.0" }]);
   });
 
-  test("createProject sends options and returns root and config", async () => {
+  test("createDestination advertises the on-disk Location field", () => {
+    // The chromium backend scaffolds onto disk, so the New Project modal renders a Location field
+    // (with Browse… backed by pickDirectory) rather than the cloud's owner/repository picker.
+    expect(platform.createDestination).toBe("path");
+  });
+
+  test("createProject forwards the caller's destination verbatim and returns root and config", async () => {
     const result = await platform.createProject({
       adapter: "static",
       description: "demo",
-      directory: "/tmp",
+      destination: { kind: "path", parent: "/tmp" },
+      directory: "fresh",
       name: "Fresh",
       url: "https://fresh.example",
     });
@@ -201,7 +208,8 @@ describe("chromium platform: search, formats and packages", () => {
       params: {
         adapter: "static",
         description: "demo",
-        directory: "/tmp",
+        destination: { kind: "path", parent: "/tmp" },
+        directory: "fresh",
         name: "Fresh",
         url: "https://fresh.example",
       },

--- a/packages/desktop/tests/chromium-platform.test.ts
+++ b/packages/desktop/tests/chromium-platform.test.ts
@@ -75,6 +75,10 @@ const responses: Record<string, unknown> = {
 // Track forced errors for specific methods
 const forcedErrors = new Map<string, string>();
 
+// Every request the platform actually sent, so a test can assert both that one RPC was used and
+// That another one was NOT (the folder chooser must never fire two dialogs).
+const methodLog: { method: string; params?: Record<string, unknown> }[] = [];
+
 const server = Bun.serve({
   fetch(req, srv) {
     if (srv.upgrade(req)) {
@@ -90,6 +94,7 @@ const server = Bun.serve({
         method: string;
         params?: Record<string, unknown>;
       };
+      methodLog.push({ method: msg.method, params: msg.params });
 
       const forcedError = forcedErrors.get(msg.method);
       if (forcedError) {
@@ -217,36 +222,63 @@ describe("chromium desktop platform", () => {
     await expect(platform.activate()).resolves.toBeUndefined();
   });
 
-  // ─── AI-guided site import ─────────────────────────────────────────────
+  // ─── Folder chooser for the New Project modal ──────────────────────────
+  // This build keeps its native XDG portal dialog, which returns a filesystem path directly. It is
+  // Deliberately NOT Chrome's showDirectoryPicker(): that handle carries no path and would have to
+  // Be placed by writing a marker file and scanning for it, which is the dev server's fallback.
 
   test("pickDirectory returns the natively picked path", async () => {
     await expect(platform.pickDirectory!()).resolves.toBe("/picked/parent");
   });
 
-  test("importSite resolves a relative directory under a picked parent and streams via the tokened endpoint", async () => {
+  test("pickDirectory uses the portal RPC even when a browser chooser is available", async () => {
+    interface PickerGlobal {
+      showDirectoryPicker?: unknown;
+    }
+    const had = "showDirectoryPicker" in (globalThis as PickerGlobal);
+    const saved = (globalThis as PickerGlobal).showDirectoryPicker;
+    (globalThis as PickerGlobal).showDirectoryPicker = () => {
+      throw new Error("the native portal must win on this build");
+    };
+    try {
+      methodLog.length = 0;
+      await expect(platform.pickDirectory!()).resolves.toBe("/picked/parent");
+      expect(methodLog).toEqual([{ method: "pickDirectory", params: undefined }]);
+    } finally {
+      if (had) {
+        (globalThis as PickerGlobal).showDirectoryPicker = saved;
+      } else {
+        delete (globalThis as PickerGlobal).showDirectoryPicker;
+      }
+    }
+  });
+
+  // ─── AI-guided site import ─────────────────────────────────────────────
+
+  test("importSite rejects a relative directory instead of resolving it under a picked parent", async () => {
+    // The modal resolves the destination before calling (Location field + slug), so a bare slug
+    // Means a caller skipped it — the bridge refuses rather than quietly opening a folder dialog.
+    streamImportCalls.length = 0;
+    await expect(
+      platform.importSite!(
+        {
+          aiComponents: false,
+          depth: 1,
+          directory: "my-slug",
+          maxPages: 5,
+          name: "X",
+          url: "https://x.example",
+        },
+        () => {},
+      ),
+    ).rejects.toThrow("A destination folder is required.");
+    expect(streamImportCalls).toHaveLength(0);
+  });
+
+  test("importSite streams an absolute directory via the tokened endpoint without a dialog", async () => {
     streamImportCalls.length = 0;
     const onProgress = () => {};
     const result = await platform.importSite!(
-      {
-        aiComponents: false,
-        depth: 1,
-        directory: "my-slug",
-        maxPages: 5,
-        name: "X",
-        url: "https://x.example",
-      },
-      onProgress,
-    );
-    expect(result).toEqual({ config: { name: "Imported" }, root: "/imported" } as never);
-    const [endpoint, opts, cb] = streamImportCalls[0]!;
-    expect(endpoint).toBe("/__studio__/import-site?token=CHROMIUM_TOK");
-    expect((opts as { directory: string }).directory).toBe("/picked/parent/my-slug");
-    expect(cb).toBe(onProgress);
-  });
-
-  test("importSite passes an absolute directory through without a dialog", async () => {
-    streamImportCalls.length = 0;
-    await platform.importSite!(
       {
         aiComponents: false,
         depth: 0,
@@ -255,30 +287,31 @@ describe("chromium desktop platform", () => {
         name: "X",
         url: "https://x.example",
       },
-      () => {},
+      onProgress,
     );
-    expect((streamImportCalls[0]![1] as { directory: string }).directory).toBe("/abs/dest");
+    expect(result).toEqual({ config: { name: "Imported" }, root: "/imported" } as never);
+    const [endpoint, opts, cb] = streamImportCalls[0]!;
+    expect(endpoint).toBe("/__studio__/import-site?token=CHROMIUM_TOK");
+    expect((opts as { directory: string }).directory).toBe("/abs/dest");
+    expect(cb).toBe(onProgress);
   });
 
-  test("importSite rejects when the directory picker is cancelled", async () => {
-    responses.pickDirectory = { path: null };
-    try {
-      await expect(
-        platform.importSite!(
-          {
-            aiComponents: false,
-            depth: 0,
-            directory: "slug",
-            maxPages: 1,
-            name: "X",
-            url: "https://x.example",
-          },
-          () => {},
-        ),
-      ).rejects.toThrow("No destination folder was selected.");
-    } finally {
-      responses.pickDirectory = { path: "/picked/parent" };
-    }
+  test("importSite rejects an empty destination directory", async () => {
+    streamImportCalls.length = 0;
+    await expect(
+      platform.importSite!(
+        {
+          aiComponents: false,
+          depth: 0,
+          directory: "",
+          maxPages: 1,
+          name: "X",
+          url: "https://x.example",
+        },
+        () => {},
+      ),
+    ).rejects.toThrow("A destination folder is required.");
+    expect(streamImportCalls).toHaveLength(0);
   });
 
   // ─── Class resolution ──────────────────────────────────────────────────

--- a/packages/desktop/tests/handlers.test.ts
+++ b/packages/desktop/tests/handlers.test.ts
@@ -32,7 +32,14 @@ const {
   createProject,
 } = await import("../src/handlers");
 
+// The folder picker lives on the session object (the legacy handlers shim does not re-export
+// PickDirectory), so the picker tests below drive it through a session of their own.
+const { createProjectSession } = await import("../src/project-session");
+
 const FIXTURES = join(import.meta.dir, "_fixtures_handlers");
+
+type CreateProjectOpts = Parameters<typeof createProject>[0];
+const noDialog = () => setDirectoryDialog(null as unknown as () => Promise<string | null>);
 
 function setup() {
   mkdirSync(FIXTURES, { recursive: true });
@@ -974,46 +981,133 @@ describe("openProject", () => {
   });
 });
 
-// ─── createProject ─────────────────────────────────────────────────────────
+// ─── pickDirectory ─────────────────────────────────────────────────────────
+// The native folder picker is now the New Project modal's tool (the Browse… button next to the
+// Location field) rather than something the backend triggers on its own, but the RPC is unchanged.
 
-describe("createProject", () => {
-  const clearDialog = () => setDirectoryDialog(null as unknown as () => Promise<string | null>);
+describe("pickDirectory", () => {
+  const session = createProjectSession(null);
 
   test("throws when no directory dialog is configured", async () => {
-    clearDialog();
-    await expect(createProject({ directory: "x", name: "X" })).rejects.toThrow(
-      "No directory dialog configured",
-    );
+    noDialog();
+    await expect(session.pickDirectory()).rejects.toThrow("No directory dialog configured");
   });
 
-  test("throws when name or directory is missing", async () => {
-    setDirectoryDialog(async () => FIXTURES);
+  test("returns the folder the native dialog picked", async () => {
+    setDirectoryDialog(async () => "/picked/parent");
     try {
-      await expect(createProject({ directory: "", name: "" })).rejects.toThrow(
-        "name and directory are required",
-      );
+      expect(await session.pickDirectory()).toEqual({ path: "/picked/parent" });
     } finally {
-      clearDialog();
+      noDialog();
     }
   });
 
-  test("throws when the folder picker is cancelled", async () => {
+  test("reports a cancelled picker as a null path", async () => {
     setDirectoryDialog(async () => null);
     try {
-      await expect(createProject({ directory: "x", name: "X" })).rejects.toThrow(
-        "No destination folder was selected.",
-      );
+      expect(await session.pickDirectory()).toEqual({ path: null });
     } finally {
-      clearDialog();
+      noDialog();
+    }
+  });
+});
+
+// ─── createProject ─────────────────────────────────────────────────────────
+// A new project is written only where the caller said (specs/desktop.md §4.5): the destination
+// Arrives with the request and the backend never opens a folder picker of its own. Every test here
+// Arms a directory dialog precisely so a stray backend-side picker would be observable.
+
+describe("createProject", () => {
+  const dialog = mock(async (): Promise<string | null> => FIXTURES);
+  const armDialog = () => {
+    dialog.mockClear();
+    setDirectoryDialog(dialog);
+  };
+
+  test("throws when name or directory is missing", async () => {
+    armDialog();
+    try {
+      await expect(
+        createProject({
+          destination: { kind: "path", parent: FIXTURES },
+          directory: "",
+          name: "",
+        }),
+      ).rejects.toThrow("name and directory are required");
+    } finally {
+      noDialog();
     }
   });
 
-  test("scaffolds a blank project into the chosen folder and returns its config", async () => {
+  test("throws when the request carries no usable path destination", async () => {
+    armDialog();
+    try {
+      await expect(
+        createProject({ directory: "x", name: "X" } as unknown as CreateProjectOpts),
+      ).rejects.toThrow("A destination folder is required.");
+      await expect(
+        createProject({ destination: { kind: "path", parent: "" }, directory: "x", name: "X" }),
+      ).rejects.toThrow("A destination folder is required.");
+      // A repo destination belongs to the cloud platform; the desktop backend only writes to disk.
+      await expect(
+        createProject({
+          destination: { kind: "repo", owner: "me", private: false, repo: "x" },
+          directory: "x",
+          name: "X",
+        } as unknown as CreateProjectOpts),
+      ).rejects.toThrow("A destination folder is required.");
+      // The missing destination is reported, never papered over by opening a picker.
+      expect(dialog).not.toHaveBeenCalled();
+    } finally {
+      noDialog();
+    }
+  });
+
+  test("throws when the destination parent is a relative path", async () => {
+    armDialog();
+    try {
+      await expect(
+        createProject({
+          destination: { kind: "path", parent: "relative/parent" },
+          directory: "x",
+          name: "X",
+        }),
+      ).rejects.toThrow("Destination folder must be an absolute path: relative/parent");
+      expect(dialog).not.toHaveBeenCalled();
+    } finally {
+      noDialog();
+    }
+  });
+
+  test("rejects a directory that is a path rather than a folder name", async () => {
     setup();
-    setDirectoryDialog(async () => FIXTURES);
+    armDialog();
+    try {
+      // The parent is fine, but joining a dot-segment onto it would land the project outside the
+      // Folder the user actually chose.
+      for (const directory of ["../escape", "nested/dir", ".."]) {
+        await expect(
+          createProject({
+            destination: { kind: "path", parent: FIXTURES },
+            directory,
+            name: "Escape",
+          }),
+        ).rejects.toThrow("Directory must be a folder name, not a path");
+      }
+      expect(existsSync(join(FIXTURES, "..", "escape", "project.json"))).toBe(false);
+      expect(dialog).not.toHaveBeenCalled();
+    } finally {
+      noDialog();
+    }
+  });
+
+  test("scaffolds a blank project under the chosen destination without opening a dialog", async () => {
+    setup();
+    armDialog();
     try {
       const result = await createProject({
         description: "A new site",
+        destination: { kind: "path", parent: FIXTURES },
         directory: "my-new-site",
         name: "My New Site",
         url: "https://new.example",
@@ -1024,17 +1118,20 @@ describe("createProject", () => {
       expect(existsSync(join(FIXTURES, "my-new-site", "pages"))).toBe(true);
       // The freshly-scaffolded project becomes the active project.
       expect(getProjectRoot()).toBe(join(FIXTURES, "my-new-site"));
+      // The caller supplied the destination, so the native picker stayed shut.
+      expect(dialog).not.toHaveBeenCalled();
     } finally {
-      clearDialog();
+      noDialog();
       cleanup();
     }
   });
 
   test("forwards a built-in template id to the generator", async () => {
     setup();
-    setDirectoryDialog(async () => FIXTURES);
+    armDialog();
     try {
       const result = await createProject({
+        destination: { kind: "path", parent: FIXTURES },
         directory: "my-app",
         name: "My App",
         template: "mobile-first",
@@ -1042,25 +1139,28 @@ describe("createProject", () => {
       const media = (result.config as { $media?: Record<string, string> }).$media;
       expect(media?.["--"]).toBe("375px");
       expect(media?.["--lg"]).toBe("(min-width: 1024px)");
+      expect(dialog).not.toHaveBeenCalled();
     } finally {
-      clearDialog();
+      noDialog();
       cleanup();
     }
   });
 
   test("forwards design quickstart options to the generator", async () => {
     setup();
-    setDirectoryDialog(async () => FIXTURES);
+    armDialog();
     try {
       const result = await createProject({
         design: { accent: "#ff5500" },
+        destination: { kind: "path", parent: FIXTURES },
         directory: "my-designed-site",
         name: "My Designed Site",
       });
       const { style } = result.config as { style?: Record<string, string> };
       expect(style?.["--color-primary"]).toBe("#ff5500");
+      expect(dialog).not.toHaveBeenCalled();
     } finally {
-      clearDialog();
+      noDialog();
       cleanup();
     }
   });

--- a/packages/desktop/tests/platform.test.ts
+++ b/packages/desktop/tests/platform.test.ts
@@ -291,6 +291,9 @@ describe("platform methods", () => {
   test("identity and activate", async () => {
     expect(platform.id).toBe("desktop");
     expect(platform.projectRoot).toBe("");
+    // The desktop backend scaffolds onto disk, so the New Project modal renders a Location field
+    // (with Browse…) rather than the cloud's owner/repository picker.
+    expect(platform.createDestination).toBe("path");
     await platform.activate();
   });
 
@@ -445,10 +448,11 @@ describe("platform methods", () => {
     ],
     [
       "createProject",
-      [{ directory: "/tmp/p", name: "p" }],
+      [{ destination: { kind: "path", parent: "/tmp" }, directory: "p", name: "p" }],
       "createProject",
       {
-        directory: "/tmp/p",
+        destination: { kind: "path", parent: "/tmp" },
+        directory: "p",
         name: "p",
       },
     ],
@@ -814,36 +818,38 @@ describe("importSite / pickDirectory", () => {
     await expect(platform.pickDirectory!()).resolves.toBe("/picked/parent");
   });
 
-  test("a relative directory is resolved under a picked parent and streamed to the RPC endpoint", async () => {
+  test("a relative directory is rejected instead of being resolved under a picked parent", async () => {
+    // The modal resolves the destination before calling (Location field + slug), so a bare slug
+    // Means a caller skipped it — the bridge refuses rather than quietly opening a folder dialog.
     streamImportCalls.length = 0;
+    const picksBefore = callsFor("pickDirectory").length;
     impls.set("pickDirectory", () => ({ path: "/picked/parent" }));
     impls.set("importSiteUrl", () => "http://127.0.0.1:9/__studio/import-site?token=T");
-    const onProgress = () => {};
-    const result = await platform.importSite!(
-      {
-        aiComponents: false,
-        depth: 1,
-        directory: "my-slug",
-        maxPages: 5,
-        name: "X",
-        url: "https://x.example",
-      },
-      onProgress,
-    );
-    expect(result).toEqual({ config: { name: "Imported" }, root: "/imported" } as never);
-    const [endpoint, opts, cb] = streamImportCalls[0]!;
-    expect(endpoint).toBe("http://127.0.0.1:9/__studio/import-site?token=T");
-    expect((opts as { directory: string }).directory).toBe("/picked/parent/my-slug");
-    expect(cb).toBe(onProgress);
+    await expect(
+      platform.importSite!(
+        {
+          aiComponents: false,
+          depth: 1,
+          directory: "my-slug",
+          maxPages: 5,
+          name: "X",
+          url: "https://x.example",
+        },
+        () => {},
+      ),
+    ).rejects.toThrow("A destination folder is required.");
+    expect(callsFor("pickDirectory")).toHaveLength(picksBefore);
+    expect(streamImportCalls).toHaveLength(0);
   });
 
-  test("an absolute directory skips the directory dialog", async () => {
+  test("an absolute directory is streamed to the RPC endpoint without a dialog", async () => {
     streamImportCalls.length = 0;
     impls.set("pickDirectory", () => {
       throw new Error("dialog must not open");
     });
     impls.set("importSiteUrl", () => "http://127.0.0.1:9/__studio/import-site?token=T");
-    await platform.importSite!(
+    const onProgress = () => {};
+    const result = await platform.importSite!(
       {
         aiComponents: false,
         depth: 0,
@@ -852,25 +858,49 @@ describe("importSite / pickDirectory", () => {
         name: "X",
         url: "https://x.example",
       },
-      () => {},
+      onProgress,
     );
-    expect((streamImportCalls[0]![1] as { directory: string }).directory).toBe("/abs/dest");
+    expect(result).toEqual({ config: { name: "Imported" }, root: "/imported" } as never);
+    const [endpoint, opts, cb] = streamImportCalls[0]!;
+    expect(endpoint).toBe("http://127.0.0.1:9/__studio/import-site?token=T");
+    expect((opts as { directory: string }).directory).toBe("/abs/dest");
+    expect(cb).toBe(onProgress);
   });
 
-  test("rejects when the directory picker is cancelled", async () => {
-    impls.set("pickDirectory", () => ({ path: null }));
+  test("a windows drive-letter destination counts as absolute", async () => {
+    streamImportCalls.length = 0;
+    impls.set("importSiteUrl", () => "http://127.0.0.1:9/__studio/import-site?token=T");
+    await platform.importSite!(
+      {
+        aiComponents: false,
+        depth: 0,
+        directory: String.raw`C:\Sites\dest`,
+        maxPages: 1,
+        name: "X",
+        url: "https://x.example",
+      },
+      () => {},
+    );
+    expect((streamImportCalls[0]![1] as { directory: string }).directory).toBe(
+      String.raw`C:\Sites\dest`,
+    );
+  });
+
+  test("rejects an empty destination directory", async () => {
+    streamImportCalls.length = 0;
     await expect(
       platform.importSite!(
         {
           aiComponents: false,
           depth: 0,
-          directory: "slug",
+          directory: "",
           maxPages: 1,
           name: "X",
           url: "https://x.example",
         },
         () => {},
       ),
-    ).rejects.toThrow("No destination folder was selected.");
+    ).rejects.toThrow("A destination folder is required.");
+    expect(streamImportCalls).toHaveLength(0);
   });
 });

--- a/packages/desktop/tests/window-manager.test.ts
+++ b/packages/desktop/tests/window-manager.test.ts
@@ -99,8 +99,10 @@ function makeSession(initialRoot: string | null) {
         handle: { name: "Proj", projectConfig: {}, root: "." },
       };
     }),
-    createProject: mock(async (opts: { directory: string }) => {
-      root = `/proj/${opts.directory}`;
+    // Mirrors the real session: the project lands under the destination the caller chose, never
+    // Under a folder the backend picked for itself.
+    createProject: mock(async (opts: { destination: { parent: string }; directory: string }) => {
+      root = `${opts.destination.parent}/${opts.directory}`;
       return { config: { name: "New" }, root };
     }),
   };
@@ -594,15 +596,25 @@ describe("openProject request handler", () => {
 });
 
 describe("createProject request handler", () => {
-  test("scaffolds a project, binds the root and updates the window title", async () => {
+  test("scaffolds at the chosen destination, binds the root and updates the window title", async () => {
     const win = openProjectWindow(null) as unknown as MockWindow;
     const reqs = lastRequests();
     const session = sessions.at(-1)!;
 
-    const result = await reqs.createProject({ directory: "shiny", name: "New" } as never);
+    const params = {
+      destination: { kind: "path", parent: "/home/dev/Sites" },
+      directory: "shiny",
+      name: "New",
+    };
+    const result = await reqs.createProject(params as never);
     expect(session.createProject).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ config: { name: "New" }, root: "/proj/shiny" } as never);
-    expect(listOpenWindows().find((w) => w.id === win.id)?.projectRoot).toBe("/proj/shiny");
+    // The window layer is a pass-through: the destination the modal chose reaches the session
+    // Intact, so the project is written only where the user said.
+    expect(session.createProject).toHaveBeenCalledWith(params);
+    expect(result).toEqual({ config: { name: "New" }, root: "/home/dev/Sites/shiny" } as never);
+    expect(listOpenWindows().find((w) => w.id === win.id)?.projectRoot).toBe(
+      "/home/dev/Sites/shiny",
+    );
     expect(win.setTitle).toHaveBeenLastCalledWith(`shiny ${DASH} Jx Studio`);
   });
 });

--- a/packages/protocol/src/routes.ts
+++ b/packages/protocol/src/routes.ts
@@ -12,6 +12,17 @@
 /** Bumped when a route's request/response shape changes incompatibly. */
 export const STUDIO_PROTOCOL_VERSION = 1;
 
+/**
+ * Hidden file a browser-hosted Studio drops into a folder chosen with `showDirectoryPicker()` so
+ * the backend can find it (specs/desktop.md §8.2.1). Its contents are a one-shot random id; the
+ * backend matches on those contents, not on the filename, and deletes the file once it matches.
+ *
+ * Lives here because the writer (`@jxsuite/studio/directory-picker`) and the reader (the backend
+ * serving `locateDirectory`) must agree on it, and this package is the contract both already
+ * share.
+ */
+export const LOCATION_ID_FILE = ".jx-loc-id";
+
 export type StudioRouteMethod = "GET" | "POST" | "PUT" | "DELETE";
 
 export interface StudioRoute {
@@ -68,7 +79,17 @@ export const STUDIO_ROUTES = {
     "Locate a project directory by name outside the root",
     "openProject falls back to config-matching only.",
   ),
-  createProject: route("POST", "/__studio/create-project", "Scaffold a project → {root, config}"),
+  locateDirectory: route(
+    "GET",
+    "/__studio/locate-directory",
+    `Resolve the absolute path of a showDirectoryPicker() folder by the id in its ${LOCATION_ID_FILE}`,
+    "The New Project Location field loses its Browse… button and is typed by hand.",
+  ),
+  createProject: route(
+    "POST",
+    "/__studio/create-project",
+    "Scaffold a project at a caller-chosen destination → {root, config}",
+  ),
   starters: route(
     "GET",
     "/__studio/starters",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -13,13 +13,13 @@
  *   proxying, and studio filesystem integration as a single createDevServer() call.
  */
 
-import { join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { buildAll } from "./build.ts";
 import { createCollabRegistry } from "./collab.ts";
 import { createWatcher, injectSSE } from "./watch.ts";
 import { handleJxMounts } from "./jx-mounts.ts";
 import { handleResolve, handleServerFunction, projectAssetMounts } from "./resolve.ts";
-import { assertAccessible, handleStudioApi } from "./studio-api.ts";
+import { assertAccessible, assertCreatableParent, handleStudioApi } from "./studio-api.ts";
 import {
   containedPath,
   decodeAndNormalizePath,
@@ -217,6 +217,14 @@ export async function createDevServer(options: {
   }
   const absRoot = resolve(root);
 
+  /**
+   * Projects created through Studio's New Project modal, which land wherever the user pointed the
+   * Location field — normally outside `absRoot`. Remembering them lets the very next
+   * `/__studio/activate` open what was just created without widening the filesystem API to
+   * arbitrary directories.
+   */
+  const createdRoots: string[] = [];
+
   // ─── Build pipeline ─────────────────────────────────────────────────────────
 
   if (builds.length > 0) {
@@ -343,7 +351,8 @@ export async function createDevServer(options: {
           const requested = resolve(absRoot, raw);
           const permitted =
             containedPath(requested, absRoot) !== null ||
-            allowedRoots.some((allowed) => containedPath(requested, resolve(allowed)) !== null);
+            allowedRoots.some((allowed) => containedPath(requested, resolve(allowed)) !== null) ||
+            createdRoots.some((created) => containedPath(requested, created) !== null);
           if (!permitted) {
             return Response.json({ ok: false, error: "root not permitted" }, { status: 403 });
           }
@@ -357,14 +366,26 @@ export async function createDevServer(options: {
           return aiRes;
         }
 
-        // AI-guided site import (/__studio/import-site) — NDJSON progress stream
+        // AI-guided site import (/__studio/import-site) — NDJSON progress stream. An ABSOLUTE
+        // Directory is a destination the user chose in the New Project modal, so it is vetted the
+        // Same way a create is (specs/server.md §4.2). A RELATIVE one predates that field and stays
+        // Contained to the server root — resolving it there and then widening the check to the
+        // Creatable roots would let "../escape" out.
         const importRes = await handleImportApi(req, url, {
           resolveDest: (dir) => {
+            if (isAbsolute(dir)) {
+              assertCreatableParent(dirname(dir), absRoot, allowedRoots);
+              createdRoots.push(dir);
+              return dir;
+            }
             const dest = resolve(absRoot, dir);
             assertAccessible(dest, absRoot, activeProjectRoot);
             return dest;
           },
-          toRoot: (dest) => relative(absRoot, dest).replaceAll("\\", "/"),
+          toRoot: (dest) =>
+            containedPath(dest, absRoot) === null
+              ? dest
+              : relative(absRoot, dest).replaceAll("\\", "/"),
         });
         if (importRes) {
           return importRes;
@@ -375,7 +396,10 @@ export async function createDevServer(options: {
           return codeRes;
         }
 
-        const res = await handleStudioApi(req, url, absRoot, activeProjectRoot);
+        const res = await handleStudioApi(req, url, absRoot, activeProjectRoot, {
+          allowedRoots,
+          onProjectCreated: (created) => createdRoots.push(created),
+        });
         if (res) {
           return res;
         }

--- a/packages/server/src/studio-api.ts
+++ b/packages/server/src/studio-api.ts
@@ -10,7 +10,9 @@
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { errorMessage } from "@jxsuite/schema/parse";
 import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { LOCATION_ID_FILE } from "@jxsuite/protocol/routes";
 import {
   buildExtensionsPayload,
   buildProjectExtensionRegistry,
@@ -175,6 +177,33 @@ export function assertAccessible(filePath: string, root: string, activeProjectRo
   throw new Error("Path outside project root");
 }
 
+/**
+ * Check that a NEW project may be scaffolded under `parent` (specs/server.md §4.2).
+ *
+ * Deliberately wider than {@link assertAccessible}: a new project is normally created _outside_ the
+ * server root — the whole point of the modal's Location field — so root containment cannot apply.
+ * What it still refuses is a destination the user did not name (relative paths) and anything
+ * outside the places a person keeps projects: the server root, any configured `allowedRoots`, and
+ * the account's home directory. That keeps a hostile page on the loopback origin from scaffolding
+ * into system paths while leaving every realistic location reachable.
+ *
+ * @param {string} parent
+ * @param {string} root
+ * @param {string[]} allowedRoots
+ */
+export function assertCreatableParent(parent: string, root: string, allowedRoots: string[] = []) {
+  if (!parent || !isAbsolute(parent)) {
+    throw new Error("Destination folder must be an absolute path");
+  }
+  const bases = [root, ...allowedRoots, homedir()].filter(Boolean);
+  if (bases.some((base) => containedPath(parent, resolve(base)) !== null)) {
+    return;
+  }
+  throw new Error(
+    "Destination folder is outside the permitted roots (the server root, an allowed root, or your home directory)",
+  );
+}
+
 const statusMap: Record<string, string> = {
   A: "A",
   C: "C",
@@ -253,6 +282,18 @@ export function parseGitStatus(out: string) {
   return { ahead, behind, branch, files };
 }
 
+/** Host hooks for the routes that reach outside the server root (project creation). */
+export interface StudioApiOptions {
+  /** Extra roots a new project may be created under, mirroring `createDevServer.allowedRoots`. */
+  allowedRoots?: string[];
+  /**
+   * Called with the absolute root of a project this API just created, so the host can permit a
+   * subsequent `/__studio/activate` on it — a project created outside the server root is otherwise
+   * unreachable by the very request that made it.
+   */
+  onProjectCreated?: (projectRoot: string) => void;
+}
+
 /**
  * Handle /__studio/* requests.
  *
@@ -260,6 +301,7 @@ export function parseGitStatus(out: string) {
  * @param {URL} url
  * @param {string} root
  * @param {string | null} [activeProjectRoot]
+ * @param {StudioApiOptions} [opts]
  * @returns {Promise<Response | null>}
  */
 export async function handleStudioApi(
@@ -267,6 +309,7 @@ export async function handleStudioApi(
   url: URL,
   root: string,
   activeProjectRoot: string | null = null,
+  opts: StudioApiOptions = {},
 ) {
   const path = url.pathname;
 
@@ -416,6 +459,74 @@ export async function handleStudioApi(
     }
   }
 
+  /*
+   * Recover the absolute path of a directory the browser picked with `showDirectoryPicker()`.
+   *
+   * A `FileSystemDirectoryHandle` exposes only `.name`, never a filesystem path (§8.2), and unlike
+   * /__studio/find-project there is no `project.json` to search for — the whole point is that the
+   * folder is empty. So the client tags the folder with a hidden LOCATION_ID_FILE holding a random
+   * id and asks us which directory carries that id.
+   *
+   * Identity lives in the file's CONTENTS, not its name: matching the id is exact where matching a
+   * path shape is only probable — two folders can share a basename, and a file left behind by a
+   * crashed session can still be on disk. A candidate whose contents do not equal `id` is skipped,
+   * so a stale tag can never redirect a create. The winning file is deleted here, the moment it has
+   * served its purpose, rather than being left for the client to tidy up.
+   */
+  if (path === "/__studio/locate-directory" && req.method === "GET") {
+    const name = url.searchParams.get("name");
+    const id = url.searchParams.get("id");
+    // `name` is interpolated into a glob; the id is only ever compared, never used as a pattern.
+    if (!name || !id || !/^[a-f0-9]{32}$/.test(id) || !/^[^/\\]+$/.test(name)) {
+      return Response.json({ error: "Missing or invalid name/id" }, { status: 400 });
+    }
+    try {
+      const home = process.env.HOME || process.env.USERPROFILE || "";
+      if (!home) {
+        return Response.json({ path: null });
+      }
+      /** The tagged directory when this candidate holds our id, else null. */
+      const claim = (dir: string): string | null => {
+        const file = resolve(dir, LOCATION_ID_FILE);
+        try {
+          if (readFileSync(file, "utf8").trim() !== id) {
+            return null;
+          }
+        } catch {
+          return null;
+        }
+        try {
+          unlinkSync(file);
+        } catch {
+          // Read-only or already gone; the client's own cleanup is the backstop.
+        }
+        return dir;
+      };
+
+      // The home directory itself is a legitimate pick, and no `**/<name>/` glob can match it.
+      const atHome = claim(home);
+      if (atHome) {
+        return Response.json({ path: atHome });
+      }
+      // `dot: true` — the tag is a dotfile, so a dot-blind scan would never see it.
+      const glob = new Bun.Glob(`**/${name}/${LOCATION_ID_FILE}`);
+      try {
+        for await (const match of glob.scan({ cwd: home, dot: true })) {
+          if (match.includes("node_modules") || match.includes(".Trash")) {
+            continue;
+          }
+          const claimed = claim(resolve(home, dirname(match)));
+          if (claimed) {
+            return Response.json({ path: claimed });
+          }
+        }
+      } catch {}
+      return Response.json({ path: null });
+    } catch (error) {
+      return Response.json({ error: errorMessage(error) }, { status: 500 });
+    }
+  }
+
   // Discover site projects — find all project.json files under root
   if (path === "/__studio/sites" && req.method === "GET") {
     try {
@@ -453,6 +564,7 @@ export async function handleStudioApi(
         url?: string;
         adapter?: "static" | "cloudflare-pages" | "cloudflare-workers" | "node" | "bun";
         directory?: string;
+        destination?: { kind?: string; parent?: string };
         starter?: string;
         template?: string;
         design?: DesignOptions;
@@ -463,6 +575,7 @@ export async function handleStudioApi(
         url: siteUrl,
         adapter,
         directory,
+        destination,
         starter,
         template,
         design,
@@ -470,12 +583,32 @@ export async function handleStudioApi(
       if (!name || !directory) {
         return Response.json({ error: "name and directory are required" }, { status: 400 });
       }
+      // The destination is the user's to choose (specs/server.md §4.2). Without one the project
+      // Would silently land under the server root — which, when the dev server is the jx checkout,
+      // Means scaffolding into the monorepo. Refuse instead of guessing.
+      if (destination?.kind !== "path" || !destination.parent) {
+        return Response.json({ error: "A destination folder is required." }, { status: 400 });
+      }
+      // `directory` names the project FOLDER, not a path: a separator or dot-segment would walk out
+      // Of the parent that was just vetted below, which is exactly what the vetting is for.
+      if (/[/\\]/.test(directory) || directory === "." || directory === "..") {
+        return Response.json(
+          { error: "Directory must be a folder name, not a path" },
+          { status: 400 },
+        );
+      }
       const { isTemplateId } = await import("@jxsuite/create/templates");
       if (template !== undefined && !isTemplateId(template)) {
         return Response.json({ error: `Unknown template: "${template}"` }, { status: 400 });
       }
-      const destPath = resolve(root, directory);
-      assertAccessible(destPath, root, activeProjectRoot);
+      // A bad destination is client input, so answer 400 rather than letting the guard's throw fall
+      // Through to the catch-all 500 below.
+      try {
+        assertCreatableParent(destination.parent, root, opts.allowedRoots);
+      } catch (error) {
+        return Response.json({ error: errorMessage(error) }, { status: 400 });
+      }
+      const destPath = resolve(destination.parent, directory);
 
       const { generateProject } = await import("@jxsuite/create/generate");
       await generateProject(destPath, {
@@ -491,8 +624,12 @@ export async function handleStudioApi(
       const config = JSON.parse(
         await readFile(resolve(destPath, "project.json"), "utf8"),
       ) as ProjectConfig;
-      const projectRoot = fwd(relative(root, destPath));
-      return Response.json({ config, root: projectRoot });
+      // Root-relative while the project happens to sit under the server root (the historical
+      // Shape every caller already handles); absolute otherwise, which is the same shape
+      // /__studio/find-project returns for an external project.
+      const inRoot = containedPath(destPath, root) !== null;
+      opts.onProjectCreated?.(destPath);
+      return Response.json({ config, root: inRoot ? fwd(relative(root, destPath)) : destPath });
     } catch (error) {
       return Response.json({ error: errorMessage(error) }, { status: 500 });
     }

--- a/packages/server/tests/coverage-gaps.test.ts
+++ b/packages/server/tests/coverage-gaps.test.ts
@@ -1,14 +1,16 @@
 /**
  * Coverage-gaps.test.ts — integration coverage for dev-server and project-server branches the other
  * suites do not reach: the /_jx extension-mount route on both servers, the import-site delegation,
- * the absolute-path static miss under an active project, npm exports mappings whose target file is
- * gone, a failed WebSocket upgrade, the project server's AI route, and an npm bundle failure on the
- * project server.
+ * create-project at a user-chosen destination and the activate that follows it, the absolute-path
+ * static miss under an active project, npm exports mappings whose target file is gone, a failed
+ * WebSocket upgrade, the project server's AI route, and an npm bundle failure on the project
+ * server.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { join, resolve } from "node:path";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { createDevServer, resolveNpmPath } from "../src/server.ts";
 import { createProjectServer } from "../src/project-server.ts";
 import type { ProjectServerHandle } from "../src/project-server.ts";
@@ -60,9 +62,17 @@ function writeEchoExtension(root: string) {
 
 let devServer: { port: number; stop: (force?: boolean) => void };
 let projectServer: ProjectServerHandle;
+/**
+ * Where the New Project modal "chose" to put the project. It has to sit under the home directory
+ * but under neither the server root nor an allowed root, so that the follow-up activate can only
+ * succeed because the server remembered what it just created. Anchoring it to homedir() keeps that
+ * relationship true wherever the checkout lives.
+ */
+let createdParent: string;
 
 beforeAll(async () => {
   rmSync(FIXTURES, { force: true, recursive: true });
+  createdParent = mkdtempSync(join(homedir(), ".jx-server-created-"));
 
   // Dev-server root: echo mounts, an activatable project subdir, and an npm package whose
   // Exports map points at a missing file while the direct subpath exists.
@@ -113,6 +123,7 @@ afterAll(() => {
   devServer.stop(true);
   projectServer.stop();
   rmSync(FIXTURES, { force: true, recursive: true });
+  rmSync(createdParent, { force: true, recursive: true });
 });
 
 // ─── Dev server ───────────────────────────────────────────────────────────────
@@ -178,6 +189,55 @@ describe("dev server — absolute paths under the active project", () => {
     const res = await fetch(`http://localhost:${devServer.port}/external.txt`);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("external data");
+  });
+});
+
+describe("dev server — create-project at a chosen destination", () => {
+  test("refuses to create anything without a destination", async () => {
+    const res = await fetch(`http://localhost:${devServer.port}/__studio/create-project`, {
+      body: JSON.stringify({ directory: "unwanted", name: "Unwanted" }),
+      method: "POST",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("A destination folder is required.");
+    expect(existsSync(join(SERVER_ROOT, "unwanted"))).toBe(false);
+  });
+
+  test("scaffolds at the chosen parent and permits activating what it just created", async () => {
+    const res = await fetch(`http://localhost:${devServer.port}/__studio/create-project`, {
+      body: JSON.stringify({
+        destination: { kind: "path", parent: createdParent },
+        directory: "made-here",
+        name: "Made Here",
+      }),
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { config: { name: string }; root: string };
+    // Outside the server root, so the root comes back absolute rather than root-relative.
+    expect(body.root).toBe(join(createdParent, "made-here"));
+    expect(body.config.name).toBe("Made Here");
+    expect(existsSync(join(createdParent, "made-here", "project.json"))).toBe(true);
+
+    // The server remembered the new root, so the activate Studio sends next is permitted even
+    // Though the project sits under neither the server root nor allowedRoots.
+    const activate = await fetch(`http://localhost:${devServer.port}/__studio/activate`, {
+      body: JSON.stringify({ root: body.root }),
+      method: "POST",
+    });
+    expect(activate.status).toBe(200);
+    const activated = (await activate.json()) as { ok: boolean; root: string };
+    expect(activated.ok).toBe(true);
+    expect(activated.root).toBe(join(createdParent, "made-here"));
+  });
+
+  test("still refuses to activate a directory it never created", async () => {
+    const activate = await fetch(`http://localhost:${devServer.port}/__studio/activate`, {
+      body: JSON.stringify({ root: join(createdParent, "never-made") }),
+      method: "POST",
+    });
+    expect(activate.status).toBe(403);
   });
 });
 

--- a/packages/server/tests/studio-api-gaps.test.ts
+++ b/packages/server/tests/studio-api-gaps.test.ts
@@ -1,20 +1,30 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { handleStudioApi } from "../src/studio-api";
-import { join, resolve } from "node:path";
+import { assertCreatableParent, handleStudioApi } from "../src/studio-api";
+import { LOCATION_ID_FILE } from "@jxsuite/protocol/routes";
+import type { StudioApiOptions } from "../src/studio-api";
+import { basename, join, resolve } from "node:path";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 
 const FIXTURES = resolve(import.meta.dir, "_studio_gaps_fixtures");
 const ROOT = join(FIXTURES, "root");
 const EXTERNAL = join(FIXTURES, "external");
+/** Parent for projects created outside the server root; reachable only via allowedRoots. */
+const OUTSIDE_PARENT = join(FIXTURES, "elsewhere");
+/**
+ * A parent under neither the server root, an allowed root, nor the home directory — a sibling of
+ * the home directory, so the relationship holds wherever the checkout happens to live.
+ */
+const UNPERMITTED_PARENT = resolve(homedir(), "..", "jx-unpermitted-destination");
 
 async function callApi(
   req: Request,
   url: URL,
   root: string = ROOT,
   activeProjectRoot: string | null = null,
+  opts: StudioApiOptions = {},
 ) {
-  const res = await handleStudioApi(req, url, root, activeProjectRoot);
+  const res = await handleStudioApi(req, url, root, activeProjectRoot, opts);
   if (!res) {
     throw new Error("handleStudioApi returned null");
   }
@@ -41,6 +51,9 @@ beforeAll(() => {
   // External project (outside server root) for activeProjectRoot access checks
   mkdirSync(EXTERNAL, { recursive: true });
   writeFileSync(join(EXTERNAL, "ext.txt"), "external file");
+
+  // Destination parent outside the server root, for create-project's chosen-location path
+  mkdirSync(OUTSIDE_PARENT, { recursive: true });
 
   // Home dir for ~ expansion and find-project
   mkdirSync(join(FIXTURES, "home", "my-site"), { recursive: true });
@@ -323,28 +336,286 @@ describe("find-project — gaps", () => {
   });
 });
 
+// ─── locate-directory ────────────────────────────────────────────────────────
+
+/** Throwaway home directories handed to the locate-directory route, removed after the suite. */
+const LOCATE_HOMES: string[] = [];
+
+/**
+ * Makes a private home directory for one locate-directory case. It lives under the real home so the
+ * route — which only ever scans `$HOME` — stays inside the user's tree, and so the scan sees
+ * nothing but the fixture the test just wrote.
+ */
+function locateHome() {
+  const home = mkdtempSync(join(homedir(), "jx-locate-home-"));
+  LOCATE_HOMES.push(home);
+  return home;
+}
+
+/** Calls the route with `$HOME` pointed at `home`, restoring the ambient environment after. */
+async function locateDirectory(home: string, query: string) {
+  const originalHome = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    const { req, url } = getReq(`/__studio/locate-directory?${query}`);
+    return await callApi(req, url);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  }
+}
+
+describe("locate-directory", () => {
+  /** A well-formed id — the route accepts only 32 lowercase hex characters. */
+  const ID = "a1b2c3d4e5f60718293a4b5c6d7e8f90";
+  const OTHER_ID = "0f9e8d7c6b5a493827160f5e4d3c2b1a";
+
+  /** Shared by the validation cases, which are refused before anything touches the filesystem. */
+  let emptyHome = "";
+
+  /** Tag `dir` as the picked folder by writing `id` into its hidden location file. */
+  function tag(dir: string, id: string) {
+    writeFileSync(join(dir, LOCATION_ID_FILE), id);
+  }
+
+  beforeAll(() => {
+    emptyHome = locateHome();
+  });
+
+  afterAll(() => {
+    for (const home of LOCATE_HOMES) {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects a missing name", async () => {
+    const res = await locateDirectory(emptyHome, `id=${ID}`);
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe("Missing or invalid name/id");
+  });
+
+  test("rejects a missing id", async () => {
+    const res = await locateDirectory(emptyHome, "name=new-site");
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe("Missing or invalid name/id");
+  });
+
+  test("rejects an id outside the generated 32-hex shape", async () => {
+    // The id is only ever compared, never used as a pattern — but a strict shape keeps a
+    // Malformed value from reaching the filesystem at all.
+    for (const bad of ["../escape", "not-hex-at-all", "A1B2C3D4E5F60718293A4B5C6D7E8F90", "abc"]) {
+      const res = await locateDirectory(emptyHome, `name=new-site&id=${encodeURIComponent(bad)}`);
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test("rejects a name containing a separator", async () => {
+    // A directory handle's `.name` is a single path segment; anything else is not a real pick.
+    const nested = encodeURIComponent("nested/new-site");
+    const res = await locateDirectory(emptyHome, `name=${nested}&id=${ID}`);
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe("Missing or invalid name/id");
+
+    const backslash = encodeURIComponent(String.raw`nested\new-site`);
+    const winRes = await locateDirectory(emptyHome, `name=${backslash}&id=${ID}`);
+    expect(winRes.status).toBe(400);
+  });
+
+  test("resolves a tag written straight into the home directory to the home directory", async () => {
+    // Picking the home directory itself is legitimate, and no `**/<name>/` glob can match it.
+    const home = locateHome();
+    tag(home, ID);
+    const res = await locateDirectory(home, `name=${basename(home)}&id=${ID}`);
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { path: string | null };
+    expect(payload.path).toBe(home);
+    // The route cleans up the moment it matches, rather than leaving the tag for the client.
+    expect(existsSync(join(home, LOCATION_ID_FILE))).toBe(false);
+  });
+
+  test("resolves a tag in a nested directory to that directory, skipping node_modules", async () => {
+    const home = locateHome();
+    const target = join(home, "projects", "sites", "new-site");
+    mkdirSync(target, { recursive: true });
+    tag(target, ID);
+    // A same-named decoy inside node_modules must never win.
+    mkdirSync(join(home, "node_modules", "new-site"), { recursive: true });
+    tag(join(home, "node_modules", "new-site"), ID);
+
+    const res = await locateDirectory(home, `name=new-site&id=${ID}`);
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { path: string | null };
+    expect(payload.path).toBe(target);
+    expect(existsSync(join(target, LOCATION_ID_FILE))).toBe(false);
+  });
+
+  test("ignores a same-named folder whose tag holds a different id", async () => {
+    // This is the whole reason identity lives in the CONTENTS: two folders can share a basename,
+    // And a tag left by a crashed session can still be on disk. Only the live id may win.
+    const home = locateHome();
+    const stale = join(home, "a", "new-site");
+    const live = join(home, "b", "new-site");
+    mkdirSync(stale, { recursive: true });
+    mkdirSync(live, { recursive: true });
+    tag(stale, OTHER_ID);
+    tag(live, ID);
+
+    const res = await locateDirectory(home, `name=new-site&id=${ID}`);
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { path: string | null };
+    expect(payload.path).toBe(live);
+    // The loser's tag is left untouched — it belongs to someone else's pick.
+    expect(existsSync(join(stale, LOCATION_ID_FILE))).toBe(true);
+  });
+
+  test("returns a null path when no tag anywhere holds the id", async () => {
+    const home = locateHome();
+    const dir = join(home, "new-site");
+    mkdirSync(dir, { recursive: true });
+    tag(dir, OTHER_ID);
+    const res = await locateDirectory(home, `name=new-site&id=${ID}`);
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { path: string | null };
+    expect(payload.path).toBeNull();
+  });
+
+  test("returns a null path when there is no home directory", async () => {
+    const originalHome = process.env.HOME;
+    const originalProfile = process.env.USERPROFILE;
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    try {
+      const { req, url } = getReq(`/__studio/locate-directory?name=new-site&id=${ID}`);
+      const res = await callApi(req, url);
+      expect(res.status).toBe(200);
+      const payload = (await res.json()) as { path: string | null };
+      expect(payload.path).toBeNull();
+    } finally {
+      if (originalHome !== undefined) {
+        process.env.HOME = originalHome;
+      }
+      if (originalProfile !== undefined) {
+        process.env.USERPROFILE = originalProfile;
+      }
+    }
+  });
+});
+
+// ─── assertCreatableParent ───────────────────────────────────────────────────
+
+describe("assertCreatableParent", () => {
+  test("rejects a relative parent", () => {
+    expect(() => assertCreatableParent("sites/mine", ROOT)).toThrow(
+      "Destination folder must be an absolute path",
+    );
+  });
+
+  test("rejects an empty parent", () => {
+    expect(() => assertCreatableParent("", ROOT)).toThrow(
+      "Destination folder must be an absolute path",
+    );
+  });
+
+  test("rejects a parent outside the root, the allowed roots, and home", () => {
+    expect(() => assertCreatableParent(UNPERMITTED_PARENT, ROOT, [EXTERNAL])).toThrow(
+      "Destination folder is outside the permitted roots",
+    );
+  });
+
+  test("accepts a parent under the server root", () => {
+    expect(() => assertCreatableParent(join(ROOT, "nested", "deep"), ROOT)).not.toThrow();
+  });
+
+  test("accepts a parent under an allowedRoots entry", () => {
+    expect(() => assertCreatableParent(join(EXTERNAL, "sites"), ROOT, [EXTERNAL])).not.toThrow();
+  });
+
+  test("accepts a parent under the home directory", () => {
+    expect(() => assertCreatableParent(join(homedir(), "jx-sites"), ROOT)).not.toThrow();
+  });
+});
+
 // ─── create-project ──────────────────────────────────────────────────────────
+
+/** A create-project body pointed at `parent`, which the modal always supplies. */
+function createReq(body: Record<string, unknown>, parent: string = ROOT) {
+  return jsonReq("/__studio/create-project", "POST", {
+    destination: { kind: "path", parent },
+    ...body,
+  });
+}
 
 describe("create-project", () => {
   test("requires name and directory", async () => {
-    const { req, url } = jsonReq("/__studio/create-project", "POST", { name: "x" });
+    const { req, url } = createReq({ name: "x" });
     const res = await callApi(req, url);
     expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe("name and directory are required");
   });
 
-  test("rejects directories outside the root", async () => {
+  test("requires a destination — the project never lands somewhere the user did not choose", async () => {
     const { req, url } = jsonReq("/__studio/create-project", "POST", {
-      directory: "../escape",
-      name: "Escape",
+      directory: "nowhere-site",
+      name: "Nowhere",
     });
     const res = await callApi(req, url);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
     const payload = await res.json();
-    expect(payload.error).toContain("outside");
+    expect(payload.error).toBe("A destination folder is required.");
+    expect(existsSync(join(ROOT, "nowhere-site"))).toBe(false);
+  });
+
+  test("rejects a repo destination — the dev server only scaffolds on disk", async () => {
+    const { req, url } = jsonReq("/__studio/create-project", "POST", {
+      destination: { kind: "repo", owner: "acme", private: false, repo: "site" },
+      directory: "repo-site",
+      name: "Repo Site",
+    });
+    const res = await callApi(req, url);
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toBe("A destination folder is required.");
+  });
+
+  test("rejects a relative destination parent", async () => {
+    const { req, url } = createReq({ directory: "escape", name: "Escape" }, "relative/parent");
+    const res = await callApi(req, url);
+    // A bad destination is client input, so it answers 400 like the other destination refusals —
+    // Not the catch-all 500.
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toContain("must be an absolute path");
+  });
+
+  test("rejects a directory that is a path rather than a folder name", async () => {
+    // The parent passes the creatable check, but joining a "../" directory onto it would land the
+    // Project outside the folder the user actually chose.
+    const { req, url } = createReq({ directory: "../../escape", name: "Escape" }, ROOT);
+    const res = await callApi(req, url);
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toContain("folder name, not a path");
+    // Nothing was scaffolded at the escaped path (which may itself already exist as a plain dir).
+    expect(existsSync(resolve(ROOT, "../../escape/project.json"))).toBe(false);
+  });
+
+  test("rejects a destination parent outside the permitted roots", async () => {
+    const { req, url } = createReq({ directory: "escape", name: "Escape" }, UNPERMITTED_PARENT);
+    const res = await callApi(req, url);
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error).toContain("outside the permitted roots");
   });
 
   test("generates a new project and returns its config", async () => {
-    const { req, url } = jsonReq("/__studio/create-project", "POST", {
+    const { req, url } = createReq({
       description: "A test site",
       directory: "generated-site",
       name: "Generated Site",
@@ -359,8 +630,32 @@ describe("create-project", () => {
     );
   });
 
+  test("scaffolds under the chosen parent and returns an absolute root when it is outside the server root", async () => {
+    const { req, url } = createReq({ directory: "away-site", name: "Away Site" }, OUTSIDE_PARENT);
+    const res = await callApi(req, url, ROOT, null, { allowedRoots: [FIXTURES] });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.root).toBe(join(OUTSIDE_PARENT, "away-site"));
+    expect(body.config.name).toBe("Away Site");
+    expect(existsSync(join(OUTSIDE_PARENT, "away-site", "project.json"))).toBe(true);
+    // Nothing was written under the server root.
+    expect(existsSync(join(ROOT, "away-site"))).toBe(false);
+  });
+
+  test("notifies onProjectCreated with the absolute root even when the response root is relative", async () => {
+    const created: string[] = [];
+    const { req, url } = createReq({ directory: "notified-site", name: "Notified Site" });
+    const res = await callApi(req, url, ROOT, null, {
+      onProjectCreated: (projectRoot) => created.push(projectRoot),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.root).toBe("notified-site");
+    expect(created).toEqual([join(ROOT, "notified-site")]);
+  });
+
   test("clones a starter template when one is selected", async () => {
-    const { req, url } = jsonReq("/__studio/create-project", "POST", {
+    const { req, url } = createReq({
       directory: "from-starter",
       name: "My Cafe",
       starter: "restaurant",
@@ -375,7 +670,7 @@ describe("create-project", () => {
   });
 
   test("applies a built-in template variant", async () => {
-    const { req, url } = jsonReq("/__studio/create-project", "POST", {
+    const { req, url } = createReq({
       directory: "from-template",
       name: "My App",
       template: "mobile-first",
@@ -388,7 +683,7 @@ describe("create-project", () => {
   });
 
   test("applies design quickstart options to the generated project", async () => {
-    const { req, url } = jsonReq("/__studio/create-project", "POST", {
+    const { req, url } = createReq({
       design: {
         accent: "#ff5500",
         media: { "--": "1440px", "--sm": "(max-width: 600px)" },
@@ -404,7 +699,7 @@ describe("create-project", () => {
   });
 
   test("rejects an unknown template id", async () => {
-    const { req, url } = jsonReq("/__studio/create-project", "POST", {
+    const { req, url } = createReq({
       directory: "bad-template",
       name: "Bad",
       template: "spaceship",

--- a/packages/studio/index.html
+++ b/packages/studio/index.html
@@ -3026,6 +3026,27 @@
         color: var(--danger);
         padding: 4px 0;
       }
+      /* Destination row: the Location field takes the slack, Browse… stays its natural width. */
+      .new-project-location-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .new-project-location-row .new-project-location {
+        flex: 1;
+        min-width: 0;
+      }
+      /* Live preview of where the project will land — the answer to "where did that go?". */
+      .new-project-destination-preview {
+        font-size: var(--spectrum-font-size-75, 12px);
+        color: var(--fg-dim);
+        padding: 2px 0 4px;
+        overflow-wrap: anywhere;
+      }
+      .new-project-destination-preview code {
+        font-family: var(--font-mono, ui-monospace, monospace);
+        color: var(--fg);
+      }
       /* Backend/global creation errors sit between the scroll body and the footer so they are
          visible regardless of scroll position. */
       .new-project-error--global {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -21,6 +21,7 @@
     ".": "./src/studio.ts",
     "./platform": "./src/platform.ts",
     "./types": "./src/types.ts",
+    "./directory-picker": "./src/services/directory-picker.ts",
     "./import-client": "./src/services/import-client.ts",
     "./platforms/cloud": "./src/platforms/cloud.ts"
   },

--- a/packages/studio/src/new-project/import-tab.ts
+++ b/packages/studio/src/new-project/import-tab.ts
@@ -9,9 +9,10 @@ import { html } from "lit-html";
 import { getPlatform } from "../platform";
 import { getBaseUrl, getModel, getOpenAiKey, hasOpenAiKey } from "../services/ai-settings";
 import { errorMessage } from "@jxsuite/schema/parse";
+import { destinationPath } from "./location-fields";
 import type { TemplateResult } from "lit-html";
 import type { ProjectConfig } from "@jxsuite/schema/types";
-import type { ImportProgressEvent } from "../types";
+import type { CreateProjectDestination, ImportProgressEvent } from "../types";
 
 /** Structural view of src/ui/ai-credentials-form's controller (what this tab renders when gated). */
 export interface CredsFormLike {
@@ -22,6 +23,12 @@ export interface CredsFormLike {
 export interface ImportTabCtx {
   /** The modal's shared name/directory state (the import destination slug). */
   form: { name: string; directory: string };
+  /**
+   * Validate the shared Parameters fields and return where to write, or null when something is
+   * missing (the modal has already rendered the reason inline). Import is always a `"path"`
+   * destination — cloud ships no `importSite`, so the Import tab never renders there.
+   */
+  resolveDestination: () => CreateProjectDestination | null;
   rerender: () => void;
   /** Called with the imported project; the modal resolves and closes. */
   onDone: (result: { root: string; config: ProjectConfig }) => void;
@@ -111,13 +118,9 @@ export async function startImport(ctx: ImportTabCtx) {
     ctx.rerender();
     return;
   }
-  if (!ctx.form.name.trim()) {
-    _errorMsg = "Project name is required";
-    ctx.rerender();
+  const destination = ctx.resolveDestination();
+  if (!destination || destination.kind !== "path") {
     return;
-  }
-  if (!ctx.form.directory.trim()) {
-    ctx.form.directory = slugOf(ctx.form.name);
   }
 
   _status = "running";
@@ -134,7 +137,7 @@ export async function startImport(ctx: ImportTabCtx) {
       {
         url: parsed.href,
         name: ctx.form.name.trim(),
-        directory: ctx.form.directory.trim(),
+        directory: destinationPath(destination, ctx.form.directory),
         depth: _depth,
         maxPages: _maxPages,
         aiComponents: _aiNaming,

--- a/packages/studio/src/new-project/location-fields.ts
+++ b/packages/studio/src/new-project/location-fields.ts
@@ -1,0 +1,323 @@
+/**
+ * The destination section of the New Project Parameters step — where the project is written.
+ *
+ * Two shapes, chosen by the platform's `createDestination` (specs/desktop.md §4.5):
+ *
+ * - `"path"` (desktop, dev server): a required **Location** (absolute parent directory) plus the
+ *   folder name. Desktop backs the Browse… button with the native dialog via `pickDirectory`; the
+ *   dev server has no dialog, so the path is typed. Nothing is ever written to a directory the user
+ *   did not name.
+ * - `"repo"` (cloud): the repository location — owner (personal account or organization), the
+ *   repository name, and its visibility.
+ *
+ * This module owns the destination fields AND the name-derived slug they share, so the field order
+ * reads naturally in both shapes (Location → Directory, versus Owner → Repository → Visibility).
+ *
+ * @docs studio/projects/create
+ */
+
+import { html, nothing } from "lit-html";
+import { getPlatform } from "../platform";
+import type { TemplateResult } from "lit-html";
+import type { CreateProjectDestination, RepoInfo } from "../types";
+
+/** Absolute POSIX (`/…`) or Windows (`C:\…` / `C:/…`) path. */
+const ABSOLUTE_PATH = /^(?:[a-zA-Z]:[/\\]|\/)/;
+
+let _parent = "";
+let _owner = "";
+let _private = true;
+/** Owner logins offered in the repo-mode picker (empty until loaded / when unavailable). */
+let _owners: string[] = [];
+/** Repositories already owned, for the name-collision hint. Null until loaded. */
+let _repos: RepoInfo[] | null = null;
+/** Inline validation error shown under the destination fields. */
+let _error = "";
+let _browsing = false;
+
+/** Reset the section for a fresh modal pass. */
+export function resetLocationFields() {
+  _parent = "";
+  _owner = "";
+  _private = true;
+  _owners = [];
+  _repos = null;
+  _error = "";
+  _browsing = false;
+}
+
+/**
+ * Load the repo-mode owner candidates (and the repo list behind the collision hint) in the
+ * background. No-op on `"path"` platforms. Failures are non-fatal — the owner field falls back to
+ * free text, exactly as it behaves before the lists arrive.
+ */
+export function loadLocationOptions(rerender: () => void) {
+  const platform = getPlatform();
+  if (platform.createDestination !== "repo") {
+    return;
+  }
+  const owners = new Set<string>();
+  void Promise.allSettled([
+    platform.getAccountStatus?.().then((status) => {
+      for (const install of status?.installations ?? []) {
+        if (install.account) {
+          owners.add(install.account);
+        }
+      }
+    }),
+    platform.listRepos?.().then((repos) => {
+      _repos = repos;
+      for (const repo of repos) {
+        owners.add(repo.owner);
+      }
+    }),
+  ]).then(() => {
+    _owners = [...owners].toSorted((a, b) => a.localeCompare(b));
+    _owner ||= _owners[0] ?? "";
+    rerender();
+  });
+}
+
+/** The label for the shared slug field — it names a folder on disk, or a repository. */
+export function slugFieldLabel(): string {
+  return getPlatform().createDestination === "repo" ? "Repository" : "Directory";
+}
+
+/**
+ * The destination to send with createProject, or null when the fields are incomplete/invalid (the
+ * reason is then in `locationError()` and rendered inline).
+ */
+export function collectDestination(slug: string): CreateProjectDestination | null {
+  _error = "";
+  if (getPlatform().createDestination === "repo") {
+    if (!_owner.trim()) {
+      _error = "Choose an owner for the repository";
+      return null;
+    }
+    if (!slug.trim()) {
+      _error = "Repository name is required";
+      return null;
+    }
+    return { kind: "repo", owner: _owner.trim(), private: _private, repo: slug.trim() };
+  }
+  const parent = _parent.trim();
+  if (!parent) {
+    _error = "Choose a location for the project folder";
+    return null;
+  }
+  if (!ABSOLUTE_PATH.test(parent)) {
+    _error = "Location must be an absolute path";
+    return null;
+  }
+  if (!slug.trim()) {
+    _error = "Directory name is required";
+    return null;
+  }
+  return { kind: "path", parent: trimTrailingSep(parent) };
+}
+
+/** The inline validation message from the last `collectDestination`, if any. */
+export function locationError(): string {
+  return _error;
+}
+
+/** Drop trailing separators, but never reduce a filesystem root (`/`, `C:\`) to nothing. */
+function trimTrailingSep(parent: string): string {
+  const trimmed = parent.replace(/[/\\]+$/, "");
+  return trimmed || parent;
+}
+
+/**
+ * Join a parent directory and a folder name with the parent's own separator, so a Windows path
+ * stays a Windows path. Shared by the preview and the resolved destination — the string the user
+ * reads must be the string that gets created.
+ */
+function joinPath(parent: string, name: string): string {
+  const sep = parent.includes("\\") && !parent.includes("/") ? "\\" : "/";
+  return parent.endsWith("/") || parent.endsWith("\\")
+    ? `${parent}${name}`
+    : `${parent}${sep}${name}`;
+}
+
+/**
+ * The absolute directory a `"path"` destination writes to. The import pipeline takes a plain
+ * absolute `directory` rather than a destination object (it is never repo-mode — cloud ships no
+ * `importSite`), so the modal resolves it here.
+ */
+export function destinationPath(destination: CreateProjectDestination, slug: string): string {
+  if (destination.kind !== "path") {
+    throw new Error("Only filesystem destinations have a path");
+  }
+  return joinPath(destination.parent, slug.trim());
+}
+
+/** The destination the user has chosen so far, rendered for the preview line. */
+function previewOf(slug: string): string {
+  const name = slug.trim() || "…";
+  if (getPlatform().createDestination === "repo") {
+    return `${_owner.trim() || "…"}/${name}`;
+  }
+  const parent = trimTrailingSep(_parent.trim());
+  return parent ? joinPath(parent, name) : `…/${name}`;
+}
+
+/** True when a repo of this name already exists under the chosen owner. */
+function repoExists(slug: string): boolean {
+  const full = `${_owner.trim()}/${slug.trim()}`.toLowerCase();
+  return (_repos ?? []).some((r) => r.fullName.toLowerCase() === full);
+}
+
+function slugFieldTpl(slug: string, onSlugInput: (e: Event) => void): TemplateResult {
+  return html`
+    <label class="new-project-field">
+      <span class="new-project-label">${slugFieldLabel()}</span>
+      <sp-textfield
+        class="new-project-slug"
+        placeholder="my-site"
+        .value=${slug}
+        @input=${onSlugInput}
+        style="width: 100%"
+      ></sp-textfield>
+    </label>
+  `;
+}
+
+function pathFieldsTpl(ctx: {
+  rerender: () => void;
+  slug: string;
+  onSlugInput: (e: Event) => void;
+}): TemplateResult {
+  const platform = getPlatform();
+
+  const browse = async () => {
+    if (!platform.pickDirectory || _browsing) {
+      return;
+    }
+    _browsing = true;
+    ctx.rerender();
+    try {
+      const picked = await platform.pickDirectory();
+      if (picked) {
+        _parent = picked;
+        _error = "";
+      }
+    } finally {
+      _browsing = false;
+      ctx.rerender();
+    }
+  };
+
+  return html`
+    <label class="new-project-field">
+      <span class="new-project-label">Location *</span>
+      <div class="new-project-location-row">
+        <sp-textfield
+          class="new-project-location"
+          placeholder=${platform.pickDirectory
+            ? "Choose a folder to create the project in"
+            : "/absolute/path/to/your/projects"}
+          .value=${_parent}
+          @input=${(e: Event) => {
+            _parent = (e.target as HTMLInputElement).value;
+            _error = "";
+            ctx.rerender();
+          }}
+          style="width: 100%"
+        ></sp-textfield>
+        ${platform.pickDirectory
+          ? html`
+              <sp-button variant="secondary" ?disabled=${_browsing} @click=${() => void browse()}>
+                ${_browsing ? "Choosing…" : "Browse…"}
+              </sp-button>
+            `
+          : nothing}
+      </div>
+    </label>
+    ${slugFieldTpl(ctx.slug, ctx.onSlugInput)}
+  `;
+}
+
+function repoFieldsTpl(ctx: {
+  rerender: () => void;
+  slug: string;
+  onSlugInput: (e: Event) => void;
+}): TemplateResult {
+  const ownerField =
+    _owners.length > 0
+      ? html`
+          <sp-picker
+            class="new-project-owner"
+            .value=${_owner}
+            @change=${(e: Event) => {
+              _owner = (e.target as HTMLElement & { value: string }).value;
+              _error = "";
+              ctx.rerender();
+            }}
+            style="width: 100%"
+          >
+            ${_owners.map((owner) => html`<sp-menu-item value=${owner}>${owner}</sp-menu-item>`)}
+          </sp-picker>
+        `
+      : html`
+          <sp-textfield
+            class="new-project-owner"
+            placeholder="your-account-or-org"
+            .value=${_owner}
+            @input=${(e: Event) => {
+              _owner = (e.target as HTMLInputElement).value;
+              _error = "";
+              ctx.rerender();
+            }}
+            style="width: 100%"
+          ></sp-textfield>
+        `;
+
+  return html`
+    <label class="new-project-field">
+      <span class="new-project-label">Owner *</span>
+      ${ownerField}
+    </label>
+    ${slugFieldTpl(ctx.slug, ctx.onSlugInput)}
+    ${repoExists(ctx.slug)
+      ? html`<div class="new-project-error new-project-error--destination">
+          ${_owner}/${ctx.slug} already exists — choose another name.
+        </div>`
+      : nothing}
+    <label class="new-project-field">
+      <span class="new-project-label">Visibility</span>
+      <sp-picker
+        class="new-project-visibility"
+        .value=${_private ? "private" : "public"}
+        @change=${(e: Event) => {
+          _private = (e.target as HTMLElement & { value: string }).value !== "public";
+          ctx.rerender();
+        }}
+        style="width: 100%"
+      >
+        <sp-menu-item value="private">Private</sp-menu-item>
+        <sp-menu-item value="public">Public</sp-menu-item>
+      </sp-picker>
+    </label>
+  `;
+}
+
+/**
+ * The destination fields (including the shared slug), branched on the platform's
+ * `createDestination`, followed by a live preview of where the project will land.
+ */
+export function renderLocationFields(ctx: {
+  rerender: () => void;
+  slug: string;
+  onSlugInput: (e: Event) => void;
+}): TemplateResult {
+  const isRepo = getPlatform().createDestination === "repo";
+  return html`
+    ${isRepo ? repoFieldsTpl(ctx) : pathFieldsTpl(ctx)}
+    <div class="new-project-destination-preview">
+      ${isRepo ? "Repository" : "Creates"}: <code>${previewOf(ctx.slug)}</code>
+    </div>
+    ${_error
+      ? html`<div class="new-project-error new-project-error--destination">${_error}</div>`
+      : nothing}
+  `;
+}

--- a/packages/studio/src/new-project/new-project-modal.ts
+++ b/packages/studio/src/new-project/new-project-modal.ts
@@ -20,6 +20,12 @@ import { createAiCredentialsForm } from "../ui/ai-credentials-form";
 import { PROJECT_TEMPLATES } from "./templates";
 import { collectDesign, renderDesignFields, resetDesignFields } from "./design-fields";
 import {
+  collectDestination,
+  loadLocationOptions,
+  renderLocationFields,
+  resetLocationFields,
+} from "./location-fields";
+import {
   cancelImport,
   importButtonLabel,
   isImportRunning,
@@ -31,7 +37,7 @@ import {
   validateImportSource,
 } from "./import-tab";
 import type { ProjectConfig } from "@jxsuite/schema/types";
-import type { StarterInfo } from "../types";
+import type { CreateProjectDestination, StarterInfo } from "../types";
 import type { ImportTabCtx } from "./import-tab";
 
 type NewProjectTab = "template" | "starter" | "import" | "agent";
@@ -142,10 +148,17 @@ export function openNewProjectModal(options?: { tab?: "template" | "starter" }):
   _dirDerived = true;
   resetImportTab();
   resetDesignFields();
+  resetLocationFields();
 
-  // Load starter templates in the background; re-render when they arrive. Platforms without
-  // Starters leave the Starter Site tab showing its empty note.
+  // Load the destination options (repo-mode owners) and starter templates in the background,
+  // Re-rendering when they arrive. Platforms without starters leave the Starter Site tab showing
+  // Its empty note.
   const platform = getPlatform();
+  loadLocationOptions(() => {
+    if (_handle) {
+      renderModal();
+    }
+  });
   if (platform.listStarters) {
     void platform
       .listStarters()
@@ -226,6 +239,7 @@ function renderModal() {
     form: _form,
     onDone: finish,
     rerender: renderModal,
+    resolveDestination: () => validateParams(),
   };
 
   const onInput =
@@ -326,15 +340,35 @@ function renderModal() {
 
   // ─── Submission ────────────────────────────────────────────────────────────
 
-  const onSubmit = async () => {
+  /**
+   * Validate the Parameters step, returning the destination to create at (null when something is
+   * missing — the reason is already rendered inline and the modal re-drawn). The slug is derived
+   * from the name when left blank, but the destination itself is never guessed.
+   */
+  const validateParams = (): CreateProjectDestination | null => {
     if (!_form.name.trim()) {
       _nameError = "Project name is required";
       renderModal();
       focusNameField();
-      return;
+      return null;
     }
     if (!_form.directory.trim()) {
       _form.directory = deriveSlug(_form.name);
+    }
+    const destination = collectDestination(_form.directory);
+    if (!destination) {
+      _nameError = "";
+      renderModal();
+      focusNameField();
+      return null;
+    }
+    return destination;
+  };
+
+  const onSubmit = async () => {
+    const destination = validateParams();
+    if (!destination) {
+      return;
     }
 
     _creating = true;
@@ -346,6 +380,7 @@ function renderModal() {
       const design = collectDesign();
       const result = await getPlatform().createProject({
         ..._form,
+        destination,
         ...(_tab === "starter" && _starter ? { starter: _starter } : { template: _template }),
         ...(design ? { design } : {}),
       });
@@ -358,14 +393,9 @@ function renderModal() {
   };
 
   const onAgentSubmit = async () => {
-    if (!_form.name.trim()) {
-      _nameError = "Project name is required";
-      renderModal();
-      focusNameField();
+    const destination = validateParams();
+    if (!destination) {
       return;
-    }
-    if (!_form.directory.trim()) {
-      _form.directory = deriveSlug(_form.name);
     }
 
     _creating = true;
@@ -377,6 +407,7 @@ function renderModal() {
       const design = collectDesign();
       const result = await getPlatform().createProject({
         ..._form,
+        destination,
         template: "blank",
         ...(design ? { design } : {}),
       });
@@ -490,6 +521,7 @@ function renderModal() {
     <label class="new-project-field">
       <span class="new-project-label">Project Name *</span>
       <sp-textfield
+        class="new-project-name"
         placeholder="My Site"
         .value=${_form.name}
         ?invalid=${Boolean(_nameError)}
@@ -502,15 +534,11 @@ function renderModal() {
       </sp-textfield>
     </label>
 
-    <label class="new-project-field">
-      <span class="new-project-label">Directory</span>
-      <sp-textfield
-        placeholder="my-site"
-        .value=${_form.directory}
-        @input=${onInput("directory")}
-        style="width: 100%"
-      ></sp-textfield>
-    </label>
+    ${renderLocationFields({
+      onSlugInput: onInput("directory"),
+      rerender: renderModal,
+      slug: _form.directory,
+    })}
   `;
 
   const paramsBodyTpl = () => html`

--- a/packages/studio/src/platforms/cloud.ts
+++ b/packages/studio/src/platforms/cloud.ts
@@ -14,6 +14,7 @@
 import type { WsCollabConnection } from "@jxsuite/collab/client";
 import type { ProjectConfig } from "@jxsuite/schema/types";
 import type {
+  CreateProjectDestination,
   DirEntry,
   ExtensionsInfo,
   FsEvent,
@@ -212,6 +213,10 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
     /* Open Project routes through Studio's repo picker (write-access repos via listRepos +
        importProject) — sessions are URL-bound, so openProject() below never opens a dialog. */
     openProjectPicker: "repo-list",
+
+    /* A cloud project IS a GitHub repo, so the New Project modal collects the repository location
+       (owner, name, visibility) rather than a folder. */
+    createDestination: "repo",
 
     async activate() {
       if (!project) {
@@ -664,9 +669,17 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
       name: string;
       description?: string | undefined;
       directory: string;
+      destination: CreateProjectDestination;
       starter?: string | undefined;
       template?: string | undefined;
     }) {
+      // The repository location comes from the modal's Owner / Repository / Visibility fields —
+      // Never from a server-side default. The API resolves `owner` against the session login to
+      // Decide between /user/repos and /orgs/<owner>/repos.
+      const { destination } = opts;
+      if (destination.kind !== "repo" || !destination.owner || !destination.repo) {
+        throw new Error("A destination repository is required.");
+      }
       const res = await fetch("/api/v1/projects", {
         method: "POST",
         credentials: "include",
@@ -675,6 +688,9 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
           name: opts.name,
           description: opts.description,
           starter: opts.starter,
+          owner: destination.owner,
+          repo: destination.repo,
+          private: destination.private,
         }),
       });
       if (!res.ok) {

--- a/packages/studio/src/platforms/devserver.ts
+++ b/packages/studio/src/platforms/devserver.ts
@@ -9,9 +9,11 @@
  */
 
 import { streamImport } from "../services/import-client";
+import { canPickDirectory, pickDirectoryPath } from "../services/directory-picker";
 import type { WsCollabConnection } from "@jxsuite/collab/client";
 import type { ProjectConfig } from "@jxsuite/schema/types";
 import type {
+  CreateProjectDestination,
   DataConnectionsResponse,
   DataConnectionTestResult,
   DataPushResult,
@@ -98,6 +100,11 @@ export function createDevServerPlatform() {
 
   return {
     id: "devserver",
+
+    /* New projects go where the user says — the server refuses a create without a destination
+       rather than defaulting to its own root, which is the jx checkout when serving this
+       monorepo. */
+    createDestination: "path" as const,
 
     /** Get or set the current project root (absolute path). */
     get projectRoot() {
@@ -229,12 +236,16 @@ export function createDevServerPlatform() {
     // ─── Project creation ─────────────────────────────────────────────────
 
     /**
+     * Scaffold a project at `destination.parent/directory`. The dev server refuses the request
+     * outright when no destination is supplied — it will not fall back to its own root.
+     *
      * @param {{
      *   name: string;
      *   description?: string;
      *   url?: string;
      *   adapter?: string;
      *   directory: string;
+     *   destination: CreateProjectDestination;
      * }} opts
      */
     async createProject(opts: {
@@ -243,6 +254,7 @@ export function createDevServerPlatform() {
       url?: string;
       adapter?: string;
       directory: string;
+      destination: CreateProjectDestination;
       starter?: string;
       template?: string;
       design?: Record<string, unknown>;
@@ -258,6 +270,31 @@ export function createDevServerPlatform() {
       }
       return await res.json();
     },
+
+    /**
+     * Native folder chooser for the New Project modal's Browse… button. Present only when the
+     * browser implements `showDirectoryPicker` (Chromium-based); elsewhere the member stays
+     * undefined and the modal falls back to a typed Location field.
+     *
+     * The picked handle carries no filesystem path, so it is resolved by the id the picker tags the
+     * folder with (see `@jxsuite/studio/directory-picker`).
+     */
+    ...(canPickDirectory()
+      ? {
+          async pickDirectory(): Promise<string | null> {
+            return pickDirectoryPath(async ({ id, name }) => {
+              const res = await fetch(
+                `/__studio/locate-directory?name=${encodeURIComponent(name)}&id=${encodeURIComponent(id)}`,
+              );
+              if (!res.ok) {
+                return null;
+              }
+              const found = await readJson<{ path?: string }>(res);
+              return found.path ?? null;
+            });
+          },
+        }
+      : {}),
 
     /** List starter templates from the dev server. */
     async listStarters(): Promise<StarterInfo[]> {

--- a/packages/studio/src/services/ai-project-tools.ts
+++ b/packages/studio/src/services/ai-project-tools.ts
@@ -15,6 +15,7 @@
  */
 
 import { createToolDefinition } from "@jxsuite/ai/tools";
+import type { CreateProjectDestination } from "../types";
 import type { ToolRegistry, ToolResult } from "@jxsuite/ai/tools";
 import type { JxMutableNode } from "@jxsuite/schema/types";
 import { getPlatform } from "../platform";
@@ -400,7 +401,10 @@ export function registerProjectTools(
         "Create a new Jx project (project.json, conventional directories, starter pages) and open " +
         "it in the studio. Only available while no project is open. After it succeeds, the file " +
         "and document tools become available for building out the project. If the directory " +
-        "already exists, retry with a different directory slug.",
+        "already exists, retry with a different directory slug. Requires an explicit destination: " +
+        'on a filesystem platform pass "location" (an absolute parent folder); on the cloud pass ' +
+        '"owner" (a GitHub account or organization). Ask the user where to put it rather than ' +
+        "guessing — nothing is created without one.",
       parameters: {
         type: "object",
         properties: {
@@ -414,7 +418,24 @@ export function registerProjectTools(
           },
           directory: {
             type: "string",
-            description: "Directory slug to create the project in. Defaults to a slug of the name.",
+            description:
+              "Folder (or repository) name to create the project as. Defaults to a slug of the name.",
+          },
+          location: {
+            type: "string",
+            description:
+              "Absolute path of the EXISTING parent folder to create the project folder inside, " +
+              'e.g. "/home/you/Sites". Required on filesystem platforms (desktop, dev server).',
+          },
+          owner: {
+            type: "string",
+            description:
+              "GitHub account or organization to create the repository under. Required on the " +
+              "cloud platform.",
+          },
+          private: {
+            type: "boolean",
+            description: "Cloud only: repository visibility. Defaults to private.",
           },
           design: {
             type: "object",
@@ -426,12 +447,24 @@ export function registerProjectTools(
         required: ["name"],
       },
       async execute(args) {
-        const { name, description, template, directory, design } = args as {
+        const {
+          name,
+          description,
+          template,
+          directory,
+          design,
+          location,
+          owner,
+          private: isPrivate,
+        } = args as {
           name: string;
           description?: string;
           template?: string;
           directory?: string;
           design?: Record<string, string>;
+          location?: string;
+          owner?: string;
+          private?: boolean;
         };
         if (workspace.projectRoot) {
           return {
@@ -450,10 +483,45 @@ export function registerProjectTools(
           return { success: false, error: 'Could not derive a directory slug — pass "directory".' };
         }
 
+        // No destination, no project. The backend refuses one anyway; failing here gives the model
+        // A message it can act on instead of a wire error.
+        const platform = getPlatform();
+        let destination: CreateProjectDestination;
+        if (platform.createDestination === "repo") {
+          if (!owner?.trim()) {
+            return {
+              success: false,
+              error:
+                'Pass "owner" — the GitHub account or organization to create the repository under. ' +
+                "Ask the user which one to use.",
+            };
+          }
+          destination = {
+            kind: "repo",
+            owner: owner.trim(),
+            private: isPrivate ?? true,
+            repo: slug,
+          };
+        } else {
+          if (!location?.trim()) {
+            return {
+              success: false,
+              error:
+                'Pass "location" — the absolute path of the folder to create the project inside. ' +
+                "Ask the user where the project should live.",
+            };
+          }
+          if (!/^(?:[a-zA-Z]:[/\\]|\/)/.test(location.trim())) {
+            return { success: false, error: `"location" must be an absolute path: ${location}` };
+          }
+          destination = { kind: "path", parent: location.trim().replace(/[/\\]+$/, "") };
+        }
+
         let result: { root: string; config: object };
         try {
-          result = await getPlatform().createProject({
+          result = await platform.createProject({
             name,
+            destination,
             directory: slug,
             ...(description ? { description } : {}),
             ...(template ? { template } : {}),

--- a/packages/studio/src/services/directory-picker.ts
+++ b/packages/studio/src/services/directory-picker.ts
@@ -1,0 +1,115 @@
+/// <reference lib="dom" />
+/**
+ * Browser-side folder picking for the New Project modal's **Browse…** button.
+ *
+ * `showDirectoryPicker()` is the only native folder chooser a web page gets, but it hands back a
+ * `FileSystemDirectoryHandle` that exposes `.name` and nothing else — never a filesystem path
+ * (specs/desktop.md §8.2). Opening a project works around that by searching for the `project.json`
+ * the user pointed at, which is no help when choosing a _destination_: that folder is empty by
+ * definition, and often does not exist as a project at all.
+ *
+ * So the handle is made to identify itself. Using the readwrite grant the picker just issued, we
+ * drop a hidden {@link LOCATION_ID_FILE} holding a freshly generated id and ask the backend which
+ * directory holds that exact id. A fixed filename with the identity in its _contents_ is what makes
+ * the match unambiguous: two folders may share a basename, and a stale file from a crashed session
+ * may still be lying around, but only one file anywhere holds this id. The backend deletes the file
+ * as soon as it matches, and this module removes it too, so neither a lost tab nor a failed lookup
+ * leaves anything behind in the user's new project folder.
+ *
+ * Only the plain dev-server browser session needs this. Every packaged build has a real native
+ * dialog that returns a path directly and keeps it — electrobun's `Utils.openFileDialog`, and the
+ * NixOS chromium build's XDG desktop portal.
+ *
+ * @docs studio/projects/create
+ */
+
+import { LOCATION_ID_FILE } from "@jxsuite/protocol/routes";
+
+/** Re-exported so a caller wiring up `locate` need not also reach into the protocol package. */
+export { LOCATION_ID_FILE } from "@jxsuite/protocol/routes";
+
+/** The subset of the File System Access API this module uses. */
+interface WritableHandle {
+  createWritable: () => Promise<{
+    write: (data: string) => Promise<void>;
+    close: () => Promise<void>;
+  }>;
+}
+
+interface DirectoryHandle {
+  name: string;
+  getFileHandle: (name: string, opts?: { create?: boolean }) => Promise<WritableHandle>;
+  removeEntry: (name: string, opts?: { recursive?: boolean }) => Promise<void>;
+}
+
+type ShowDirectoryPicker = (opts?: {
+  id?: string;
+  mode?: "read" | "readwrite";
+  startIn?: string;
+}) => Promise<DirectoryHandle>;
+
+/** Whether this browser can open a native folder chooser at all. */
+export function canPickDirectory(): boolean {
+  return (
+    typeof (globalThis as { showDirectoryPicker?: unknown }).showDirectoryPicker === "function"
+  );
+}
+
+/** A location id: URL-safe, unguessable enough that a concurrent pick cannot collide. */
+function newLocationId(): string {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Open the browser's native folder chooser and resolve the chosen folder's absolute path.
+ *
+ * Resolves `null` when the user cancels, when the API is unavailable, or when the backend cannot
+ * place the folder (e.g. it lives outside the home directory the backend scans) — all three are "no
+ * destination chosen", which the caller already handles by leaving the Location field alone.
+ *
+ * MUST be called synchronously from a user gesture; `showDirectoryPicker()` is invoked before this
+ * function awaits anything so a click handler that calls it directly keeps the gesture.
+ *
+ * @param locate Ask the backend which directory holds `id`, given the handle's `name`.
+ */
+export async function pickDirectoryPath(
+  locate: (query: { name: string; id: string }) => Promise<string | null>,
+): Promise<string | null> {
+  const show = (globalThis as { showDirectoryPicker?: ShowDirectoryPicker }).showDirectoryPicker;
+  if (typeof show !== "function") {
+    return null;
+  }
+
+  let handle: DirectoryHandle;
+  try {
+    // `id` makes Chrome reopen at the last folder chosen for this purpose across sessions.
+    handle = await show({ id: "jx-new-project-location", mode: "readwrite", startIn: "documents" });
+  } catch {
+    // AbortError on cancel; a SecurityError if the gesture was lost. Neither is worth surfacing.
+    return null;
+  }
+
+  const id = newLocationId();
+  try {
+    const file = await handle.getFileHandle(LOCATION_ID_FILE, { create: true });
+    const writable = await file.createWritable();
+    await writable.write(id);
+    await writable.close();
+  } catch {
+    // Read-only grant or a folder we cannot write: not a usable project destination anyway.
+    return null;
+  }
+  try {
+    return await locate({ id, name: handle.name });
+  } catch {
+    return null;
+  } finally {
+    // The backend removes the file the moment it matches; this covers every path where it did not
+    // (no match, a network failure, a backend that never ran the lookup).
+    await handle.removeEntry(LOCATION_ID_FILE).catch(() => {
+      /* Already gone — the backend beat us to it. */
+    });
+  }
+}

--- a/packages/studio/src/types.ts
+++ b/packages/studio/src/types.ts
@@ -112,6 +112,20 @@ export interface RepoInfo {
   isJxProject: boolean;
 }
 
+/**
+ * Where a new project is written. The New Project modal collects this from the user and the backend
+ * MUST honor it — no backend may pick a destination on its own (see
+ * `StudioPlatform.createDestination`).
+ *
+ * - `"path"`: `parent` is an absolute filesystem directory; the project lands at
+ *   `parent/<directory>`.
+ * - `"repo"`: a remote repository — `owner` is a GitHub account or organization login, `repo` the
+ *   repository name, `private` its visibility.
+ */
+export type CreateProjectDestination =
+  | { kind: "path"; parent: string }
+  | { kind: "repo"; owner: string; repo: string; private: boolean };
+
 export interface StudioPlatform {
   id: string;
   projectRoot: string;
@@ -249,12 +263,21 @@ export interface StudioPlatform {
   gitClone?: (url: string) => Promise<{ ok: boolean; root: string }>;
   gitInit: () => Promise<void>;
   gitAddRemote: (name: string, url: string) => Promise<void>;
+  /**
+   * How the New Project modal collects a destination, and which `CreateProjectDestination` variant
+   * `createProject` requires. `"path"`: a Location field (absolute parent directory) plus a Browse…
+   * button over `pickDirectory`. `"repo"`: owner / repository-name / visibility fields. Every
+   * backend sets one — a project is never written to a destination the user did not choose.
+   */
+  createDestination: "path" | "repo";
   createProject: (opts: {
     name: string;
     description?: string;
     url?: string;
     adapter?: string;
     directory: string;
+    /** Where to write it. Required; its `kind` matches this platform's `createDestination`. */
+    destination: CreateProjectDestination;
     /** Id of a starter template to clone, or "blank"/undefined for the minimal template. */
     starter?: string;
     /** Id of a built-in template variant (from `@jxsuite/create/templates`); undefined = blank. */
@@ -286,8 +309,9 @@ export interface StudioPlatform {
     signal?: AbortSignal,
   ) => Promise<{ root: string; config: ProjectConfig }>;
   /**
-   * Open a native directory picker and return the chosen absolute path (null when cancelled).
-   * Desktop only; the dev server interprets directories relative to its root instead.
+   * Open a native directory picker and return the chosen absolute path (null when cancelled). Backs
+   * the New Project modal's **Browse…** button on `createDestination: "path"` platforms. Desktop
+   * only — the dev server has no native dialog, so its Location field is typed by hand.
    */
   pickDirectory?: () => Promise<string | null>;
   /** Stack B AI assistant: URL of the OpenAI-compatible SSE chat proxy (`/__studio/ai/chat`). */

--- a/packages/studio/tests/ai-project-tools.test.ts
+++ b/packages/studio/tests/ai-project-tools.test.ts
@@ -4,7 +4,8 @@
  * Drives the tools through a real ToolRegistry against the harness's in-memory platform: path
  * traversal guards, listing exclusions/caps, read truncation, write pre-validation (schema +
  * render), open-tab reconciliation (dirty refusal / clean reload), project.json config sync, and
- * the create_project → adopt → re-key handoff.
+ * the create_project → adopt → re-key handoff (including the required destination — "location" on
+ * path platforms, "owner" on repo platforms).
  */
 import { installMockPlatform, resetWorkspaceWithTab } from "./harness";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -12,7 +13,14 @@ import { createToolRegistry } from "@jxsuite/ai";
 import { registerProjectTools } from "../src/services/ai-project-tools";
 import type { ProjectToolsCtx } from "../src/services/ai-project-tools";
 import { closeAllTabs, setWorkspaceProject } from "../src/workspace/workspace";
-import type { DirEntry } from "../src/types";
+import type { CreateProjectDestination, DirEntry } from "../src/types";
+
+/** The shape of the `createProject` options the create_project tool sends to the platform. */
+interface CreateOpts {
+  name: string;
+  directory: string;
+  destination: CreateProjectDestination;
+}
 
 /** Directory listing over a plain path→content map that also understands the "." root. */
 function listingFor(files: Record<string, string>) {
@@ -311,19 +319,125 @@ describe("ai-project-tools — create_project", () => {
       // Simulate openRecentProject succeeding: the workspace now holds the project.
       setWorkspaceProject(root, { name: "New Site" });
     });
-    const createProject = mock(async (opts: { name: string; directory: string }) => ({
+    const createProject = mock(async (opts: CreateOpts) => ({
       config: { name: opts.name },
       root: `/abs/${opts.directory}`,
     }));
     const { registry } = makeHarness({}, { adoptProject, onProjectAdopted }, { createProject });
 
-    const res = await registry.execute("create_project", { name: "New Site!" });
+    const res = await registry.execute("create_project", {
+      location: "/home/dev/Sites",
+      name: "New Site!",
+    });
     expect(res.success).toBe(true);
     expect(res.summary).toContain("opened it");
-    // The directory slug derives from the name.
+    // The directory slug derives from the name; the location becomes the path destination.
     expect(createProject.mock.calls[0]![0]!.directory).toBe("new-site");
+    expect(createProject.mock.calls[0]![0]!.destination).toEqual({
+      kind: "path",
+      parent: "/home/dev/Sites",
+    });
     expect(adoptProject).toHaveBeenCalledWith("/abs/new-site");
     expect(onProjectAdopted).toHaveBeenCalledWith("/abs/new-site");
+  });
+
+  test("trailing slashes are trimmed off the location parent", async () => {
+    const createProject = mock(async (opts: CreateOpts) => ({
+      config: { name: opts.name },
+      root: `/abs/${opts.directory}`,
+    }));
+    const { registry } = makeHarness({}, {}, { createProject });
+    const res = await registry.execute("create_project", {
+      location: "/home/dev/Sites/",
+      name: "Trimmed",
+    });
+    expect(res.success).toBe(true);
+    expect(createProject.mock.calls[0]![0]!.destination).toEqual({
+      kind: "path",
+      parent: "/home/dev/Sites",
+    });
+  });
+
+  test("refuses without a location on a path platform, before touching the backend", async () => {
+    const { registry, state } = makeHarness();
+    const res = await registry.execute("create_project", { name: "Homeless" });
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("location");
+    expect(state.calls.some(([name]) => name === "createProject")).toBe(false);
+  });
+
+  test("rejects a relative location", async () => {
+    const { registry, state } = makeHarness();
+    const res = await registry.execute("create_project", {
+      location: "Sites/clients",
+      name: "Relative",
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("absolute path");
+    expect(state.calls.some(([name]) => name === "createProject")).toBe(false);
+  });
+
+  test("refuses without an owner on a repo platform", async () => {
+    const createProject = mock(async (opts: CreateOpts) => ({
+      config: { name: opts.name },
+      root: "owner/repo",
+    }));
+    const { registry } = makeHarness({}, {}, { createDestination: "repo", createProject });
+    // "Location" is meaningless on the cloud — it must still demand an owner.
+    const res = await registry.execute("create_project", {
+      location: "/home/dev/Sites",
+      name: "Cloudy",
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("owner");
+    expect(createProject).not.toHaveBeenCalled();
+  });
+
+  test("builds a private repo destination from the owner on a repo platform", async () => {
+    const adoptProject = mock(async (root: string) => {
+      setWorkspaceProject(root, { name: "Cloud Site" });
+    });
+    const createProject = mock(async (opts: CreateOpts) => ({
+      config: { name: opts.name },
+      root:
+        opts.destination.kind === "repo"
+          ? `${opts.destination.owner}/${opts.destination.repo}`
+          : "?",
+    }));
+    const { registry } = makeHarness(
+      {},
+      { adoptProject },
+      { createDestination: "repo", createProject },
+    );
+    const res = await registry.execute("create_project", { name: "Cloud Site!", owner: "acme" });
+    expect(res.success).toBe(true);
+    expect(createProject.mock.calls[0]![0]!.destination).toEqual({
+      kind: "repo",
+      owner: "acme",
+      private: true,
+      repo: "cloud-site",
+    });
+    expect(adoptProject).toHaveBeenCalledWith("acme/cloud-site");
+  });
+
+  test("honours an explicit public visibility on a repo platform", async () => {
+    const createProject = mock(async (opts: CreateOpts) => ({
+      config: { name: opts.name },
+      root: "acme/public-site",
+    }));
+    const { registry } = makeHarness({}, {}, { createDestination: "repo", createProject });
+    const res = await registry.execute("create_project", {
+      name: "Public Site",
+      owner: "acme",
+      private: false,
+    });
+    expect(res.success).toBe(true);
+    expect(createProject.mock.calls[0]![0]!.destination).toEqual({
+      kind: "repo",
+      owner: "acme",
+      private: false,
+      repo: "public-site",
+    });
   });
 
   test("refuses while a project is already open", async () => {
@@ -348,7 +462,10 @@ describe("ai-project-tools — create_project", () => {
         createProject: async () => ({ config: {}, root: "/abs/elsewhere" }),
       },
     );
-    const res = await registry.execute("create_project", { name: "Ghost" });
+    const res = await registry.execute("create_project", {
+      location: "/home/dev/Sites",
+      name: "Ghost",
+    });
     expect(res.success).toBe(true);
     expect(res.summary).toContain("not opened in this window");
     expect(onProjectAdopted).not.toHaveBeenCalled();
@@ -364,7 +481,10 @@ describe("ai-project-tools — create_project", () => {
         },
       },
     );
-    const res = await failing.registry.execute("create_project", { name: "Dup" });
+    const res = await failing.registry.execute("create_project", {
+      location: "/home/dev/Sites",
+      name: "Dup",
+    });
     expect(res.success).toBe(false);
     expect(res.error).toContain("directory exists");
 
@@ -377,7 +497,10 @@ describe("ai-project-tools — create_project", () => {
       },
       { createProject: async () => ({ config: {}, root: "/abs/x" }) },
     );
-    const res2 = await adoptFail.registry.execute("create_project", { name: "Solo" });
+    const res2 = await adoptFail.registry.execute("create_project", {
+      location: "/home/dev/Sites",
+      name: "Solo",
+    });
     expect(res2.success).toBe(true);
     expect(res2.summary).toContain("no adopter registered");
   });

--- a/packages/studio/tests/cloud-platform.test.ts
+++ b/packages/studio/tests/cloud-platform.test.ts
@@ -275,7 +275,12 @@ describe("project catalogue", () => {
     expect(await p.listStarters?.()).toEqual([starter]);
   });
 
-  test("createProject posts the starter selection and returns the root key", async () => {
+  test("the platform collects a repository destination, not a folder", () => {
+    expect(createCloudPlatform(null).createDestination).toBe("repo");
+    expect(createCloudPlatform(PROJECT).createDestination).toBe("repo");
+  });
+
+  test("createProject posts the chosen repository plus the starter selection", async () => {
     const calls = mockFetch({
       "/api/v1/projects": {
         body: { owner: "octocat", name: "my-site", defaultBranch: "main" },
@@ -286,6 +291,7 @@ describe("project catalogue", () => {
       name: "My Site",
       description: "hello",
       directory: "my-site",
+      destination: { kind: "repo", owner: "octocat", repo: "my-site", private: true },
       starter: "portfolio",
     });
     expect(created.root).toBe("octocat/my-site@main");
@@ -295,7 +301,59 @@ describe("project catalogue", () => {
       name: "My Site",
       description: "hello",
       starter: "portfolio",
+      owner: "octocat",
+      repo: "my-site",
+      private: true,
     });
+  });
+
+  test("createProject keys the created project off the SERVER's repo, not the request", async () => {
+    // The API may slugify the requested name and pick its own default branch.
+    mockFetch({
+      "/api/v1/projects": {
+        body: { owner: "acme-org", name: "my-site", defaultBranch: "trunk" },
+      },
+    });
+    const p = createCloudPlatform(null);
+    const created = await p.createProject({
+      name: "My Site",
+      directory: "my-site",
+      destination: { kind: "repo", owner: "acme-org", repo: "My Site!", private: false },
+    });
+    expect(created.root).toBe("acme-org/my-site@trunk");
+  });
+
+  test("createProject refuses a destination that names no repository", () => {
+    const calls = mockFetch({
+      "/api/v1/projects": {
+        body: { owner: "octocat", name: "my-site", defaultBranch: "main" },
+      },
+    });
+    const p = createCloudPlatform(null);
+    // A folder destination belongs to a "path" platform; cloud writes to a repository.
+    expect(
+      p.createProject({
+        name: "My Site",
+        directory: "my-site",
+        destination: { kind: "path", parent: "/home/dev/Sites" },
+      }),
+    ).rejects.toThrow("A destination repository is required.");
+    expect(
+      p.createProject({
+        name: "My Site",
+        directory: "my-site",
+        destination: { kind: "repo", owner: "", repo: "my-site", private: false },
+      }),
+    ).rejects.toThrow("A destination repository is required.");
+    expect(
+      p.createProject({
+        name: "My Site",
+        directory: "my-site",
+        destination: { kind: "repo", owner: "octocat", repo: "", private: false },
+      }),
+    ).rejects.toThrow("A destination repository is required.");
+    // Nothing was created server-side.
+    expect(calls).toHaveLength(0);
   });
 
   test("createProject surfaces the server's error message", async () => {
@@ -306,9 +364,13 @@ describe("project catalogue", () => {
       },
     });
     const p = createCloudPlatform(null);
-    expect(p.createProject({ name: "X", directory: "x" })).rejects.toThrow(
-      /GitHub blocked repository creation/,
-    );
+    expect(
+      p.createProject({
+        name: "X",
+        directory: "x",
+        destination: { kind: "repo", owner: "octocat", repo: "x", private: false },
+      }),
+    ).rejects.toThrow(/GitHub blocked repository creation/);
   });
 });
 
@@ -458,7 +520,11 @@ describe("identity & cloudflare surface", () => {
     });
     const p = createCloudPlatform(null);
     const failure = await p
-      .createProject({ directory: "site", name: "Site" })
+      .createProject({
+        directory: "site",
+        name: "Site",
+        destination: { kind: "repo", owner: "acme", repo: "site", private: false },
+      })
       .then(() => null)
       .catch((error: unknown) => error as Error & { code?: string; installUrl?: string });
     expect(failure?.message).toContain("blocked repository creation");

--- a/packages/studio/tests/devserver-platform.test.ts
+++ b/packages/studio/tests/devserver-platform.test.ts
@@ -8,7 +8,8 @@
 import "./harness";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createDevServerPlatform } from "../src/platforms/devserver";
-import type { FsEvent } from "../src/types";
+import { LOCATION_ID_FILE } from "@jxsuite/protocol/routes";
+import type { FsEvent, StudioPlatform } from "../src/types";
 
 /** Minimal EventSource stub: records the latest instance and lets tests emit named events. */
 class FakeEventSource {
@@ -122,6 +123,35 @@ function fakeDirHandle(name: string, config: unknown | null) {
 
 function setPicker(fn: unknown): void {
   (window as unknown as Record<string, unknown>).showDirectoryPicker = fn;
+}
+
+// ─── Fake directory handle for pickDirectory ─────────────────────────────────
+
+/**
+ * A picked NEW-project destination. The folder is empty by definition, so the handle carries no
+ * project.json — only the location-tag lifecycle the path recovery depends on. `written` holds the
+ * id the picker put in the tag, which is what the server matches on.
+ */
+function fakeDestHandle(name: string) {
+  const log = { created: [] as string[], removed: [] as string[], written: [] as string[] };
+  const handle = {
+    getFileHandle: async (file: string) => {
+      log.created.push(file);
+      return {
+        createWritable: async () => ({
+          close: async () => {},
+          write: async (data: string) => {
+            log.written.push(data);
+          },
+        }),
+      };
+    },
+    name,
+    removeEntry: async (file: string) => {
+      log.removed.push(file);
+    },
+  };
+  return { handle, log };
 }
 
 // ─── Basic identity, projectRoot, activate ───────────────────────────────────
@@ -347,28 +377,86 @@ describe("probeRootProject", () => {
 // ─── createProject ───────────────────────────────────────────────────────────
 
 describe("createProject", () => {
-  test("posts the options and returns the server response", async () => {
+  const dest = { kind: "path", parent: "/home/dev/Sites" } as const;
+
+  test("collects a path destination, with no picker when the browser lacks the API", () => {
+    // Typed as the interface, not the concrete literal: the point of the test is that an OPTIONAL
+    // Interface member is absent, which the literal's own type cannot express.
+    const p: StudioPlatform = createDevServerPlatform();
+    expect(p.createDestination).toBe("path");
+    // Without showDirectoryPicker there is no path-yielding folder chooser at all, so the modal
+    // Renders a typed Location field instead of a Browse… button.
+    expect(p.pickDirectory).toBeUndefined();
+  });
+
+  test("pickDirectory resolves the picked folder through /__studio/locate-directory", async () => {
+    const { handle, log } = fakeDestHandle("Sites");
+    setPicker(async () => handle);
+    route("/__studio/locate-directory", (c) => {
+      expect(c.search.get("name")).toBe("Sites");
+      // The id written INTO the tag file is what the server is asked to match on.
+      expect(c.search.get("id")).toBe(log.written[0]!);
+      return json({ path: "/home/dev/Sites" });
+    });
+    // The member is spread in at CONSTRUCTION time, so the stub must precede the platform.
+    const p: StudioPlatform = createDevServerPlatform();
+    expect(typeof p.pickDirectory).toBe("function");
+    expect(await p.pickDirectory!()).toBe("/home/dev/Sites");
+    expect(callsTo("/__studio/locate-directory").length).toBe(1);
+    // The tag is a throwaway with a fixed hidden name — it never outlives the pick.
+    expect(log.created).toEqual([LOCATION_ID_FILE]);
+    expect(log.removed).toEqual([LOCATION_ID_FILE]);
+  });
+
+  test("pickDirectory returns null when the locate route responds non-ok", async () => {
+    const { handle } = fakeDestHandle("Elsewhere");
+    setPicker(async () => handle);
+    route("/__studio/locate-directory", () => json({ error: "no home directory" }, 500));
+    const p: StudioPlatform = createDevServerPlatform();
+    // A folder the server cannot place is "no destination chosen", not an error to surface.
+    expect(await p.pickDirectory!()).toBeNull();
+  });
+
+  test("posts the options including the destination and returns the server response", async () => {
     route("/__studio/create-project", (c) => {
-      expect(c.body).toEqual({ directory: "examples", name: "fresh" });
-      return json({ config: { name: "fresh" }, root: "examples/fresh" });
+      expect(c.body).toEqual({ destination: dest, directory: "fresh", name: "fresh" });
+      return json({ config: { name: "fresh" }, root: "/home/dev/Sites/fresh" });
     });
     const p = createDevServerPlatform();
-    const result = await p.createProject({ directory: "examples", name: "fresh" });
-    expect(result).toEqual({ config: { name: "fresh" }, root: "examples/fresh" });
+    const result = await p.createProject({ destination: dest, directory: "fresh", name: "fresh" });
+    expect(result).toEqual({ config: { name: "fresh" }, root: "/home/dev/Sites/fresh" });
   });
 
   test("throws the server error message on failure", async () => {
     route("/__studio/create-project", () => json({ error: "directory exists" }, 400));
     const p = createDevServerPlatform();
-    expect(p.createProject({ directory: "x", name: "y" })).rejects.toThrow("directory exists");
+    expect(p.createProject({ destination: dest, directory: "x", name: "y" })).rejects.toThrow(
+      "directory exists",
+    );
   });
 
   test("throws a generic message when the error body has no error field", async () => {
     route("/__studio/create-project", () => json({}, 500));
     const p = createDevServerPlatform();
-    expect(p.createProject({ directory: "x", name: "y" })).rejects.toThrow(
+    expect(p.createProject({ destination: dest, directory: "x", name: "y" })).rejects.toThrow(
       "Failed to create project",
     );
+  });
+
+  test("surfaces the server's refusal when no destination was supplied", async () => {
+    route("/__studio/create-project", (c) => {
+      expect((c.body as { destination?: unknown }).destination).toBeUndefined();
+      return json({ error: "A destination folder is required." }, 400);
+    });
+    const p = createDevServerPlatform();
+    // The adapter forwards whatever the modal collected.
+    // Refusing an absent destination is the server's job, and its message must reach the caller.
+    expect(
+      p.createProject({
+        directory: "x",
+        name: "y",
+      } as unknown as Parameters<typeof p.createProject>[0]),
+    ).rejects.toThrow("A destination folder is required.");
   });
 });
 

--- a/packages/studio/tests/directory-picker.test.ts
+++ b/packages/studio/tests/directory-picker.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for src/services/directory-picker.ts — the browser-side folder chooser behind the New
+ * Project modal's **Browse…** button.
+ *
+ * `showDirectoryPicker()` hands back a handle that knows only its own `.name`, so the module tags
+ * the picked folder with a hidden `.jx-loc-id` whose CONTENTS are a one-shot random id, and asks a
+ * caller-supplied `locate` which directory carries that id. These tests stub
+ * `globalThis.showDirectoryPicker` (no DOM needed — the module reads the global lazily inside each
+ * call) and assert the whole contract: the options handed to the picker, that the id written to
+ * disk is the same id sent to the backend, every failure path resolving `null`, and the tag being
+ * cleaned up even when `locate` throws. Every stubbed global is restored in `afterEach`.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  LOCATION_ID_FILE,
+  canPickDirectory,
+  pickDirectoryPath,
+} from "../src/services/directory-picker";
+
+// ─── Global stubbing ─────────────────────────────────────────────────────────
+
+interface PickerOptions {
+  id?: string;
+  mode?: string;
+  startIn?: string;
+}
+
+interface LocateQuery {
+  id: string;
+  name: string;
+}
+
+/** One `getFileHandle` call recorded by the handle double. */
+interface CreatedEntry {
+  name: string;
+  options?: { create?: boolean };
+}
+
+const globals = globalThis as Record<string, unknown>;
+const REAL_PICKER = globals.showDirectoryPicker;
+
+/** Install (or, with `undefined`, remove) the `showDirectoryPicker` global. */
+function setPicker(fn: unknown): void {
+  if (fn === undefined) {
+    delete globals.showDirectoryPicker;
+  } else {
+    globals.showDirectoryPicker = fn;
+  }
+}
+
+afterEach(() => {
+  setPicker(REAL_PICKER);
+});
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/**
+ * A `FileSystemDirectoryHandle` double recording the entries created and removed on it, and the
+ * bytes written through each writable — the written id is the whole identification mechanism.
+ */
+class FakeDirectoryHandle {
+  readonly created: CreatedEntry[] = [];
+  readonly removed: string[] = [];
+  readonly written: string[] = [];
+  /** Whether every writable opened on this handle was closed (an unclosed one never flushes). */
+  closed = 0;
+  readonly name: string;
+  createError: Error | null = null;
+  writeError: Error | null = null;
+  removeError: Error | null = null;
+
+  constructor(name = "Projects") {
+    this.name = name;
+  }
+
+  getFileHandle(name: string, options?: { create?: boolean }): Promise<unknown> {
+    this.created.push({ name, ...(options ? { options } : {}) });
+    // A read-only grant rejects here rather than silently doing nothing.
+    if (this.createError) {
+      return Promise.reject(this.createError);
+    }
+    return Promise.resolve({
+      createWritable: () => {
+        if (this.writeError) {
+          return Promise.reject(this.writeError);
+        }
+        return Promise.resolve({
+          close: () => {
+            this.closed += 1;
+            return Promise.resolve();
+          },
+          write: (data: string) => {
+            this.written.push(data);
+            return Promise.resolve();
+          },
+        });
+      },
+    });
+  }
+
+  removeEntry(name: string): Promise<void> {
+    this.removed.push(name);
+    return this.removeError ? Promise.reject(this.removeError) : Promise.resolve();
+  }
+}
+
+/**
+ * Stub `showDirectoryPicker` with one that resolves `outcome` (or rejects when it is an `Error`),
+ * returning the array the options of every call are recorded into.
+ */
+function installPicker(outcome: FakeDirectoryHandle | Error): PickerOptions[] {
+  const calls: PickerOptions[] = [];
+  setPicker((options?: PickerOptions) => {
+    calls.push(options ?? {});
+    return outcome instanceof Error ? Promise.reject(outcome) : Promise.resolve(outcome);
+  });
+  return calls;
+}
+
+/** A `locate` double resolving `outcome` (or rejecting when it is an `Error`), plus its call log. */
+function recordLocate(outcome: string | null | Error): {
+  calls: LocateQuery[];
+  locate: (query: LocateQuery) => Promise<string | null>;
+} {
+  const calls: LocateQuery[] = [];
+  return {
+    calls,
+    locate: (query) => {
+      calls.push(query);
+      return outcome instanceof Error ? Promise.reject(outcome) : Promise.resolve(outcome);
+    },
+  };
+}
+
+/** The rejection Chrome produces when the user dismisses the folder chooser. */
+function abortError(): Error {
+  const error = new Error("The user aborted a request.");
+  error.name = "AbortError";
+  return error;
+}
+
+// ─── Availability ────────────────────────────────────────────────────────────
+
+describe("canPickDirectory", () => {
+  test("is false when the browser has no File System Access API", () => {
+    setPicker(undefined);
+    expect(canPickDirectory()).toBe(false);
+  });
+
+  test("is true only when the global is callable", () => {
+    installPicker(new FakeDirectoryHandle());
+    expect(canPickDirectory()).toBe(true);
+    // A non-function value (an over-eager polyfill shim) must not count as support.
+    setPicker({});
+    expect(canPickDirectory()).toBe(false);
+  });
+});
+
+// ─── pickDirectoryPath ───────────────────────────────────────────────────────
+
+describe("pickDirectoryPath without the API", () => {
+  test("resolves null without ever consulting the backend", async () => {
+    setPicker(undefined);
+    const { calls, locate } = recordLocate("/home/dev/Projects");
+
+    expect(await pickDirectoryPath(locate)).toBeNull();
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("pickDirectoryPath with the API", () => {
+  test("opens the chooser with the stable id, readwrite grant, and documents start", async () => {
+    const picked = installPicker(new FakeDirectoryHandle());
+    const { locate } = recordLocate("/home/dev/Projects");
+
+    await pickDirectoryPath(locate);
+
+    expect(picked).toEqual([
+      { id: "jx-new-project-location", mode: "readwrite", startIn: "documents" },
+    ]);
+  });
+
+  test("writes the id into the hidden tag file and sends that same id to the backend", async () => {
+    const handle = new FakeDirectoryHandle("Projects");
+    installPicker(handle);
+    const { calls, locate } = recordLocate("/home/dev/Projects");
+
+    expect(await pickDirectoryPath(locate)).toBe("/home/dev/Projects");
+
+    expect(calls).toHaveLength(1);
+    const { id, name } = calls[0]!;
+    expect(name).toBe("Projects");
+    // The backend matches on the FILE CONTENTS, so the two must be the same string.
+    expect(handle.written).toEqual([id]);
+    // The writable is closed, or the bytes would never reach disk.
+    expect(handle.closed).toBe(1);
+    // The tag is a fixed hidden filename, not a random one.
+    expect(handle.created).toEqual([{ name: LOCATION_ID_FILE, options: { create: true } }]);
+    expect(LOCATION_ID_FILE).toBe(".jx-loc-id");
+    // The id must survive the server's `/^[a-f0-9]{32}$/` validation.
+    expect(id).toMatch(/^[a-f0-9]{32}$/);
+    // Cleaned up rather than left behind in the user's new project folder.
+    expect(handle.removed).toEqual([LOCATION_ID_FILE]);
+  });
+
+  test("uses a fresh id for every pick", async () => {
+    const handle = new FakeDirectoryHandle();
+    installPicker(handle);
+    const { calls, locate } = recordLocate("/home/dev/Projects");
+
+    await pickDirectoryPath(locate);
+    await pickDirectoryPath(locate);
+
+    // A reused id would let a stale tag from an earlier pick claim a later one.
+    expect(calls[0]!.id).not.toBe(calls[1]!.id);
+    expect(handle.written[0]).not.toBe(handle.written[1]);
+  });
+
+  test("resolves null and writes nothing when the user cancels", async () => {
+    const handle = new FakeDirectoryHandle();
+    installPicker(abortError());
+    const { calls, locate } = recordLocate("/home/dev/Projects");
+
+    expect(await pickDirectoryPath(locate)).toBeNull();
+    expect(handle.created).toEqual([]);
+    expect(handle.removed).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test("resolves null without calling locate when the tag cannot be created", async () => {
+    const handle = new FakeDirectoryHandle();
+    handle.createError = new Error("NotAllowedError");
+    installPicker(handle);
+    const { calls, locate } = recordLocate("/home/dev/Projects");
+
+    expect(await pickDirectoryPath(locate)).toBeNull();
+    expect(handle.created).toHaveLength(1);
+    expect(calls).toEqual([]);
+    // Nothing was created, so there is nothing to clean up.
+    expect(handle.removed).toEqual([]);
+  });
+
+  test("resolves null without calling locate when the tag cannot be written", async () => {
+    const handle = new FakeDirectoryHandle();
+    handle.writeError = new Error("NoModificationAllowedError");
+    installPicker(handle);
+    const { calls, locate } = recordLocate("/home/dev/Projects");
+
+    expect(await pickDirectoryPath(locate)).toBeNull();
+    expect(handle.written).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test("resolves null when the backend cannot place the folder", async () => {
+    const handle = new FakeDirectoryHandle();
+    installPicker(handle);
+    const { locate } = recordLocate(null);
+
+    expect(await pickDirectoryPath(locate)).toBeNull();
+    // The backend never claimed it, so this side must clear the tag.
+    expect(handle.removed).toEqual([LOCATION_ID_FILE]);
+  });
+
+  test("resolves null but still clears the tag when locate throws", async () => {
+    const handle = new FakeDirectoryHandle();
+    installPicker(handle);
+    const { locate } = recordLocate(new Error("500 from /__studio/locate-directory"));
+
+    expect(await pickDirectoryPath(locate)).toBeNull();
+    expect(handle.removed).toEqual([LOCATION_ID_FILE]);
+  });
+
+  test("still returns the path when cleanup fails", async () => {
+    const handle = new FakeDirectoryHandle();
+    // The backend deletes the tag the moment it matches, so removeEntry losing the race is the
+    // Expected case — never a reason to fail a pick the user already made.
+    handle.removeError = new Error("NotFoundError");
+    installPicker(handle);
+    const { locate } = recordLocate("/home/dev/Projects");
+
+    expect(await pickDirectoryPath(locate)).toBe("/home/dev/Projects");
+    expect(handle.removed).toEqual([LOCATION_ID_FILE]);
+  });
+});

--- a/packages/studio/tests/document-assistant.test.ts
+++ b/packages/studio/tests/document-assistant.test.ts
@@ -325,7 +325,8 @@ describe("document-assistant — state-gated tools & bootstrap", () => {
       setWorkspaceProject(root, { name: "Fresh" });
     });
     nextRounds = [
-      toolCallRound("c1", "create_project", { name: "Fresh Site" }),
+      // The model must name a destination — create_project refuses without one.
+      toolCallRound("c1", "create_project", { location: "/home/dev/Sites", name: "Fresh Site" }),
       [
         { content: "Project ready", type: "delta" },
         { stopReason: "stop", type: "done" },

--- a/packages/studio/tests/harness.ts
+++ b/packages/studio/tests/harness.ts
@@ -128,10 +128,14 @@ export function installMockPlatform(
     addPackage: log("addPackage", async () => ({})),
     aiChatUrl: log("aiChatUrl", () => "/__mock/ai/chat"),
     codeService: log("codeService", async () => null),
+    createDestination: "path",
     createDirectory: log("createDirectory", async () => {}),
     createProject: log("createProject", async (opts) => ({
       config: { name: opts.name },
-      root: `${opts.directory}/${opts.name}`,
+      root:
+        opts.destination.kind === "path"
+          ? `${opts.destination.parent}/${opts.directory}`
+          : `${opts.destination.owner}/${opts.destination.repo}`,
     })),
     deleteFile: log("deleteFile", async (path) => {
       state.files.delete(path);
@@ -233,6 +237,49 @@ export function setValue(el: HTMLInputElement | HTMLTextAreaElement, value: stri
   el.value = value;
   el.dispatchEvent(new Event("input", { bubbles: true }));
   el.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+// ─── New Project modal field accessors ───────────────────────────────────────
+// The Parameters step renders a destination block between the name and description whose shape
+// Depends on the platform's `createDestination` (specs/desktop.md §4.5), so positional indexing
+// Into the textfield list is not stable. Address the identity/destination fields by class.
+
+/** A New Project Parameters-step field by its stable class suffix. */
+function npField(suffix: string): HTMLInputElement {
+  return document.querySelector(`#layer-modal .new-project-${suffix}`) as HTMLInputElement;
+}
+
+/** The Project Name textfield. */
+export const npName = () => npField("name");
+/** The Location textfield (`createDestination: "path"` platforms). */
+export const npLocation = () => npField("location");
+/** The Directory / Repository textfield — one slug shared by both destination shapes. */
+export const npSlug = () => npField("slug");
+/** The Owner field (`createDestination: "repo"` platforms; a picker once owners have loaded). */
+export const npOwner = () => npField("owner");
+
+/** The resolved-destination preview line under the fields. */
+export function npPreview(): string {
+  return (
+    document
+      .querySelector("#layer-modal .new-project-destination-preview")
+      ?.textContent?.trim()
+      .replaceAll(/\s+/g, " ") ?? ""
+  );
+}
+
+/** Set a New Project textfield's value and fire the input event the modal listens for. */
+export function npType(el: HTMLInputElement, value: string): void {
+  el.value = value;
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/**
+ * Fill the Location field so a create can proceed. Every filesystem-platform create needs one — the
+ * modal blocks submit without it and the backend refuses it.
+ */
+export function npFillLocation(parent = "/home/dev/Sites"): void {
+  npType(npLocation(), parent);
 }
 
 // ─── happy-dom gap stubs ──────────────────────────────────────────────────────

--- a/packages/studio/tests/new-project-agent-tab.test.ts
+++ b/packages/studio/tests/new-project-agent-tab.test.ts
@@ -2,8 +2,11 @@
  * The New Project wizard's Agent flow: the credentials gate and prompt validation on the source
  * step, then the scaffold-then-seed flow from the Parameters step (createProject with the blank
  * template + a pending agent prompt stored for the opening window's assistant).
+ *
+ * The Agent submit runs the same destination validation as a normal create, so a project is only
+ * ever scaffolded under the Location the user chose.
  */
-import { flush, installMockPlatform } from "./harness";
+import { flush, installMockPlatform, npFillLocation, npName, npPreview, npType } from "./harness";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 const { closeNewProjectModal, openNewProjectModal } =
@@ -17,14 +20,18 @@ document.body.innerHTML = `
 `;
 initLayers();
 
-/** Source step: field(0) = prompt. Parameters step: name(0), directory(1). */
-function field(index: number): any {
-  return document.querySelectorAll("#layer-modal sp-textfield")[index];
+/** The multiline prompt field on the Agent source step. */
+function promptField(): any {
+  return document.querySelector("#layer-modal .new-project-agent-prompt");
 }
 
-function typeInto(el: any, value: string) {
-  el.value = value;
-  el.dispatchEvent(new Event("input", { bubbles: true }));
+/** The inline destination validation message rendered under the Location fields. */
+function inlineError(): string {
+  return (
+    document
+      .querySelector("#layer-modal .new-project-error:not(.new-project-error--global)")
+      ?.textContent?.trim() ?? ""
+  );
 }
 
 function footerButtons(): any[] {
@@ -65,7 +72,7 @@ describe("Agent flow", () => {
     void openNewProjectModal();
     switchTab("agent");
     expect(document.querySelector("#layer-modal .new-project-creds")).toBeNull();
-    expect(document.querySelector("#layer-modal .new-project-agent-prompt")).toBeTruthy();
+    expect(promptField()).toBeTruthy();
 
     clickFooter("Next");
     expect(document.querySelector("#layer-modal .new-project-error")?.textContent).toContain(
@@ -80,20 +87,41 @@ describe("Agent flow", () => {
     const { state } = installMockPlatform();
     void openNewProjectModal();
     switchTab("agent");
-    typeInto(field(0), "A cozy site");
+    npType(promptField(), "A cozy site");
     clickFooter("Next");
+    npFillLocation();
     clickFooter("Create & Start Agent");
     await flush();
     // The message renders inline at the name field, not in the global strip.
     expect(
       document
-        .querySelector('#layer-modal sp-textfield sp-help-text[slot="negative-help-text"]')
+        .querySelector('#layer-modal .new-project-name sp-help-text[slot="negative-help-text"]')
         ?.textContent?.trim(),
     ).toBe("Project name is required");
     expect(state.calls.filter((c) => c[0] === "createProject")).toHaveLength(0);
   });
 
-  test("scaffolds a blank project and stores the pending agent prompt", async () => {
+  test("blocks the agent create until a Location is chosen", async () => {
+    localStorage.setItem("jx.ai.openaiKey", "sk-agent-test");
+    const { state } = installMockPlatform();
+    void openNewProjectModal();
+    switchTab("agent");
+    npType(promptField(), "A cozy site");
+    clickFooter("Next");
+    // Everything but the destination is filled in — the modal never guesses where to write.
+    npType(npName(), "Agent Site");
+    clickFooter("Create & Start Agent");
+    await flush();
+
+    expect(inlineError()).toBe("Choose a location for the project folder");
+    expect(state.calls.filter((c) => c[0] === "createProject")).toHaveLength(0);
+    // The prompt is only stored once a project exists to key it on.
+    expect(
+      Object.keys(localStorage).filter((k) => k.startsWith("jx.ai.pendingAgentPrompt:")),
+    ).toHaveLength(0);
+  });
+
+  test("scaffolds a blank project at the chosen location and stores the pending agent prompt", async () => {
     localStorage.setItem("jx.ai.openaiKey", "sk-agent-test");
     const created: Record<string, unknown>[] = [];
     installMockPlatform({
@@ -105,13 +133,15 @@ describe("Agent flow", () => {
 
     const promise = openNewProjectModal();
     switchTab("agent");
-    typeInto(field(0), "A landing page for a coffee roastery");
+    npType(promptField(), "A landing page for a coffee roastery");
     clickFooter("Next");
     // The agent scaffolds from the blank template; its breakpoint preset prefills the editor.
     expect(document.querySelector("#layer-modal .new-project-step-context")?.textContent).toContain(
       "Agent",
     );
-    typeInto(field(0), "Agent Site");
+    npType(npName(), "Agent Site");
+    npFillLocation("/home/dev/Sites");
+    expect(npPreview()).toBe("Creates: /home/dev/Sites/agent-site");
     clickFooter("Create & Start Agent");
 
     const result = await promise;
@@ -121,6 +151,7 @@ describe("Agent flow", () => {
     } as never);
 
     expect(created[0]).toMatchObject({
+      destination: { kind: "path", parent: "/home/dev/Sites" },
       directory: "agent-site",
       name: "Agent Site",
       template: "blank",
@@ -128,6 +159,7 @@ describe("Agent flow", () => {
     // Untouched design prefills are not sent.
     expect((created[0] as { design?: unknown }).design).toBeUndefined();
 
+    // The prompt is keyed on the root the platform reported, not on the destination the modal sent.
     const stored = localStorage.getItem("jx.ai.pendingAgentPrompt:/projects/agent-site");
     expect(stored).toBeTruthy();
     expect(JSON.parse(stored!).prompt).toBe("A landing page for a coffee roastery");

--- a/packages/studio/tests/new-project-coverage-gaps.test.ts
+++ b/packages/studio/tests/new-project-coverage-gaps.test.ts
@@ -2,11 +2,21 @@
  * Coverage-gap tests for the New Project wizard and the Add Existing Repository picker:
  *
  * - New-project-modal: the credentials-gate re-render callbacks, the Template context label, starter
- *   selection + missing-selection validation, the busy guards on Back/tab-change, and the agent
- *   submit's directory derivation + failure surface.
+ *   selection + missing-selection validation, the busy guards on Back/tab-change, the agent
+ *   submit's directory derivation + failure surface, and the destination fields surviving a
+ *   Back/Next round-trip.
  * - Add-repo-modal: double-open, double-import, import-less platforms, and Escape dismissal.
  */
-import { flush, installMockPlatform } from "./harness";
+import {
+  flush,
+  installMockPlatform,
+  npFillLocation,
+  npLocation,
+  npName,
+  npPreview,
+  npSlug,
+  npType,
+} from "./harness";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { RepoInfo, StarterInfo } from "../src/types";
 
@@ -24,13 +34,16 @@ initLayers();
 
 type AnyEl = HTMLElement & { value?: string; selected?: string };
 
-function field(index: number): AnyEl {
-  return document.querySelectorAll("#layer-modal sp-textfield")[index] as AnyEl;
-}
-
-function typeInto(el: AnyEl, value: string) {
-  el.value = value;
-  el.dispatchEvent(new Event("input", { bubbles: true }));
+/**
+ * A Parameters-step textfield addressed by its visible label. The identity and destination fields
+ * carry stable classes (see the harness `np*` accessors); the remaining ones don't, and positional
+ * indexing is not stable now that a destination block sits between the name and the description.
+ */
+function labelledField(label: string): AnyEl {
+  const match = [...document.querySelectorAll("#layer-modal .new-project-field")].find(
+    (f) => f.querySelector(".new-project-label")?.textContent?.trim() === label,
+  );
+  return match!.querySelector("sp-textfield") as AnyEl;
 }
 
 function footerButtons(): AnyEl[] {
@@ -147,8 +160,7 @@ describe("new-project modal gaps", () => {
     clickFooter("Next");
     expect(contextText()).toContain("Starter Site · Bakery");
     // The starter's tagline seeds the description field.
-    const description = field(2);
-    expect(description.value).toBe("Fresh daily");
+    expect(labelledField("Description").value).toBe("Fresh daily");
   });
 
   test("Back and tab switches are ignored while a create is in flight", async () => {
@@ -164,7 +176,8 @@ describe("new-project modal gaps", () => {
     const promise = openNewProjectModal();
     const staleTabs = document.querySelector("#layer-modal sp-tabs") as AnyEl;
     clickFooter("Next");
-    typeInto(field(0), "Slow Site");
+    npType(npName(), "Slow Site");
+    npFillLocation();
     clickFooter("Create Project");
     expect(footerButtons().some((b) => b.textContent?.includes("Creating…"))).toBe(true);
 
@@ -193,19 +206,42 @@ describe("new-project modal gaps", () => {
     });
     void openNewProjectModal();
     switchTab("agent");
-    typeInto(field(0), "A tiny site");
+    npType(
+      document.querySelector("#layer-modal .new-project-agent-prompt") as HTMLInputElement,
+      "A tiny site",
+    );
     clickFooter("Next");
-    typeInto(field(0), "Failing Agent Site");
-    typeInto(field(1), ""); // Clear the derived directory — submit must re-derive it.
+    npType(npName(), "Failing Agent Site");
+    npType(npSlug(), ""); // Clear the derived directory — submit must re-derive it.
+    npFillLocation("/home/dev/Sites");
     clickFooter("Create & Start Agent");
     await flush();
 
     expect(attempts[0]).toMatchObject({
+      destination: { kind: "path", parent: "/home/dev/Sites" },
       directory: "failing-agent-site",
       name: "Failing Agent Site",
       template: "blank",
     });
     expect(errorText()).toContain("quota exceeded");
+  });
+
+  test("the chosen Location survives a Back → Next round-trip", () => {
+    installMockPlatform();
+    void openNewProjectModal();
+    clickFooter("Next");
+    npType(npName(), "Round Trip");
+    npFillLocation("/home/dev/Sites");
+    expect(npPreview()).toContain("/home/dev/Sites/round-trip");
+
+    clickFooter("Back");
+    expect(document.querySelector("#layer-modal .new-project-location")).toBeNull();
+    clickFooter("Next");
+
+    // The destination fields keep the user's edits, like the rest of the Parameters step.
+    expect(npLocation().value).toBe("/home/dev/Sites");
+    expect(npSlug().value).toBe("round-trip");
+    expect(npPreview()).toContain("/home/dev/Sites/round-trip");
   });
 });
 

--- a/packages/studio/tests/new-project-design.test.ts
+++ b/packages/studio/tests/new-project-design.test.ts
@@ -1,9 +1,9 @@
 /**
  * The design-quickstart section of the New Project Parameters step: color/font/logo/breakpoint
- * overrides threaded into createProject as `design`, prefill-suppression (untouched values are not
- * sent), and the logo file gate.
+ * overrides threaded into createProject as `design` alongside the chosen `destination`,
+ * prefill-suppression (untouched values are not sent), and the logo file gate.
  */
-import { flush, installMockPlatform } from "./harness";
+import { flush, installMockPlatform, npFillLocation, npLocation, npName, npType } from "./harness";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 const { closeNewProjectModal, openNewProjectModal } =
@@ -17,14 +17,8 @@ document.body.innerHTML = `
 `;
 initLayers();
 
-function field(index: number): any {
-  return document.querySelectorAll("#layer-modal sp-textfield")[index];
-}
-
-function typeInto(el: any, value: string) {
-  el.value = value;
-  el.dispatchEvent(new Event("input", { bubbles: true }));
-}
+/** The Location the design tests create into (mirrors the harness default). */
+const LOCATION = "/home/dev/Sites";
 
 function footerButtons(): any[] {
   return [...document.querySelectorAll("#layer-modal .new-project-modal-footer sp-button")];
@@ -45,12 +39,21 @@ function fontField(index: number): any {
   return sections[1]?.querySelectorAll("sp-textfield")[index];
 }
 
+function mediaRows(): NodeListOf<Element> {
+  return document.querySelectorAll("#layer-modal .new-project-media-row");
+}
+
 function mediaRow(index: number): { name: any; value: any } {
-  const rows = document.querySelectorAll("#layer-modal .new-project-media-row");
+  const rows = mediaRows();
   return {
     name: rows[index]?.querySelector(".new-project-media-name"),
     value: rows[index]?.querySelector(".new-project-media-value"),
   };
+}
+
+/** The first inline error in the modal body (destination errors precede the design sections). */
+function inlineError(): string {
+  return document.querySelector("#layer-modal .new-project-error")?.textContent ?? "";
 }
 
 let created: Record<string, unknown>[] = [];
@@ -79,20 +82,23 @@ afterEach(() => {
 describe("design quickstart", () => {
   test("colors, fonts, and edited breakpoints travel as the design payload", async () => {
     const promise = openToParams();
-    typeInto(field(0), "Styled Site");
+    npType(npName(), "Styled Site");
+    npFillLocation(LOCATION);
 
-    typeInto(colorField(0), "#ff2200"); // Accent
-    typeInto(colorField(1), "#fffbe6"); // Background
-    typeInto(colorField(2), "#222222"); // Text
-    typeInto(fontField(0), "'Inter', sans-serif");
-    typeInto(fontField(1), "'Fraunces', serif");
+    npType(colorField(0), "#ff2200"); // Accent
+    npType(colorField(1), "#fffbe6"); // Background
+    npType(colorField(2), "#222222"); // Text
+    npType(fontField(0), "'Inter', sans-serif");
+    npType(fontField(1), "'Fraunces', serif");
     // Edit one of the prefilled breakpoint rows (blank template preset: --, --lg, --md, --sm).
-    typeInto(mediaRow(1).value, "(max-width: 1100px)");
+    npType(mediaRow(1).value, "(max-width: 1100px)");
 
     clickFooter("Create Project");
     await promise;
 
-    const opts = created[0] as { design: Record<string, unknown> };
+    const opts = created[0] as { design: Record<string, unknown>; destination: unknown };
+    // The design overrides ride alongside the destination the user chose, not instead of it.
+    expect(opts.destination).toEqual({ kind: "path", parent: LOCATION });
     expect(opts.design).toEqual({
       accent: "#ff2200",
       background: "#fffbe6",
@@ -110,7 +116,8 @@ describe("design quickstart", () => {
 
   test("removing and adding breakpoint rows counts as an edit", async () => {
     const promise = openToParams();
-    typeInto(field(0), "Break Site");
+    npType(npName(), "Break Site");
+    npFillLocation(LOCATION);
 
     // Remove the last prefilled row, then add a custom one.
     const removeButtons = [
@@ -121,10 +128,9 @@ describe("design quickstart", () => {
       b.textContent?.includes("Add Breakpoint"),
     );
     addBtn!.dispatchEvent(new Event("click", { bubbles: true }));
-    const rows = [...document.querySelectorAll("#layer-modal .new-project-media-row")];
-    const last = rows.at(-1)!;
-    typeInto(last.querySelector(".new-project-media-name"), "--xl");
-    typeInto(last.querySelector(".new-project-media-value"), "(max-width: 1600px)");
+    const last = mediaRow(mediaRows().length - 1);
+    npType(last.name, "--xl");
+    npType(last.value, "(max-width: 1600px)");
 
     clickFooter("Create Project");
     await promise;
@@ -136,7 +142,8 @@ describe("design quickstart", () => {
 
   test("a selected logo file is base64-encoded into the payload; bad extensions are rejected", async () => {
     const promise = openToParams();
-    typeInto(field(0), "Logo Site");
+    npType(npName(), "Logo Site");
+    npFillLocation(LOCATION);
 
     const input = document.querySelector(
       "#layer-modal .new-project-logo-row input[type=file]",
@@ -149,9 +156,7 @@ describe("design quickstart", () => {
     });
     input.dispatchEvent(new Event("change", { bubbles: true }));
     await flush();
-    expect(document.querySelector("#layer-modal .new-project-error")?.textContent).toContain(
-      "SVG, PNG",
-    );
+    expect(inlineError()).toContain("SVG, PNG");
 
     // A valid image is read and encoded.
     Object.defineProperty(input, "files", {
@@ -171,9 +176,38 @@ describe("design quickstart", () => {
 
   test("an untouched Parameters step sends no design payload at all", async () => {
     const promise = openToParams();
-    typeInto(field(0), "Plain Site");
+    npType(npName(), "Plain Site");
+    npFillLocation(LOCATION);
     clickFooter("Create Project");
     await promise;
-    expect((created[0] as { design?: unknown }).design).toBeUndefined();
+    const opts = created[0] as { design?: unknown; destination: unknown };
+    expect(opts.design).toBeUndefined();
+    expect(opts.destination).toEqual({ kind: "path", parent: LOCATION });
+  });
+
+  test("a missing Location blocks the create and keeps the design edits for the retry", async () => {
+    const promise = openToParams();
+    npType(npName(), "Homeless Site");
+    npType(colorField(0), "#0a84ff");
+
+    clickFooter("Create Project");
+    await flush();
+    expect(created).toHaveLength(0);
+    expect(inlineError()).toContain("Choose a location for the project folder");
+
+    // A relative path is refused too — the backend only ever writes to an absolute parent.
+    npType(npLocation(), "sites");
+    clickFooter("Create Project");
+    await flush();
+    expect(created).toHaveLength(0);
+    expect(inlineError()).toContain("Location must be an absolute path");
+
+    npFillLocation(LOCATION);
+    clickFooter("Create Project");
+    await promise;
+
+    const opts = created[0] as { design: { accent: string }; destination: unknown };
+    expect(opts.destination).toEqual({ kind: "path", parent: LOCATION });
+    expect(opts.design.accent).toBe("#0a84ff");
   });
 });

--- a/packages/studio/tests/new-project-import-tab.test.ts
+++ b/packages/studio/tests/new-project-import-tab.test.ts
@@ -1,10 +1,20 @@
 /**
  * The New Project wizard's Import flow: the credentials gate and URL validation on the source step,
- * the Parameters hand-off, the streaming progress log, success/failure/cancel flows, and the
- * options threaded into platform.importSite.
+ * the Parameters hand-off (identity plus the destination the user chose), the streaming progress
+ * log, success/failure/cancel flows, and the options threaded into platform.importSite.
  */
-import { flush, installMockPlatform } from "./harness";
+import {
+  flush,
+  installMockPlatform,
+  npFillLocation,
+  npLocation,
+  npName,
+  npPreview,
+  npSlug,
+  npType,
+} from "./harness";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ImportTabCtx } from "../src/new-project/import-tab";
 import type { ImportProgressEvent } from "../src/types";
 
 const { closeNewProjectModal, openNewProjectModal } =
@@ -23,14 +33,41 @@ function modal(): HTMLElement | null {
   return document.querySelector("#layer-modal .new-project-modal");
 }
 
-/** Source step: field(0) = Site URL. Parameters step: name(0), directory(1). */
-function field(index: number): any {
-  return document.querySelectorAll("#layer-modal sp-textfield")[index];
+/** The Import source step's only textfield: Site URL. */
+function urlField(): HTMLInputElement {
+  return document.querySelector("#layer-modal sp-textfield") as HTMLInputElement;
 }
 
-function typeInto(el: any, value: string) {
-  el.value = value;
-  el.dispatchEvent(new Event("input", { bubbles: true }));
+/** The Project Name field's inline validation message (Spectrum's negative help text). */
+function nameError(): string {
+  return (
+    document
+      .querySelector('#layer-modal .new-project-name sp-help-text[slot="negative-help-text"]')
+      ?.textContent?.trim() ?? ""
+  );
+}
+
+/** The inline error rendered under the destination fields (or by a failed run). */
+function inlineError(): string {
+  return document.querySelector("#layer-modal .new-project-error")?.textContent?.trim() ?? "";
+}
+
+/**
+ * A hand-built ImportTabCtx for driving startImport directly (the modal only ever hands it a
+ * filesystem destination), paired with a counter for the rerenders it requests.
+ */
+function directCtx(resolveDestination: ImportTabCtx["resolveDestination"]) {
+  const counter = { rerenders: 0 };
+  const ctx: ImportTabCtx = {
+    credsForm: { render: () => "" as never, startEdit: () => {} },
+    form: { directory: "site", name: "Site" },
+    onDone: () => {},
+    rerender: () => {
+      counter.rerenders += 1;
+    },
+    resolveDestination,
+  };
+  return { counter, ctx };
 }
 
 function footerButtons(): any[] {
@@ -88,7 +125,7 @@ function setKey() {
 function reachParams(url = "https://clone.example/") {
   const promise = openNewProjectModal();
   switchTab("import");
-  typeInto(field(0), url);
+  npType(urlField(), url);
   clickFooter("Next");
   return promise;
 }
@@ -137,11 +174,9 @@ describe("Import source step", () => {
     importPlatform();
     void openNewProjectModal();
     switchTab("import");
-    typeInto(field(0), "not a url");
+    npType(urlField(), "not a url");
     clickFooter("Next");
-    expect(document.querySelector("#layer-modal .new-project-error")?.textContent).toContain(
-      "valid URL",
-    );
+    expect(inlineError()).toContain("valid URL");
     // Still on the source step.
     expect(document.querySelector("#layer-modal sp-tabs")).toBeTruthy();
     expect(captured).toBeNull();
@@ -151,9 +186,12 @@ describe("Import source step", () => {
     setKey();
     importPlatform();
     void reachParams("https://www.coffee-shop.example/menu");
-    // Parameters step: name(0) and directory(1) carry the hostname prefill.
-    expect(field(0).value).toBe("coffee-shop.example");
-    expect(field(1).value).toBe("coffee-shop-example");
+    // Parameters step: name and slug carry the hostname prefill; the destination is never guessed,
+    // So the Location field starts empty.
+    expect(npName().value).toBe("coffee-shop.example");
+    expect(npSlug().value).toBe("coffee-shop-example");
+    expect(npLocation()).toBeTruthy();
+    expect(npLocation().value).toBe("");
     // Import parameters are identity-only: no adapter picker, no design sections.
     expect(document.querySelector("#layer-modal sp-picker")).toBeNull();
     expect(document.querySelectorAll("#layer-modal .new-project-design-section")).toHaveLength(0);
@@ -161,30 +199,59 @@ describe("Import source step", () => {
 });
 
 describe("Import — parameters validation", () => {
-  test("an empty project name blocks the import; Back shows the inline error", async () => {
+  test("an empty project name blocks the import and shows the inline name error", async () => {
     setKey();
     importPlatform();
     void reachParams();
-    typeInto(field(0), ""); // Clear the prefilled name.
+    npFillLocation();
+    npType(npName(), ""); // Clear the prefilled name.
     clickFooter("Import Site");
     await flush();
     expect(captured).toBeNull();
+    // The modal — not the tab — owns identity validation now, so the message lands on the field.
+    expect(nameError()).toBe("Project name is required");
+  });
 
-    clickFooter("Back");
-    expect(document.querySelector("#layer-modal .new-project-error")?.textContent).toContain(
-      "Project name is required",
-    );
+  test("a missing Location blocks the import before importSite is called", async () => {
+    setKey();
+    importPlatform();
+    void reachParams();
+    // Location left empty: the name and slug are prefilled, so only the destination is missing.
+    clickFooter("Import Site");
+    await flush();
+    expect(captured).toBeNull();
+    expect(inlineError()).toContain("Choose a location for the project folder");
+    // Still on the Parameters step, ready for the user to choose one.
+    expect(npLocation()).toBeTruthy();
+    expect(importButtonLabel()).toBe("Import Site");
+  });
+
+  test("importSite receives the Location joined with the slug", async () => {
+    setKey();
+    importPlatform();
+    void reachParams();
+    npFillLocation("/home/dev/Sites");
+    npType(npName(), "My Clone");
+    npType(npSlug(), "clone-dir");
+    expect(npPreview()).toContain("/home/dev/Sites/clone-dir");
+    clickFooter("Import Site");
+    await flush();
+    expect(captured!.opts.directory).toBe("/home/dev/Sites/clone-dir");
   });
 
   test("a blank directory defaults to the name's slug", async () => {
     setKey();
     importPlatform();
     void reachParams();
-    typeInto(field(0), "Coffee & Cream");
-    typeInto(field(1), ""); // Clear the derived directory.
+    npFillLocation();
+    npType(npName(), "Coffee & Cream");
+    npType(npSlug(), ""); // Clear the derived directory.
     clickFooter("Import Site");
     await flush();
-    expect(captured!.opts).toMatchObject({ directory: "coffee-cream", name: "Coffee & Cream" });
+    expect(captured!.opts).toMatchObject({
+      directory: "/home/dev/Sites/coffee-cream",
+      name: "Coffee & Cream",
+    });
   });
 
   test("crawl options and the AI-naming switch thread into importSite", async () => {
@@ -192,7 +259,7 @@ describe("Import — parameters validation", () => {
     importPlatform();
     void openNewProjectModal();
     switchTab("import");
-    typeInto(field(0), "https://clone.example/");
+    npType(urlField(), "https://clone.example/");
 
     const numberFields = [
       ...document.querySelectorAll("#layer-modal sp-number-field"),
@@ -208,6 +275,7 @@ describe("Import — parameters validation", () => {
     aiSwitch.dispatchEvent(new Event("change", { bubbles: true }));
 
     clickFooter("Next");
+    npFillLocation();
     clickFooter("Import Site");
     await flush();
     expect(captured!.opts).toMatchObject({ aiComponents: false, depth: 2, maxPages: 50 });
@@ -215,16 +283,51 @@ describe("Import — parameters validation", () => {
 
   test("Import Site is a no-op when the platform lacks importSite", async () => {
     installMockPlatform();
-    let rerenders = 0;
-    await startImport({
-      credsForm: { render: () => "" as never, startEdit: () => {} },
-      form: { directory: "", name: "Site" },
-      onDone: () => {},
-      rerender: () => {
-        rerenders += 1;
-      },
+    const { counter, ctx } = directCtx(() => ({ kind: "path", parent: "/home/dev/Sites" }));
+    await startImport(ctx);
+    expect(counter.rerenders).toBe(0);
+  });
+
+  test("a repository destination never starts an import", async () => {
+    setKey();
+    importPlatform();
+    void openNewProjectModal();
+    switchTab("import");
+    npType(urlField(), "https://clone.example/");
+    // The pipeline writes to a folder; a repo destination is not a place it can clone into.
+    const { counter, ctx } = directCtx(() => ({
+      kind: "repo",
+      owner: "acme",
+      private: true,
+      repo: "site",
+    }));
+    await startImport(ctx);
+    expect(captured).toBeNull();
+    expect(counter.rerenders).toBe(0);
+  });
+
+  test("a missing or non-web URL is refused before the destination is resolved", async () => {
+    setKey();
+    importPlatform();
+    void openNewProjectModal();
+    switchTab("import");
+    let resolved = 0;
+    const { counter, ctx } = directCtx(() => {
+      resolved += 1;
+      return { kind: "path", parent: "/home/dev/Sites" };
     });
-    expect(rerenders).toBe(0);
+
+    // No URL at all (the source step never validated one).
+    await startImport(ctx);
+    expect(captured).toBeNull();
+    expect(counter.rerenders).toBe(1);
+
+    // Parsable, but not an http(s) site.
+    npType(urlField(), "ftp://files.example/");
+    await startImport(ctx);
+    expect(captured).toBeNull();
+    expect(counter.rerenders).toBe(2);
+    expect(resolved).toBe(0);
   });
 });
 
@@ -233,7 +336,8 @@ describe("Import — streaming flow", () => {
     setKey();
     importPlatform();
     const promise = reachParams();
-    typeInto(field(0), "Cloned Site");
+    npFillLocation();
+    npType(npName(), "Cloned Site");
     clickFooter("Import Site");
     await flush();
 
@@ -243,7 +347,7 @@ describe("Import — streaming flow", () => {
       apiKey: "sk-import-test",
       baseUrl: "http://llm.local/v1",
       depth: 1,
-      directory: "cloned-site",
+      directory: "/home/dev/Sites/cloned-site",
       maxPages: 20,
       model: "test-model",
       name: "Cloned Site",
@@ -259,11 +363,11 @@ describe("Import — streaming flow", () => {
     expect(labels).toEqual(["Cancel Import"]);
 
     // Success resolves the modal promise with the imported project.
-    captured!.resolve({ config: { name: "Cloned Site" }, root: "/projects/cloned-site" });
+    captured!.resolve({ config: { name: "Cloned Site" }, root: "/home/dev/Sites/cloned-site" });
     const result = await promise;
     expect(result).toEqual({
       config: { name: "Cloned Site" },
-      root: "/projects/cloned-site",
+      root: "/home/dev/Sites/cloned-site",
     } as never);
     expect(modal()).toBeNull();
   });
@@ -272,6 +376,7 @@ describe("Import — streaming flow", () => {
     setKey();
     importPlatform();
     void reachParams();
+    npFillLocation();
     expect(importButtonLabel()).toBe("Import Site");
     clickFooter("Import Site");
     await flush();
@@ -282,6 +387,7 @@ describe("Import — streaming flow", () => {
     setKey();
     importPlatform();
     void reachParams();
+    npFillLocation();
     clickFooter("Import Site");
     await flush();
 
@@ -290,18 +396,14 @@ describe("Import — streaming flow", () => {
     await flush();
 
     expect(modal()).toBeTruthy();
-    expect(document.querySelector("#layer-modal .new-project-error")?.textContent).toContain(
-      "Chrome not found",
-    );
+    expect(inlineError()).toContain("Chrome not found");
     const labels = footerButtons().map((b) => b.textContent?.trim());
     expect(labels.at(-1)).toContain("Retry Import");
     expect(importButtonLabel()).toBe("Retry Import");
 
     // Back on the Import source step, the error and the retained log both render.
     clickFooter("Back");
-    expect(document.querySelector("#layer-modal .new-project-error")?.textContent).toContain(
-      "Chrome not found",
-    );
+    expect(inlineError()).toContain("Chrome not found");
     expect(logLines()).toEqual(["launch Launching browser..."]);
   });
 
@@ -309,6 +411,7 @@ describe("Import — streaming flow", () => {
     setKey();
     importPlatform();
     void reachParams();
+    npFillLocation();
     clickFooter("Import Site");
     await flush();
 

--- a/packages/studio/tests/new-project-location-fields.test.ts
+++ b/packages/studio/tests/new-project-location-fields.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Destination fields of the New Project Parameters step (specs/desktop.md §4.5).
+ *
+ * The modal suites exercise the `"path"` shape end-to-end through the wizard; this file drives
+ * `location-fields.ts` directly so the `"repo"` shape — which only the cloud platform selects, and
+ * which the modal tests' mock platform therefore never renders — is covered too, along with the
+ * owner-loading, collision-hint, and separator edge cases.
+ */
+import { flush, installMockPlatform, renderInto } from "./harness";
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { RepoInfo, StudioPlatform } from "../src/types";
+
+const {
+  collectDestination,
+  destinationPath,
+  loadLocationOptions,
+  locationError,
+  renderLocationFields,
+  resetLocationFields,
+  slugFieldLabel,
+} = await import("../src/new-project/location-fields");
+
+const REPOS: RepoInfo[] = [
+  {
+    defaultBranch: "main",
+    fullName: "acme/site",
+    isJxProject: true,
+    name: "site",
+    owner: "acme",
+    permission: "admin",
+    private: true,
+  },
+  {
+    defaultBranch: "main",
+    fullName: "zoe/blog",
+    isJxProject: false,
+    name: "blog",
+    owner: "zoe",
+    permission: "write",
+    private: false,
+  },
+];
+
+/** Install a repo-destination platform (the cloud shape), with optional owner sources. */
+function installRepoPlatform(overrides: Partial<StudioPlatform> = {}) {
+  return installMockPlatform({ createDestination: "repo", ...overrides });
+}
+
+/** Set an sp-picker's value and fire the `change` event the fields listen for. */
+function setPickerValue(el: Element, value: string) {
+  (el as HTMLElement & { value: string }).value = value;
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+/** Render the destination block into a detached container and return it. */
+async function renderFields(slug: string) {
+  return renderInto(renderLocationFields({ onSlugInput: () => {}, rerender: () => {}, slug }));
+}
+
+beforeEach(() => {
+  resetLocationFields();
+});
+
+// ─── Path destinations ────────────────────────────────────────────────────────
+
+describe("path destinations", () => {
+  test("labels the slug field Directory and refuses an unset location", () => {
+    installMockPlatform({ createDestination: "path" });
+    expect(slugFieldLabel()).toBe("Directory");
+    expect(collectDestination("my-site")).toBeNull();
+    expect(locationError()).toBe("Choose a location for the project folder");
+  });
+
+  test("destinationPath joins with the parent's own separator", () => {
+    expect(destinationPath({ kind: "path", parent: "/home/dev/Sites" }, "my-site")).toBe(
+      "/home/dev/Sites/my-site",
+    );
+    // A Windows-style parent keeps backslashes rather than acquiring a mixed separator.
+    expect(destinationPath({ kind: "path", parent: String.raw`C:\Sites` }, "my-site")).toBe(
+      String.raw`C:\Sites\my-site`,
+    );
+  });
+
+  test("destinationPath does not double a separator the parent already ends with", () => {
+    expect(destinationPath({ kind: "path", parent: "/" }, "my-site")).toBe("/my-site");
+  });
+
+  test("destinationPath refuses a repo destination", () => {
+    expect(() =>
+      destinationPath({ kind: "repo", owner: "acme", private: true, repo: "site" }, "site"),
+    ).toThrow("Only filesystem destinations have a path");
+  });
+});
+
+// ─── Repo destinations ────────────────────────────────────────────────────────
+
+describe("repo destinations", () => {
+  test("labels the slug field Repository", () => {
+    installRepoPlatform();
+    expect(slugFieldLabel()).toBe("Repository");
+  });
+
+  test("refuses a missing owner, then a missing repository name", () => {
+    installRepoPlatform();
+    expect(collectDestination("my-site")).toBeNull();
+    expect(locationError()).toBe("Choose an owner for the repository");
+  });
+
+  test("collects owner, repo, and visibility once an owner is chosen", async () => {
+    installRepoPlatform({ listRepos: async () => REPOS });
+    loadLocationOptions(() => {});
+    await flush();
+
+    // The first owner alphabetically is selected by default so the field is never empty.
+    const destination = collectDestination("my-site");
+    expect(destination).toEqual({ kind: "repo", owner: "acme", private: true, repo: "my-site" });
+    expect(locationError()).toBe("");
+  });
+
+  test("an empty repository name is refused once an owner exists", async () => {
+    installRepoPlatform({ listRepos: async () => REPOS });
+    loadLocationOptions(() => {});
+    await flush();
+
+    expect(collectDestination("  ")).toBeNull();
+    expect(locationError()).toBe("Repository name is required");
+  });
+
+  test("owners merge account installations and repo owners, sorted and deduped", async () => {
+    installRepoPlatform({
+      getAccountStatus: async () => ({
+        installations: [
+          { account: "zoe", id: 1 },
+          { account: null, id: 2 },
+          { account: "beta-org", id: 3 },
+        ],
+      }),
+      listRepos: async () => REPOS,
+    });
+    let rerenders = 0;
+    loadLocationOptions(() => {
+      rerenders += 1;
+    });
+    await flush();
+    expect(rerenders).toBe(1);
+
+    const container = await renderFields("my-site");
+    const options = [...container.querySelectorAll("sp-menu-item")].map((o) =>
+      o.getAttribute("value"),
+    );
+    // "zoe" appears in both sources and must not be duplicated; visibility adds its own two items.
+    expect(options.slice(0, 3)).toEqual(["acme", "beta-org", "zoe"]);
+  });
+
+  test("a failing owner source leaves a free-text owner field rather than erroring", async () => {
+    installRepoPlatform({
+      getAccountStatus: async () => {
+        throw new Error("offline");
+      },
+      listRepos: async () => {
+        throw new Error("offline");
+      },
+    });
+    loadLocationOptions(() => {});
+    await flush();
+
+    const container = await renderFields("my-site");
+    expect(container.querySelector("sp-picker.new-project-owner")).toBeNull();
+    expect(container.querySelector("sp-textfield.new-project-owner")).not.toBeNull();
+  });
+
+  test("warns when the chosen owner already has a repo of that name", async () => {
+    installRepoPlatform({ listRepos: async () => REPOS });
+    loadLocationOptions(() => {});
+    await flush();
+
+    // The default owner is "acme", which already owns "site".
+    const clashing = await renderFields("site");
+    expect(clashing.textContent).toContain("already exists");
+
+    const free = await renderFields("brand-new");
+    expect(free.textContent).not.toContain("already exists");
+  });
+
+  test("previews the repository rather than a filesystem path", async () => {
+    installRepoPlatform({ listRepos: async () => REPOS });
+    loadLocationOptions(() => {});
+    await flush();
+
+    const container = await renderFields("my-site");
+    const preview = container.querySelector(".new-project-destination-preview");
+    expect(preview?.textContent).toContain("Repository");
+    expect(preview?.textContent).toContain("acme/my-site");
+  });
+
+  test("renders the visibility picker defaulting to private", async () => {
+    installRepoPlatform();
+    const container = await renderFields("my-site");
+    const visibility = container.querySelector("sp-picker.new-project-visibility");
+    expect(visibility).not.toBeNull();
+    expect((visibility as HTMLInputElement).value).toBe("private");
+  });
+
+  test("switching visibility to public is carried into the destination, and back", async () => {
+    installRepoPlatform({ listRepos: async () => REPOS });
+    loadLocationOptions(() => {});
+    await flush();
+
+    const container = await renderFields("my-site");
+    const visibility = container.querySelector("sp-picker.new-project-visibility")!;
+    setPickerValue(visibility, "public");
+    expect(collectDestination("my-site")).toMatchObject({ private: false });
+
+    setPickerValue(visibility, "private");
+    expect(collectDestination("my-site")).toMatchObject({ private: true });
+  });
+
+  test("choosing an owner from the picker clears the pending error", async () => {
+    installRepoPlatform({ listRepos: async () => REPOS });
+    loadLocationOptions(() => {});
+    await flush();
+
+    const container = await renderFields("my-site");
+    setPickerValue(container.querySelector("sp-picker.new-project-owner")!, "zoe");
+    expect(collectDestination("my-site")).toMatchObject({ owner: "zoe" });
+  });
+
+  test("typing an owner into the free-text field is collected", async () => {
+    // No owner sources, so the field falls back to free text.
+    installRepoPlatform();
+    const container = await renderFields("my-site");
+    const owner = container.querySelector("sp-textfield.new-project-owner") as HTMLInputElement;
+
+    // Prove the error is cleared by the edit, not merely absent.
+    expect(collectDestination("my-site")).toBeNull();
+    expect(locationError()).not.toBe("");
+    owner.value = "hand-typed-org";
+    owner.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(locationError()).toBe("");
+    expect(collectDestination("my-site")).toMatchObject({ owner: "hand-typed-org" });
+  });
+});
+
+// ─── Loading gate ─────────────────────────────────────────────────────────────
+
+describe("loadLocationOptions", () => {
+  test("is a no-op on path platforms — no owner lookup is attempted", async () => {
+    const { state } = installMockPlatform({
+      createDestination: "path",
+      listRepos: async () => REPOS,
+    });
+    loadLocationOptions(() => {});
+    await flush();
+    expect(state.calls.some(([name]) => name === "listRepos")).toBe(false);
+  });
+
+  test("resetLocationFields clears a previously chosen destination", async () => {
+    installRepoPlatform({ listRepos: async () => REPOS });
+    loadLocationOptions(() => {});
+    await flush();
+    expect(collectDestination("my-site")).not.toBeNull();
+
+    resetLocationFields();
+    expect(collectDestination("my-site")).toBeNull();
+    expect(locationError()).toBe("Choose an owner for the repository");
+  });
+});

--- a/packages/studio/tests/new-project-modal.test.ts
+++ b/packages/studio/tests/new-project-modal.test.ts
@@ -1,10 +1,20 @@
 /**
  * New Project modal tests (E9). Drives the real two-step wizard through the layer system: the
- * source tab strip, the Next/Back transitions, field input with directory-slug derivation,
- * validation, platform createProject success/failure, template/starter selection, and the various
- * dismissal paths.
+ * source tab strip, the Next/Back transitions, field input with directory-slug derivation, the
+ * destination block (Location + Browse…, on a `createDestination: "path"` platform), validation,
+ * platform createProject success/failure, template/starter selection, and the various dismissal
+ * paths.
  */
-import { flush, installMockPlatform } from "./harness";
+import {
+  flush,
+  installMockPlatform,
+  npFillLocation,
+  npLocation,
+  npName,
+  npPreview,
+  npSlug,
+  npType,
+} from "./harness";
 import { afterEach, describe, expect, test } from "bun:test";
 
 const { closeNewProjectModal, openNewProjectModal } =
@@ -22,14 +32,23 @@ function modal(): HTMLElement | null {
   return document.querySelector("#layer-modal .new-project-modal");
 }
 
-/** Textfields in form order on the Parameters step: name, directory, description, url, …design. */
+/**
+ * Textfields in form order on the Parameters step of a `createDestination: "path"` platform: name,
+ * location, directory, description, url, …design. The identity and destination fields carry stable
+ * classes (use the harness accessors); only the unclassed description/url fields need an index.
+ */
 function field(index: number): any {
   return document.querySelectorAll("#layer-modal sp-textfield")[index];
 }
 
-function typeInto(el: any, value: string) {
-  el.value = value;
-  el.dispatchEvent(new Event("input", { bubbles: true }));
+/** The Description textfield — it follows the whole destination block. */
+function npDescription(): any {
+  return field(3);
+}
+
+/** The Production URL textfield. */
+function npUrl(): any {
+  return field(4);
 }
 
 function footerButtons(): any[] {
@@ -48,6 +67,20 @@ function clickCreate() {
 
 function errorText(): string | null {
   return document.querySelector("#layer-modal .new-project-error")?.textContent?.trim() ?? null;
+}
+
+/** The inline destination-validation message rendered under the Location/Directory fields. */
+function destinationError(): string | null {
+  return (
+    document
+      .querySelector("#layer-modal .new-project-modal-body .new-project-error")
+      ?.textContent?.trim() ?? null
+  );
+}
+
+/** The Browse… button beside the Location field (absent without `platform.pickDirectory`). */
+function browseButton(): any {
+  return document.querySelector("#layer-modal .new-project-location-row sp-button");
 }
 
 /** The inline validation message slotted into the Project Name textfield. */
@@ -103,8 +136,11 @@ describe("openNewProjectModal — wizard lifecycle", () => {
     expect(document.querySelector("#layer-modal .new-project-step-context")?.textContent).toContain(
       "Template · Blank",
     );
-    // Identity fields + adapter picker + the design quickstart sections.
-    expect(document.querySelectorAll("#layer-modal sp-textfield").length).toBeGreaterThanOrEqual(4);
+    // Identity + destination fields, adapter picker, and the design quickstart sections.
+    expect(document.querySelectorAll("#layer-modal sp-textfield").length).toBeGreaterThanOrEqual(5);
+    expect(npName()).toBeTruthy();
+    expect(npLocation()).toBeTruthy();
+    expect(npSlug()).toBeTruthy();
     expect(document.querySelector("#layer-modal sp-picker")).toBeTruthy();
     expect(document.querySelectorAll("#layer-modal .new-project-design-section")).toHaveLength(4);
     // The tab strip is hidden on the Parameters step.
@@ -177,19 +213,147 @@ describe("openNewProjectModal — directory derivation", () => {
     installMockPlatform();
     void openNewProjectModal();
     goNext();
-    typeInto(field(0), "My Cool Site!");
-    expect(field(1).value).toBe("my-cool-site");
-    typeInto(field(0), "Renamed Site");
-    expect(field(1).value).toBe("renamed-site");
+    npType(npName(), "My Cool Site!");
+    expect(npSlug().value).toBe("my-cool-site");
+    npType(npName(), "Renamed Site");
+    expect(npSlug().value).toBe("renamed-site");
   });
 
   test("manual directory entry stops further derivation", () => {
     installMockPlatform();
     void openNewProjectModal();
     goNext();
-    typeInto(field(1), "custom-dir");
-    typeInto(field(0), "Some Project");
-    expect(field(1).value).toBe("custom-dir");
+    npType(npSlug(), "custom-dir");
+    npType(npName(), "Some Project");
+    expect(npSlug().value).toBe("custom-dir");
+  });
+});
+
+describe("openNewProjectModal — destination", () => {
+  test("blocks create with an inline error when the Location is empty", async () => {
+    const { state } = installMockPlatform();
+    void openNewProjectModal();
+    goNext();
+    npType(npName(), "Homeless Site");
+    clickCreate();
+
+    // The destination message replaces the name error and the modal stays open for a fix.
+    expect(destinationError()).toBe("Choose a location for the project folder");
+    expect(nameError()).toBeNull();
+    expect(modal()).toBeTruthy();
+    expect(state.calls.filter((c) => c[0] === "createProject")).toHaveLength(0);
+    // The scroll-to-top + focus helper runs without throwing.
+    await flush();
+  });
+
+  test("rejects a relative Location as not an absolute path", async () => {
+    const { state } = installMockPlatform();
+    void openNewProjectModal();
+    goNext();
+    npType(npName(), "Relative Site");
+    npType(npLocation(), "sites/relative");
+    clickCreate();
+
+    expect(destinationError()).toBe("Location must be an absolute path");
+    expect(modal()).toBeTruthy();
+    expect(state.calls.filter((c) => c[0] === "createProject")).toHaveLength(0);
+    await flush();
+  });
+
+  test("typing a Location clears the inline destination error", async () => {
+    installMockPlatform();
+    void openNewProjectModal();
+    goNext();
+    npType(npName(), "Fixable Site");
+    clickCreate();
+    expect(destinationError()).toBe("Choose a location for the project folder");
+    npFillLocation();
+    expect(destinationError()).toBeNull();
+    await flush();
+  });
+
+  test("the preview tracks the location and the slug", () => {
+    installMockPlatform();
+    void openNewProjectModal();
+    goNext();
+    // Both halves are still unknown before anything is typed.
+    expect(npPreview()).toBe("Creates: …/…");
+
+    npType(npName(), "My Cool Site");
+    expect(npPreview()).toBe("Creates: …/my-cool-site");
+
+    // A trailing separator on the typed location is not doubled up.
+    npFillLocation("/home/dev/Sites/");
+    expect(npPreview()).toBe("Creates: /home/dev/Sites/my-cool-site");
+
+    npType(npSlug(), "cool-dir");
+    expect(npPreview()).toBe("Creates: /home/dev/Sites/cool-dir");
+  });
+
+  test("createProject receives the typed Location as a path destination", async () => {
+    const { state } = installMockPlatform();
+    const promise = openNewProjectModal();
+    goNext();
+    npType(npName(), "Placed Site");
+    npFillLocation("/home/dev/Sites/");
+    clickCreate();
+
+    const result = await promise;
+    const call = state.calls.find((c) => c[0] === "createProject") as any[];
+    expect(call[1].destination).toEqual({ kind: "path", parent: "/home/dev/Sites" });
+    expect(call[1].directory).toBe("placed-site");
+    // The mock scaffolds under exactly the parent the user named.
+    expect(result?.root).toBe("/home/dev/Sites/placed-site");
+  });
+
+  test("no Browse… button when the platform cannot open a directory dialog", () => {
+    installMockPlatform();
+    void openNewProjectModal();
+    goNext();
+    expect(browseButton()).toBeNull();
+    expect(npLocation().getAttribute("placeholder")).toBe("/absolute/path/to/your/projects");
+  });
+
+  test("Browse… fills the Location from pickDirectory", async () => {
+    let picks = 0;
+    installMockPlatform({
+      pickDirectory: (async () => {
+        picks += 1;
+        return "/Users/dev/Projects";
+      }) as never,
+    });
+    void openNewProjectModal();
+    goNext();
+    expect(npLocation().getAttribute("placeholder")).toBe(
+      "Choose a folder to create the project in",
+    );
+    expect(browseButton()).toBeTruthy();
+
+    browseButton().dispatchEvent(new Event("click", { bubbles: true }));
+    // While the native dialog is open the button is busy and further clicks are ignored.
+    expect(browseButton().textContent).toContain("Choosing…");
+    expect(browseButton().hasAttribute("disabled")).toBe(true);
+    browseButton().dispatchEvent(new Event("click", { bubbles: true }));
+    await flush();
+
+    expect(picks).toBe(1);
+    expect(npLocation().value).toBe("/Users/dev/Projects");
+    expect(npPreview()).toBe("Creates: /Users/dev/Projects/…");
+    expect(browseButton().textContent).toContain("Browse…");
+    expect(browseButton().hasAttribute("disabled")).toBe(false);
+  });
+
+  test("a cancelled Browse… leaves the typed Location untouched", async () => {
+    installMockPlatform({ pickDirectory: (async () => null) as never });
+    void openNewProjectModal();
+    goNext();
+    npFillLocation("/home/dev/Sites");
+
+    browseButton().dispatchEvent(new Event("click", { bubbles: true }));
+    await flush();
+
+    expect(npLocation().value).toBe("/home/dev/Sites");
+    expect(npPreview()).toBe("Creates: /home/dev/Sites/…");
   });
 });
 
@@ -219,7 +383,8 @@ describe("openNewProjectModal — Template tab", () => {
     ].map((el: any) => el.value);
     expect(mediaNames).toEqual(["--", "--sm", "--md", "--lg"]);
 
-    typeInto(field(0), "My App");
+    npType(npName(), "My App");
+    npFillLocation();
     clickCreate();
     await flush();
     const call = state.calls.find((c) => c[0] === "createProject");
@@ -276,13 +441,14 @@ describe("openNewProjectModal — Starter Site tab", () => {
       "Bistro & Café",
     );
     // Description prefilled from the tagline; accent prefilled from the registry accent.
-    expect(field(2).value).toBe("A menu-driven site.");
+    expect(npDescription().value).toBe("A menu-driven site.");
     const accentField: any = document.querySelector(
       "#layer-modal .new-project-color-row sp-textfield",
     );
     expect(accentField.value).toBe("#b45309");
 
-    typeInto(field(0), "My Diner");
+    npType(npName(), "My Diner");
+    npFillLocation();
     clickCreate();
     await flush();
     const call = state.calls.find((c) => c[0] === "createProject");
@@ -325,7 +491,9 @@ describe("openNewProjectModal — submit", () => {
     clickCreate();
     // The message renders inside the name field, not in the global strip.
     expect(nameError()).toBe("Project name is required");
-    expect(field(0).hasAttribute("invalid")).toBe(true);
+    expect(npName().hasAttribute("invalid")).toBe(true);
+    // The name is checked before the destination, so no location complaint yet.
+    expect(destinationError()).toBeNull();
     expect(errorText()).toBeNull();
     expect(modal()).toBeTruthy();
     expect(state.calls.filter((c) => c[0] === "createProject")).toHaveLength(0);
@@ -339,9 +507,9 @@ describe("openNewProjectModal — submit", () => {
     goNext();
     clickCreate();
     expect(nameError()).toBe("Project name is required");
-    typeInto(field(0), "My Site");
+    npType(npName(), "My Site");
     expect(nameError()).toBeNull();
-    expect(field(0).hasAttribute("invalid")).toBe(false);
+    expect(npName().hasAttribute("invalid")).toBe(false);
   });
 
   test("creates the project, shows progress, and resolves with the result", async () => {
@@ -358,22 +526,27 @@ describe("openNewProjectModal — submit", () => {
 
     const promise = openNewProjectModal();
     goNext();
-    typeInto(field(0), "My Site");
-    typeInto(field(2), "A demo site");
-    typeInto(field(3), "https://example.com");
+    npType(npName(), "My Site");
+    npFillLocation();
+    npType(npDescription(), "A demo site");
+    npType(npUrl(), "https://example.com");
     clickCreate();
 
     // While createProject is pending the button is disabled and shows progress
     expect(footerButtons()[1].textContent).toContain("Creating…");
     expect(footerButtons()[1].hasAttribute("disabled")).toBe(true);
 
-    resolveCreate({ config: { name: "My Site" }, root: "/projects/my-site" });
+    resolveCreate({ config: { name: "My Site" }, root: "/home/dev/Sites/my-site" });
     const result = await promise;
-    expect(result).toEqual({ config: { name: "My Site" }, root: "/projects/my-site" } as never);
+    expect(result).toEqual({
+      config: { name: "My Site" },
+      root: "/home/dev/Sites/my-site",
+    } as never);
     expect(modal()).toBeNull();
     expect(created[0]).toEqual({
       adapter: "static",
       description: "A demo site",
+      destination: { kind: "path", parent: "/home/dev/Sites" },
       directory: "my-site",
       name: "My Site",
       template: "blank",
@@ -385,8 +558,9 @@ describe("openNewProjectModal — submit", () => {
     const { state } = installMockPlatform();
     const promise = openNewProjectModal();
     goNext();
-    typeInto(field(0), "Site X");
-    typeInto(field(1), ""); // User clears the derived value
+    npType(npName(), "Site X");
+    npType(npSlug(), ""); // User clears the derived value
+    npFillLocation();
     clickCreate();
     await promise;
     const call = state.calls.find((c) => c[0] === "createProject") as any[];
@@ -397,7 +571,8 @@ describe("openNewProjectModal — submit", () => {
     const { state } = installMockPlatform();
     const promise = openNewProjectModal();
     goNext();
-    typeInto(field(0), "Node Site");
+    npType(npName(), "Node Site");
+    npFillLocation();
     const picker: any = document.querySelector("#layer-modal sp-picker");
     picker.value = "node";
     picker.dispatchEvent(new Event("change", { bubbles: true }));
@@ -419,7 +594,8 @@ describe("openNewProjectModal — submit", () => {
       settled = true;
     });
     goNext();
-    typeInto(field(0), "Doomed");
+    npType(npName(), "Doomed");
+    npFillLocation();
     clickCreate();
     await flush();
 
@@ -450,7 +626,8 @@ describe("openNewProjectModal — submit", () => {
     });
     const promise = openNewProjectModal();
     goNext();
-    typeInto(field(0), "Blocked");
+    npType(npName(), "Blocked");
+    npFillLocation();
     clickCreate();
     await flush();
 

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,9 +2,9 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.2.7-draft
+**Version:** 0.3.0-draft
 **Status:** Pending
-**Updated:** 2026-07-24
+**Updated:** 2026-07-25
 **License:** MIT
 
 ---
@@ -77,18 +77,18 @@ The PAL is a plain JavaScript object conforming to a `StudioPlatform` interface.
 
 The canonical `StudioPlatform` interface is `packages/studio/src/types.ts` — roughly 70 members today. This spec deliberately does not duplicate it; the summary below names the member families and the model that governs them. The transport-level view of the same contract is the `STUDIO_ROUTES` table in `@jxsuite/protocol` (§5.1).
 
-| Family                   | Representative members                                                                                                                                                                  |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Session / project**    | `id`, `projectRoot`, `activate`, `openProject`, `openProjectPicker?`, `probeRootProject`, `createProject`, `listStarters?`, `importSite?`, `listProjects?`, recent-projects persistence |
-| **Filesystem**           | `listDirectory`, `readFile`, `writeFile`, `uploadFile`, `deleteFile`, `renameFile`, `createDirectory`, `locateFile`, `searchFiles`, `subscribeFileEvents?`                              |
-| **Documents / formats**  | `discoverComponents`, `listFormats?`, `listExtensions?`, `fetchProjectSchemas?`, `formatAction?`, `fetchPluginSchema`                                                                   |
-| **Packages**             | `listPackages`, `addPackage`, `removePackage`, `installDependencies?`, `outdatedPackages?`, `setPackageVersions?`                                                                       |
-| **Git**                  | `gitStatus`, `gitCommit`, `gitPush`, `gitPull`, `gitDiff`, `gitCheckout`, `gitClone?`, `createPullRequest?`, …                                                                          |
-| **Collab**               | `collab?` (realtime co-editing handle per document)                                                                                                                                     |
-| **Data / secrets**       | `dataConnections?`, `dataRows?`, row CRUD, `dataPush?`, `listSecrets?`, `setSecrets?`                                                                                                   |
-| **Publish / identity**   | `getUser?`, `getAccountStatus?`, `listRepos?`, `importProject?`, `cfConnection?`, `cfApi?`                                                                                              |
-| **Code services / AI**   | `codeService` (§5.3), `resolveClass?`, `aiChatUrl`                                                                                                                                      |
-| **Multi-window / shell** | `openProjectInNewWindow?`, `newWindow?`, `setWindowProject?`, `getProjectRoot?`, `getAppInfo?`, backend-persisted settings                                                              |
+| Family                   | Representative members                                                                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Session / project**    | `id`, `projectRoot`, `activate`, `openProject`, `openProjectPicker?`, `probeRootProject`, `createDestination`, `createProject`, `pickDirectory?`, `listStarters?`, `importSite?`, `listProjects?`, recent-projects persistence |
+| **Filesystem**           | `listDirectory`, `readFile`, `writeFile`, `uploadFile`, `deleteFile`, `renameFile`, `createDirectory`, `locateFile`, `searchFiles`, `subscribeFileEvents?`                                                                     |
+| **Documents / formats**  | `discoverComponents`, `listFormats?`, `listExtensions?`, `fetchProjectSchemas?`, `formatAction?`, `fetchPluginSchema`                                                                                                          |
+| **Packages**             | `listPackages`, `addPackage`, `removePackage`, `installDependencies?`, `outdatedPackages?`, `setPackageVersions?`                                                                                                              |
+| **Git**                  | `gitStatus`, `gitCommit`, `gitPush`, `gitPull`, `gitDiff`, `gitCheckout`, `gitClone?`, `createPullRequest?`, …                                                                                                                 |
+| **Collab**               | `collab?` (realtime co-editing handle per document)                                                                                                                                                                            |
+| **Data / secrets**       | `dataConnections?`, `dataRows?`, row CRUD, `dataPush?`, `listSecrets?`, `setSecrets?`                                                                                                                                          |
+| **Publish / identity**   | `getUser?`, `getAccountStatus?`, `listRepos?`, `importProject?`, `cfConnection?`, `cfApi?`                                                                                                                                     |
+| **Code services / AI**   | `codeService` (§5.3), `resolveClass?`, `aiChatUrl`                                                                                                                                                                             |
+| **Multi-window / shell** | `openProjectInNewWindow?`, `newWindow?`, `setWindowProject?`, `getProjectRoot?`, `getAppInfo?`, backend-persisted settings                                                                                                     |
 
 **Core vs. optional, and degradation.** Required members are the minimal backend every platform implements. Optional members (marked `?` in the interface) each back an optional protocol route; Studio feature-detects them and degrades gracefully when they are absent — hiding the corresponding UI or falling back to a client-side path. Each optional route's `degradation` note in `STUDIO_ROUTES` records exactly what turns off (e.g. no `collab` → Studio edits solo with file-level saves; no `importSite` → the New Project modal hides its Import tab).
 
@@ -223,6 +223,50 @@ projectState = {
 };
 ```
 
+### 4.5 Project Create Flow
+
+> **Status: Implemented.**
+
+A new project is written **only** where the user said to put it. No backend picks a destination on its own, and none falls back to its own root — an unspecified destination is an error, not a default.
+
+`StudioPlatform.createDestination` declares which kind of destination the platform takes, and the New Project modal renders the matching fields on its Parameters step:
+
+| `createDestination` | Platforms           | Fields collected                            | `createProject({ destination })`                             |
+| ------------------- | ------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `"path"`            | Desktop, dev server | **Location** (absolute parent), folder name | `{ kind: "path", parent }` → project at `parent/<directory>` |
+| `"repo"`            | Cloud               | **Owner**, **Repository**, **Visibility**   | `{ kind: "repo", owner, repo, private }`                     |
+
+```
+User fills the Parameters step (name, destination, slug)
+        │
+        ├─── createDestination: "path"
+        │    Location field, prefilled by nothing — required.
+        │    Browse… renders only when the platform implements pickDirectory()
+        │      ├── Electrobun desktop: native Utils.openFileDialog
+        │      ├── NixOS chromium desktop: native XDG desktop portal
+        │      ├── Dev server: showDirectoryPicker(), path recovered via a marker file (§8.2.1)
+        │      └── A browser without the File System Access API: omitted — the path is typed
+        │
+        └─── createDestination: "repo"
+             Owner picker over getAccountStatus().installations + listRepos() owners
+             (free-text when neither is available), repository name, visibility
+        ▼
+platform.createProject({ …, destination })
+        │
+        ├─── Desktop: RPC → session refuses a non-"path" or relative destination,
+        │    then scaffolds at resolve(destination.parent, directory)
+        ├─── Dev server: POST /__studio/create-project → 400 without a destination;
+        │    the parent is checked with assertCreatableParent (specs/server.md §4.2)
+        └─── Cloud: POST /api/v1/projects { owner, repo, private, … } → the repo is
+             created under the chosen account, never a server-side default
+        ▼
+Returns { root, config } and the modal opens it
+```
+
+A live preview under the fields shows the resolved destination (`/home/you/Sites/my-site`, or `acme/my-site`) before anything is written.
+
+**Import shares this destination.** The Import tab is one of the four New Project sources, so it collects the same Location field and sends the resolved absolute path as `ImportSiteOptions.directory`. A relative directory reaching a backend means a caller skipped the field and is refused.
+
 ---
 
 ## 5. Backend API Contract
@@ -253,10 +297,12 @@ A few illustrative rows (see the table for the rest):
 
 ### 5.2 Project Operations
 
-| Operation        | `@jxsuite/server` endpoint | PAL method                   |
-| ---------------- | -------------------------- | ---------------------------- |
-| Open project     | N/A (client-side dialog)   | `openProject()`              |
-| Project metadata | `GET /__studio/project`    | Derived from `ProjectHandle` |
+| Operation        | `@jxsuite/server` endpoint       | PAL method                              |
+| ---------------- | -------------------------------- | --------------------------------------- |
+| Open project     | N/A (client-side dialog)         | `openProject()`                         |
+| Project metadata | `GET /__studio/project`          | Derived from `ProjectHandle`            |
+| Create project   | `POST /__studio/create-project`  | `createProject({ destination })` (§4.5) |
+| Pick a folder    | `GET /__studio/locate-directory` | `pickDirectory?()` (§8.2.1)             |
 
 ### 5.3 Code Services
 
@@ -571,6 +617,30 @@ In Chrome, `showOpenFilePicker` returns a `FileSystemFileHandle` with no way to 
 
 For the **desktop app**, `Utils.openFileDialog` with `canChooseFiles: true` and `allowedFileTypes: "json"` gives us the file path directly, so the user can pick `project.json` explicitly.
 
+#### 8.2.1 Picking a destination folder
+
+> **Status: Implemented.**
+
+Choosing where a **new** project goes (§4.5) cannot use any of the three steps above: the folder is empty by definition, so there is no `project.json` to read and nothing for `/__studio/sites` to match. The handle still carries no path.
+
+**This applies only to the plain dev-server browser session.** Every packaged build already has a real native folder dialog that returns a filesystem path directly, and keeps it — electrobun uses `Utils.openFileDialog`, and the NixOS chromium build uses the XDG desktop portal. A browser page has no such option, so it gets the fallback below rather than no **Browse…** button at all.
+
+There, the handle is made to identify itself. Using the `readwrite` grant the picker just issued, `pickDirectoryPath` (`@jxsuite/studio/directory-picker`) tags the folder with a hidden `LOCATION_ID_FILE` — `.jx-loc-id`, defined in `@jxsuite/protocol` because the writer and the reader must agree on it — whose **contents** are a freshly generated 128-bit id, and asks the backend which directory carries that id:
+
+```
+Browse… (user gesture)
+  → showDirectoryPicker({ id: "jx-new-project-location", mode: "readwrite" })
+  → write <random 32-hex id> into <picked>/.jx-loc-id
+  → GET /__studio/locate-directory?name=&id=
+      ($HOME/.jx-loc-id holds the id → $HOME; else scan **/<name>/.jx-loc-id under $HOME)
+      → on match: delete the tag, return the directory
+  → finally: handle.removeEntry(".jx-loc-id")
+```
+
+**Identity is in the contents, not the filename.** A candidate whose `.jx-loc-id` does not hold this exact id is skipped, so neither a second folder sharing the basename nor a tag left behind by a crashed session can redirect a create — a fixed filename plus a content match is exact where a path shape is only probable. `name` still narrows the scan the way `/__studio/find-project` does. The backend deletes the winning tag as soon as it has served its purpose, and the client removes it too, so nothing is left in the user's new project folder on any path.
+
+Every failure — no API, cancel, a read-only grant, a folder the backend cannot place — resolves `null`, which the modal treats identically to "no folder chosen" and leaves the Location field untouched. On a browser without the File System Access API the dev-server adapter omits `pickDirectory` entirely, so the button is hidden rather than dead, and the Location field is typed.
+
 ---
 
 ## 9. NixOS Chromium App-Mode
@@ -637,6 +707,8 @@ $ ./result/bin/jx-studio [project-root]
 ### 10.1 Cloud Platform Adapter
 
 A cloud adapter replaces filesystem operations with API calls to a remote service. The project root becomes a project ID rather than a filesystem path. All PAL methods translate to REST or WebSocket calls to the cloud API.
+
+Because a cloud project _is_ a repository, the adapter sets `createDestination: "repo"` and the New Project modal collects a repository location — owner (personal account or organization), repository name, and visibility — instead of a folder (§4.5). The adapter forwards all three to the API, which resolves the owner against the session login to choose between the personal and organization creation endpoints. Nothing about the destination is defaulted server-side.
 
 ### 10.2 Storage Backend
 
@@ -720,6 +792,7 @@ Ensure desktop app matches dev-mode capabilities:
 
 ## Changelog
 
+- **0.3.0-draft** (2026-07-25) — New Project requires a user-chosen destination: StudioPlatform gains the required createDestination declaration, createProject takes a required destination (path parent or repo owner/name/visibility), and §4.5 defines the create flow. No backend picks a location.
 - **0.2.7-draft** (2026-07-24) — Cloud platform registers inside studio.js via a window.__jxCloud signal (single yjs for collab).
 - **0.2.6-draft** (2026-07-24) — Document packaged static-data staging into app/bun (create templates, starters) and postBuild bundle verification.
 - **0.2.5-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
@@ -738,4 +811,4 @@ Ensure desktop app matches dev-mode capabilities:
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.2.7-draft_
+_Jx Studio Desktop Architecture Specification v0.3.0-draft_

--- a/specs/server.md
+++ b/specs/server.md
@@ -2,9 +2,9 @@
 
 ## Development Server with Live Reload, Proxy Resolution, and Studio API
 
-**Version:** 0.1.9
+**Version:** 0.2.0
 **Status:** Implemented
-**Updated:** 2026-07-23
+**Updated:** 2026-07-25
 **License:** MIT
 
 ---
@@ -124,7 +124,7 @@ The reference implementation of the Studio Backend Protocol, serving Studio's Pl
 
 The canonical endpoint list is the `STUDIO_ROUTES` table in `@jxsuite/protocol` (`packages/protocol/src/routes.ts`) — roughly 60 routes, each with method, path, core-vs-optional flag, contract summary, and degradation note. A generated reference lives in the docs (`docs/extending/embedding/backend-protocol.md`). This spec no longer enumerates them; the families are:
 
-- **Session / project** — activate, project metadata/probing, site enumeration, project creation, starters, AI-guided site import (NDJSON progress stream)
+- **Session / project** — activate, project metadata/probing, site enumeration, project creation, directory location (placing a `showDirectoryPicker()` handle on disk by the id it wrote into a hidden `.jx-loc-id`, so the New Project **Location** field gets a real folder chooser in the browser — specs/desktop.md §8.2.1), starters, AI-guided site import (NDJSON progress stream)
 - **Filesystem** — directory listing and project-wide search on one route (`files?dir=` / `files?glob=`), file CRUD, upload, rename (with refactor report), locate
 - **Realtime co-editing** — `GET /__studio/collab`: a WebSocket upgrade speaking the `@jxsuite/collab` wire envelope (one socket per project, documents multiplexed by path); a plain GET answers the capability probe. Implemented in `src/collab.ts`: rooms seed from the file on disk, persistence is explicit (flush on save, plus graceful shutdown), and genuinely external file changes bump the doc epoch and reset subscribers.
 - **Documents / components / formats** — component discovery, CEM extraction, the project's format/extension registry, generated project schemas, format parse/serialize dispatch, plugin schemas, code services (§5)
@@ -147,7 +147,8 @@ Both server entry points share one set of primitives (`src/net-guard.ts`), appli
 - **Loopback bind** (`127.0.0.1`) by default is the primary control; a `hostname` option (`--host` on the `jx dev` CLI) can widen it for containers, which removes that control and must only be used behind trusted isolation
 - **Origin/Host gate** on every privileged surface — the RCE-capable `/__jx_resolve__` / `/__jx_server__` routes (both do dynamic `import()`), the `/_jx/` extension mounts, and the whole `/__studio/*` API: a loopback (or absent) Origin is accepted, a non-loopback Origin or Host is rejected (anti-CSRF, anti-DNS-rebinding). The browser Studio and the served site are same-origin, so they pass; an external page does not. No token is used — same-origin does not need one
 - **File containment**: every static path and every caller-supplied relative or absolute `$src` / `$base` / `$implementation` resolved before a dynamic `import()` passes a lexical `relative()` check **plus a realpath re-check** (`containedPath`), so a `../` or absolute path cannot escape and a symlink cannot point outside the tree; over-encoded paths are rejected after a single decode. A **bare-specifier** `$src` is exempt: it resolves only through Node's `node_modules` lookup (an installed package), so the class file — and the sibling `$implementation` it names, even one above the class directory — is trusted as that package's own code; the containment check still binds a project-local relative `$src`
-- **Two-root activation**: filesystem operations go through `assertAccessible(filePath, root, activeProjectRoot)` — the path must sit under the server root **or** the active project root Studio bound via `POST /__studio/activate`, which itself only accepts a root contained under the server root or an explicit `allowedRoots` entry
+- **Two-root activation**: filesystem operations go through `assertAccessible(filePath, root, activeProjectRoot)` — the path must sit under the server root **or** the active project root Studio bound via `POST /__studio/activate`, which itself only accepts a root contained under the server root, an explicit `allowedRoots` entry, or a project this server just created (below)
+- **Project creation is the one deliberate exception to root containment.** A new project belongs wherever the user pointed the New Project modal's Location field (specs/desktop.md §4.5), which is normally _outside_ the server root — containing it there would mean scaffolding into whatever tree the dev server happens to serve. `POST /__studio/create-project` and `POST /__studio/import-site` therefore take an explicit absolute parent and check it with `assertCreatableParent(parent, root, allowedRoots)` instead of `assertAccessible`. That guard **requires** an absolute path (a request without a destination is a 400 — the server never falls back to its own root) and admits only the server root, a configured `allowedRoots` entry, or the account's home directory, so a hostile page on the loopback origin cannot scaffold into system paths. Roots created this way are remembered for the duration of the process so the very next `/__studio/activate` can open them; the create response reports a root-relative path when the project landed under the server root and an absolute one otherwise
 
 **Loopback project server (`src/project-server.ts`, used by the desktop launchers).** Adds, on top of the above, a **per-server token** as the hard gate on the WebSocket RPC upgrade and the resolve/import routes — the desktop canvas iframe is cross-origin, so it carries the token in its URL where the same-origin dev server does not need one.
 
@@ -202,6 +203,7 @@ Incremental rebuild triggered by the file watcher: only entries whose `match` (R
 
 ## Changelog
 
+- **0.2.0** (2026-07-25) — POST /__studio/create-project requires an explicit absolute destination parent — the server no longer falls back to its own root. Adds assertCreatableParent (root, allowedRoots, or home; absolute only), remembers created roots for a following activate, and returns an absolute root for projects outside the server root.
 - **0.1.9** (2026-07-23) — Serve extension asset mounts ahead of the project root in the static-file chain (§3).
 - **0.1.8** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.1.7** (2026-07-22) — Fix failing tests (`56e073f8`).
@@ -215,4 +217,4 @@ Incremental rebuild triggered by the file watcher: only entries whose `match` (R
 
 ---
 
-_`@jxsuite/server` Specification v0.1.9_
+_`@jxsuite/server` Specification v0.2.0_

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -2,9 +2,9 @@
 
 ## Visual Builder for Jx Documents
 
-**Version:** 0.1.25-draft
+**Version:** 0.1.26-draft
 **Status:** Partial
-**Updated:** 2026-07-22
+**Updated:** 2026-07-25
 **License:** MIT
 
 ---
@@ -91,6 +91,9 @@ Studio uses a platform abstraction (`platform.js`) to decouple UI from backend:
 | `discoverComponents()` | Scan project for custom elements                                                                           |
 | `openProject()`        | Open project picker (unless `openProjectPicker: "repo-list"` routes it through Studio's repository picker) |
 | `probeRootProject()`   | Auto-detect project at startup                                                                             |
+| `createDestination`    | Whether New Project collects a folder (`"path"`) or a repository (`"repo"`) — see specs/desktop.md §4.5    |
+| `createProject(opts)`  | Scaffold a project at the user-chosen `opts.destination`; never defaults a location                        |
+| `pickDirectory?()`     | Native folder picker behind the modal's **Browse…** button (desktop only)                                  |
 
 Three platform targets:
 
@@ -575,6 +578,7 @@ See the [Site Architecture Specification](site-architecture.md) for full design 
 
 ## Changelog
 
+- **0.1.26-draft** (2026-07-25) — PAL table records the destination members: createDestination, createProject's user-chosen destination, and pickDirectory.
 - **0.1.25-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.1.24-draft** (2026-07-22) — Machine-readable spec status vocabulary + generated status page (`79daba23`).
 - **0.1.23-draft** (2026-07-17) — Scheme-variant editing — token overrides, scheme-layer routing, live feedback (`49f0c525`).
@@ -604,4 +608,4 @@ See the [Site Architecture Specification](site-architecture.md) for full design 
 
 ---
 
-_`@jxsuite/studio` Specification v0.1.25-draft_
+_`@jxsuite/studio` Specification v0.1.26-draft_


### PR DESCRIPTION
Creating a project through the dev server wrote it straight into the server's own root — the jx checkout when serving this monorepo — with no prompt and no way to point it elsewhere: `assertAccessible` actively enforced the containment. Desktop and cloud were wrong in their own ways. Desktop did open a native folder dialog, but as a hidden side effect of submission, after the user clicked Create and while the modal already read "Creating…". Cloud never asked at all, silently creating a private repo in the signed-in user's personal account named `slugify(projectName)`.

A project is now written only where the user said to put it. No backend picks a destination, and none falls back to its own root — an unspecified destination is an error, not a default.

`StudioPlatform` gains a required `createDestination` declaration, and `createProject` a required `destination`:

  - "path"  (desktop, dev server) → { kind: "path", parent }
            Location field + Browse…, then the folder name
  - "repo"  (cloud)               → { kind: "repo", owner, repo, private }
            Owner / Repository / Visibility

A live preview shows the resolved destination before anything is written. The Import tab shares the same fields, so its desktop bridges no longer pop a dialog of their own.

Each platform keeps its best native folder chooser: electrobun's `Utils.openFileDialog`, the NixOS chromium build's XDG desktop portal. A plain browser has neither, so the dev server drives `showDirectoryPicker()` and recovers the path the handle withholds (specs/desktop.md §8.2.1): it tags the picked folder with a hidden `.jx-loc-id` whose contents are a one-shot random id, and `GET /__studio/locate-directory` matches on those contents — exact where a path shape is only probable, so neither a duplicated basename nor a tag left by a crashed session can redirect a create. The backend deletes the tag the moment it matches.

The dev server's root containment gets one deliberate carve-out for this, `assertCreatableParent`: absolute paths only, confined to the server root, an `allowedRoots` entry, or the account's home directory, so a hostile page on the loopback origin still cannot scaffold into system paths. Roots created this way are remembered for the process so the very next `/__studio/activate` can open them.

Two containment bugs found while building it are fixed here too: `directory` is validated as a folder name rather than a path (a `../` segment escaped the parent that had just been vetted), and a relative import directory stays contained to the server root instead of being widened to the creatable roots.

BREAKING CHANGE: `StudioPlatform` implementations must declare `createDestination` and honor `createProject`'s `destination`. `POST /__studio/create-project` rejects a request without one, and returns an absolute `root` for projects created outside the server root.

Specs: desktop.md 0.3.0-draft, server.md 0.2.0, studio.md 0.1.26-draft.