### PR TITLE
feat(studio): let the repo picker widen GitHub App repository access

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,7 +17,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.1-draft  | Partial     | 2026-07-22 |
 | `collab.md`               | 0.1.1-draft  | Partial     | 2026-07-22 |
 | `compiler.md`             | 0.1.23-draft | Partial     | 2026-07-24 |
-| `desktop.md`              | 0.3.0-draft  | Pending     | 2026-07-25 |
+| `desktop.md`              | 0.3.1-draft  | Pending     | 2026-07-25 |
 | `extensions.md`           | 0.3.1-draft  | Partial     | 2026-07-25 |
 | `imports.md`              | 0.1.6-draft  | Partial     | 2026-07-22 |
 | `jx-markdown.md`          | 0.1.7-draft  | Partial     | 2026-07-22 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -51,6 +51,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.3.1-draft** (2026-07-25) — Repo picker gains a repository-access footer: per-installation manage links, install-on-another-account, and Refresh.
 - **0.3.0-draft** (2026-07-25) — New Project requires a user-chosen destination: StudioPlatform gains the required createDestination declaration, createProject takes a required destination (path parent or repo owner/name/visibility), and §4.5 defines the create flow. No backend picks a location.
 - **0.2.7-draft** (2026-07-24) — Cloud platform registers inside studio.js via a window.__jxCloud signal (single yjs for collab).
 - **0.2.6-draft** (2026-07-24) — Document packaged static-data staging into app/bun (create templates, starters) and postBuild bundle verification.

--- a/docs/studio/interface/welcome-screen.md
+++ b/docs/studio/interface/welcome-screen.md
@@ -36,6 +36,8 @@ Studio opens the project and adds it to **Recent** for next time.
 
 On **studio.jxsuite.com**, projects live in GitHub repositories instead of local folders, so **Open Project…** opens a repository picker: it lists the GitHub repositories you have write access to (Jx projects first), with a filter field to narrow the list. Click one and Studio opens it at `/edit/owner/repo@branch`. Repositories without a `project.json` show an inline explanation instead of opening.
 
+If a repository you expect isn't listed, the App simply hasn't been given access to it — see [Repository access](#repository-access) below.
+
 ## Clone a git repository
 
 This entry appears when your Studio setup can run git.
@@ -57,7 +59,15 @@ A repository must already contain a Jx project (a `project.json` file); if it do
 
 ## Repository access
 
-If your account is connected but Studio can't reach your repositories yet, a **Repository access** section appears with an **Install the Jx Suite GitHub App** link. Follow it and choose **All repositories** so Studio can create and open projects on your behalf.
+Studio only sees the repositories you have granted the **Jx Suite GitHub App** access to. There are two places to change that.
+
+If your account is connected but Studio can't reach any repositories yet, a **Repository access** section appears on the welcome screen with an **Install the Jx Suite GitHub App** link. Follow it and choose **All repositories** so Studio can create and open projects on your behalf.
+
+Once the App is installed, the repository picker (**Open Project…** and **Add Existing Repository…**) carries the same controls in its footer, so you never have to leave the dialog to widen access:
+
+1. Click the account name in **Missing a repository?** — GitHub opens that installation's **Repository access** settings in a new tab, where you can add repositories or switch to **All repositories**. **Another account…** installs the App on an account or organization that doesn't have it yet.
+2. Save the change on GitHub, then come back to Studio.
+3. Click **Refresh** — the picker re-reads your repositories and the newly granted ones appear.
 
 ## Projects and Recent
 

--- a/docs/studio/projects.md
+++ b/docs/studio/projects.md
@@ -30,7 +30,7 @@ What each kind of file is for — and when to reach for which — is covered in 
 There are three ways to end up with a project open in Studio, all available from the [Welcome screen](/docs/studio/interface/welcome-screen):
 
 1. **Create a new one.** Click **New Project…** and pick a template or a complete starter site — or jump straight to the starter gallery with **Start from an Example…**. You choose the folder it's created in (on studio.jxsuite.com, the GitHub repository); Studio never picks one for you. The whole modal is walked through in **[Create a project](/docs/studio/projects/create)**.
-2. **Open an existing folder.** Click **Open Project…** and point Studio at a Jx project already on your machine. On studio.jxsuite.com the same button lists the GitHub repositories you can write to instead — pick one and Studio opens it. Recently opened projects also appear on the Welcome screen for one-click reopening.
+2. **Open an existing folder.** Click **Open Project…** and point Studio at a Jx project already on your machine. On studio.jxsuite.com the same button lists the GitHub repositories you can write to instead — pick one and Studio opens it, or use the links in the picker's footer to grant the Jx Suite GitHub App access to more of them. Recently opened projects also appear on the Welcome screen for one-click reopening.
 3. **Clone a repository.** Click **Clone Git Repository…** and paste a repository URL — Studio downloads the project and opens it. On platforms linked to a GitHub account, **Add Existing Repository…** lets you pick from your repositories instead of pasting a URL.
 
 :::doc-note

--- a/docs/studio/publish/github.md
+++ b/docs/studio/publish/github.md
@@ -37,7 +37,7 @@ Publishing uploads your project's files to GitHub. With **Private repository** o
 :::
 
 :::doc-tip
-Some Studio platforms connect to GitHub through the **Jx Suite GitHub App** instead — when that applies, the [Welcome screen](/docs/studio/interface/welcome-screen) offers **Install the Jx Suite GitHub App** and an **Add Existing Repository…** picker for repositories your account can already reach.
+Some Studio platforms connect to GitHub through the **Jx Suite GitHub App** instead — when that applies, the [Welcome screen](/docs/studio/interface/welcome-screen) offers **Install the Jx Suite GitHub App** and an **Add Existing Repository…** picker for repositories your account can already reach. The picker's footer links to the App's repository-access settings for each account, so you can widen what Studio sees at any time — see [Repository access](/docs/studio/interface/welcome-screen#repository-access).
 :::
 
 ## Next

--- a/packages/studio/index.html
+++ b/packages/studio/index.html
@@ -3116,6 +3116,46 @@
         color: var(--accent, #1473e6);
         text-decoration: underline;
       }
+      /* Repository-access footer: widen the GitHub App, or reload after doing so. */
+      .add-repo-access {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 6px;
+        padding-top: 8px;
+        border-top: 1px solid var(--border);
+        font-size: var(--spectrum-font-size-50, 11px);
+        color: var(--fg-dim);
+      }
+      .add-repo-access-note {
+        flex: 1 1 auto;
+      }
+      .add-repo-access-links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .add-repo-access-link {
+        color: var(--accent, #1473e6);
+        text-decoration: underline;
+      }
+      .add-repo-refresh {
+        padding: 2px 8px;
+        background: none;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        font: inherit;
+        font-size: var(--spectrum-font-size-50, 11px);
+        color: var(--fg);
+        cursor: pointer;
+      }
+      .add-repo-refresh:hover:not([disabled]) {
+        background: var(--hover-bg);
+      }
+      .add-repo-refresh[disabled] {
+        opacity: 0.5;
+        cursor: default;
+      }
       .new-project-tabs {
         padding: 0 16px;
         border-bottom: 1px solid var(--border);

--- a/packages/studio/src/account-status.ts
+++ b/packages/studio/src/account-status.ts
@@ -33,6 +33,35 @@ export function needsAppInstall(): boolean {
   return cache !== null && cache.installations.length === 0 && Boolean(cache.appInstallUrl);
 }
 
+/** Where the user can widen the App's repository access, for the repo picker's access footer. */
+export interface RepoAccessLinks {
+  /** One entry per installation that reports its settings page, in the platform's order. */
+  manage: { account: string; url: string }[];
+  /** Install the App on an account that has none yet (also covers "another organization"). */
+  installUrl?: string;
+}
+
+/**
+ * Links that let the user grant the App access to more repositories: each installation's own
+ * settings page plus the install URL for accounts it has not reached yet. Null when the status is
+ * unknown (platform without `getAccountStatus`, or a failed hydrate) or when nothing is linkable —
+ * callers render no access affordance rather than a dead link.
+ */
+export function getRepoAccessLinks(): RepoAccessLinks | null {
+  if (cache === null) {
+    return null;
+  }
+  const manage = cache.installations.flatMap((entry) =>
+    entry.manageUrl
+      ? [{ account: entry.account ?? `Installation ${entry.id}`, url: entry.manageUrl }]
+      : [],
+  );
+  if (manage.length === 0 && !cache.appInstallUrl) {
+    return null;
+  }
+  return { manage, ...(cache.appInstallUrl ? { installUrl: cache.appInstallUrl } : {}) };
+}
+
 /** Reset seam for tests. */
 export function resetAccountStatus(): void {
   cache = null;

--- a/packages/studio/src/new-project/add-repo-modal.ts
+++ b/packages/studio/src/new-project/add-repo-modal.ts
@@ -11,11 +11,21 @@
  * project.json, tags + catalogues it) and resolves with the catalogue root key; the caller opens it
  * through the same path as a recent project. Repos without a project.json fail with the backend's
  * structured message, shown inline.
+ *
+ * The list only ever shows what the Jx Suite GitHub App can reach, so the dialog also carries an
+ * access footer: per-installation links to widen the App's repository selection, a link to install
+ * it on another account, and Refresh — the user grants access in a GitHub tab, comes back, and
+ * reloads the list without losing the dialog.
  */
 
 import { html, nothing } from "lit-html";
 import { errorMessage } from "@jxsuite/schema/parse";
-import { getAccountStatus, needsAppInstall } from "../account-status";
+import {
+  getAccountStatus,
+  getRepoAccessLinks,
+  hydrateAccountStatus,
+  needsAppInstall,
+} from "../account-status";
 import { getPlatform } from "../platform";
 import { openModal } from "../ui/layers";
 import type { RepoInfo } from "../types";
@@ -60,10 +70,28 @@ function openPicker(mode: PickerMode): Promise<{ root: string } | null> {
     return Promise.resolve(null);
   }
   _mode = mode;
-  _repos = null;
   _filter = "";
-  _error = "";
   _importing = "";
+
+  loadRepos();
+
+  return new Promise((resolve) => {
+    _resolve = resolve;
+    renderModal();
+  });
+}
+
+/**
+ * (Re)load the repository list and the App's installation coverage. Both feed the same question —
+ * "which repositories can Jx see?" — so a refresh after a permission change re-reads both.
+ */
+function loadRepos(): void {
+  _repos = null;
+  _error = "";
+  // Paints the loading state on a refresh; a no-op on open, where the caller renders next.
+  renderIfOpen();
+
+  void hydrateAccountStatus().then(renderIfOpen);
 
   void getPlatform()
     .listRepos?.()
@@ -75,13 +103,15 @@ function openPicker(mode: PickerMode): Promise<{ root: string } | null> {
       _error = errorMessage(error);
     })
     .finally(() => {
-      renderModal();
+      renderIfOpen();
     });
+}
 
-  return new Promise((resolve) => {
-    _resolve = resolve;
+/** Render only while the dialog is still up — a load settling after close must not reopen it. */
+function renderIfOpen(): void {
+  if (_resolve) {
     renderModal();
-  });
+  }
 }
 
 export function closeAddRepoModal() {
@@ -168,8 +198,8 @@ function emptyTpl() {
   }
   if (_mode === "open" && (_repos ?? []).length > 0) {
     return html`<div class="add-repo-empty">
-      No repositories with write access. Widen the Jx Suite GitHub App's repository access, or ask a
-      repository admin for write access.
+      No repositories with write access. Widen the Jx Suite GitHub App's repository access below, or
+      ask a repository admin for write access.
     </div>`;
   }
   if (needsAppInstall()) {
@@ -183,7 +213,7 @@ function emptyTpl() {
       >
         Install the Jx Suite GitHub App
       </a>
-      to grant repository access, then reopen this dialog.
+      to grant repository access, then use Refresh below.
     </div>`;
   }
   return html`<div class="add-repo-empty">
@@ -201,6 +231,58 @@ function bodyTpl() {
     return emptyTpl();
   }
   return html`<div class="add-repo-list">${repos.map((repo) => repoRowTpl(repo))}</div>`;
+}
+
+/**
+ * Repository-access footer: the list is bounded by what the Jx Suite App was granted, so every mode
+ * offers a way out of that boundary — widen an existing installation, install on another account,
+ * then Refresh to pick up the newly reachable repositories.
+ */
+function accessTpl() {
+  const links = getRepoAccessLinks();
+  if (!links) {
+    return nothing;
+  }
+  return html`
+    <div class="add-repo-access">
+      <span class="add-repo-access-note">
+        Missing a repository? Grant the Jx Suite GitHub App access to more of them:
+      </span>
+      <span class="add-repo-access-links">
+        ${links.manage.map(
+          (entry) => html`
+            <a
+              class="add-repo-access-link"
+              href=${entry.url}
+              target="_blank"
+              rel="noreferrer"
+              title="Manage repository access for ${entry.account}"
+            >
+              ${entry.account}
+            </a>
+          `,
+        )}
+        ${links.installUrl
+          ? html`<a
+              class="add-repo-access-link"
+              href=${links.installUrl}
+              target="_blank"
+              rel="noreferrer"
+              title="Install the Jx Suite GitHub App on another account"
+            >
+              Another account…
+            </a>`
+          : nothing}
+      </span>
+      <button
+        class="add-repo-refresh"
+        ?disabled=${_repos === null || Boolean(_importing)}
+        @click=${() => loadRepos()}
+      >
+        Refresh
+      </button>
+    </div>
+  `;
 }
 
 function renderModal() {
@@ -233,6 +315,7 @@ function renderModal() {
           }}
         ></sp-textfield>
         ${bodyTpl()} ${_error ? html`<div class="new-project-error">${_error}</div>` : nothing}
+        ${accessTpl()}
       </div>
     </div>
   `;

--- a/packages/studio/src/platforms/cloud.ts
+++ b/packages/studio/src/platforms/cloud.ts
@@ -14,6 +14,7 @@
 import type { WsCollabConnection } from "@jxsuite/collab/client";
 import type { ProjectConfig } from "@jxsuite/schema/types";
 import type {
+  AccountStatus,
   CreateProjectDestination,
   DirEntry,
   ExtensionsInfo,
@@ -774,18 +775,30 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
       };
     },
 
-    /** GitHub-App installation coverage from /me — powers the welcome install prompt. */
+    /**
+     * GitHub-App installation coverage from /me — powers the welcome install prompt and the repo
+     * picker's "grant access to more repositories" links (`manageUrl` per installation).
+     */
     async getAccountStatus() {
       const res = await fetch("/api/v1/me", { credentials: "include" });
       if (!res.ok) {
         return null;
       }
       const me = (await res.json()) as {
-        installations?: { id: number; account: string | null }[];
+        installations?: { id: number; account: string | null; manageUrl?: string }[];
         appInstallUrl?: string;
       };
       return {
-        installations: me.installations ?? [],
+        installations: (me.installations ?? []).map((entry) => {
+          const installation: AccountStatus["installations"][number] = {
+            id: entry.id,
+            account: entry.account,
+          };
+          if (entry.manageUrl) {
+            installation.manageUrl = entry.manageUrl;
+          }
+          return installation;
+        }),
         ...(me.appInstallUrl ? { appInstallUrl: me.appInstallUrl } : {}),
       };
     },

--- a/packages/studio/src/types.ts
+++ b/packages/studio/src/types.ts
@@ -94,8 +94,12 @@ export type {
 
 /** Repository-access onboarding state returned by `StudioPlatform.getAccountStatus`. */
 export interface AccountStatus {
-  /** GitHub App installations (personal + organization) visible to the signed-in user. */
-  installations: { id: number; account: string | null }[];
+  /**
+   * GitHub App installations (personal + organization) visible to the signed-in user. `manageUrl`
+   * is that installation's own settings page, where the user widens which repositories the App can
+   * reach; absent when the platform cannot report one.
+   */
+  installations: { id: number; account: string | null; manageUrl?: string }[];
   /** Where to install the App (github.com/apps/<slug>/installations/new), when known. */
   appInstallUrl?: string;
 }

--- a/packages/studio/tests/account-status.test.ts
+++ b/packages/studio/tests/account-status.test.ts
@@ -7,6 +7,7 @@ import { installMockPlatform } from "./harness";
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
   getAccountStatus,
+  getRepoAccessLinks,
   hydrateAccountStatus,
   needsAppInstall,
   resetAccountStatus,
@@ -58,6 +59,59 @@ describe("account-status cache", () => {
     await hydrateAccountStatus();
     expect(getAccountStatus()).toBeNull();
     expect(needsAppInstall()).toBe(false);
+  });
+});
+
+describe("getRepoAccessLinks", () => {
+  test("one manage link per installation that reports one, plus the install URL", async () => {
+    installMockPlatform({
+      getAccountStatus: () =>
+        Promise.resolve({
+          appInstallUrl: INSTALL_URL,
+          installations: [
+            { account: "octocat", id: 7, manageUrl: "https://github.com/settings/installations/7" },
+            // No manageUrl: not linkable, so it contributes nothing.
+            { account: "acme", id: 8 },
+            {
+              account: null,
+              id: 9,
+              manageUrl: "https://github.com/organizations/globex/settings/installations/9",
+            },
+          ],
+        }),
+    });
+    await hydrateAccountStatus();
+    expect(getRepoAccessLinks()).toEqual({
+      manage: [
+        { account: "octocat", url: "https://github.com/settings/installations/7" },
+        {
+          account: "Installation 9",
+          url: "https://github.com/organizations/globex/settings/installations/9",
+        },
+      ],
+      installUrl: INSTALL_URL,
+    });
+  });
+
+  test("the install URL alone still offers a way to widen access", async () => {
+    installMockPlatform({
+      getAccountStatus: () =>
+        Promise.resolve({ appInstallUrl: INSTALL_URL, installations: [{ account: "a", id: 1 }] }),
+    });
+    await hydrateAccountStatus();
+    expect(getRepoAccessLinks()).toEqual({ manage: [], installUrl: INSTALL_URL });
+  });
+
+  test("unknown status, or nothing linkable, means no affordance at all", async () => {
+    installMockPlatform();
+    await hydrateAccountStatus();
+    expect(getRepoAccessLinks()).toBeNull();
+
+    installMockPlatform({
+      getAccountStatus: () => Promise.resolve({ installations: [{ account: "a", id: 1 }] }),
+    });
+    await hydrateAccountStatus();
+    expect(getRepoAccessLinks()).toBeNull();
   });
 });
 

--- a/packages/studio/tests/add-repo-modal.test.ts
+++ b/packages/studio/tests/add-repo-modal.test.ts
@@ -58,6 +58,16 @@ function errorText(): string | null {
   return document.querySelector("#layer-modal .new-project-error")?.textContent?.trim() ?? null;
 }
 
+function accessLinks(): HTMLAnchorElement[] {
+  return [
+    ...document.querySelectorAll("#layer-modal .add-repo-access-link"),
+  ] as HTMLAnchorElement[];
+}
+
+function refreshButton(): HTMLButtonElement | null {
+  return document.querySelector("#layer-modal .add-repo-refresh");
+}
+
 afterEach(() => {
   closeAddRepoModal();
   resetAccountStatus();
@@ -182,6 +192,112 @@ describe("openAddRepoModal", () => {
     expect(rows()).toHaveLength(1);
     expect(rows()[0]!.textContent).toContain("acme/docs");
     closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+});
+
+describe("repository-access footer", () => {
+  const MANAGE_URL = "https://github.com/settings/installations/7";
+  const INSTALL_URL = "https://github.com/apps/jx-suite/installations/new";
+
+  test("offers a manage link per installation plus another-account install", async () => {
+    installMockPlatform({
+      getAccountStatus: () =>
+        Promise.resolve({
+          appInstallUrl: INSTALL_URL,
+          installations: [{ account: "octocat", id: 7, manageUrl: MANAGE_URL }],
+        }),
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () => Promise.resolve(REPOS),
+      openProjectPicker: "repo-list",
+    });
+    const promise = openProjectPickerModal();
+    await flush();
+    // Rendered alongside a populated list — widening access is not just an empty-state fallback.
+    expect(rows()).toHaveLength(2);
+    expect(accessLinks().map((a) => [a.textContent?.trim(), a.href])).toEqual([
+      ["octocat", MANAGE_URL],
+      ["Another account…", INSTALL_URL],
+    ]);
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("the picker hydrates account status itself, so Add mode gets the links too", async () => {
+    installMockPlatform({
+      getAccountStatus: () =>
+        Promise.resolve({
+          appInstallUrl: INSTALL_URL,
+          installations: [{ account: "octocat", id: 7, manageUrl: MANAGE_URL }],
+        }),
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () => Promise.resolve(REPOS),
+    });
+    // No hydrateAccountStatus() call here — opening the dialog must be enough.
+    const promise = openAddRepoModal();
+    await flush();
+    expect(accessLinks()).toHaveLength(2);
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("Refresh re-reads repositories granted while the dialog stayed open", async () => {
+    let granted = false;
+    installMockPlatform({
+      getAccountStatus: () =>
+        Promise.resolve({
+          appInstallUrl: INSTALL_URL,
+          installations: [{ account: "octocat", id: 7, manageUrl: MANAGE_URL }],
+        }),
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () => Promise.resolve(granted ? REPOS : [REPOS[0]!]),
+      openProjectPicker: "repo-list",
+    });
+    const promise = openProjectPickerModal();
+    await flush();
+    expect(rows()).toHaveLength(1);
+
+    granted = true;
+    refreshButton()!.dispatchEvent(new Event("click", { bubbles: true }));
+    // Mid-refresh the list is unknown again, so Refresh cannot be double-fired.
+    expect(refreshButton()!.disabled).toBe(true);
+    await flush();
+    expect(rows()).toHaveLength(2);
+    expect(refreshButton()!.disabled).toBe(false);
+
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("platforms with no account status show no access footer", async () => {
+    installMockPlatform({
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () => Promise.resolve(REPOS),
+    });
+    const promise = openAddRepoModal();
+    await flush();
+    expect(accessLinks()).toHaveLength(0);
+    expect(refreshButton()).toBeNull();
+    closeAddRepoModal();
+    expect(await promise).toBeNull();
+  });
+
+  test("a listing that settles after dismissal does not resurrect the dialog", async () => {
+    let release: (repos: RepoInfo[]) => void = () => {};
+    installMockPlatform({
+      importProject: () => Promise.resolve({ root: "r" }),
+      listRepos: () =>
+        new Promise<RepoInfo[]>((resolve) => {
+          release = resolve;
+        }),
+    });
+    const promise = openAddRepoModal();
+    await flush();
+    closeAddRepoModal();
+    expect(modal()).toBeNull();
+    release(REPOS);
+    await flush();
+    expect(modal()).toBeNull();
     expect(await promise).toBeNull();
   });
 });

--- a/packages/studio/tests/cloud-platform.test.ts
+++ b/packages/studio/tests/cloud-platform.test.ts
@@ -507,6 +507,32 @@ describe("identity & cloudflare surface", () => {
     expect(await p.getAccountStatus?.()).toBeNull();
   });
 
+  test("getAccountStatus carries each installation's manage URL through", async () => {
+    mockFetch({
+      "/api/v1/me": {
+        body: {
+          user: { login: "octocat" },
+          installations: [
+            {
+              id: 1,
+              account: "octocat",
+              manageUrl: "https://github.com/settings/installations/1",
+            },
+            { id: 2, account: "acme" },
+          ],
+          appInstallUrl: "https://github.com/apps/jx-suite/installations/new",
+        },
+      },
+    });
+    expect(await createCloudPlatform(null).getAccountStatus?.()).toEqual({
+      installations: [
+        { id: 1, account: "octocat", manageUrl: "https://github.com/settings/installations/1" },
+        { id: 2, account: "acme" },
+      ],
+      appInstallUrl: "https://github.com/apps/jx-suite/installations/new",
+    });
+  });
+
   test("createProject preserves the structured needs_installation_access failure", async () => {
     mockFetch({
       "/api/v1/projects": {

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,7 +2,7 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.3.0-draft
+**Version:** 0.3.1-draft
 **Status:** Pending
 **Updated:** 2026-07-25
 **License:** MIT
@@ -158,6 +158,16 @@ A project is identified by its `project.json` file. This is the single point of 
 - **Desktop:** User selects `project.json` via native file dialog. The parent directory becomes the project root.
 - **Dev server:** User selects the folder containing `project.json` via `showDirectoryPicker()`. Studio reads `project.json` from the directory to validate it.
 - **Cloud:** User picks from a repository list (`openProjectPicker: "repo-list"` — GitHub repositories with write access, Jx-tagged repos first). Selection runs `importProject`, which probes the repository's `project.json` and resolves the catalogue root key Studio navigates to.
+
+What that list contains is bounded by the App's grant, not by the account's repositories, so the picker (both modes — Open Project and Add Existing Repository) also renders a **repository-access footer** built from `getAccountStatus()`:
+
+| Affordance                | Source                      | Effect                                                                        |
+| ------------------------- | --------------------------- | ----------------------------------------------------------------------------- |
+| One link per installation | `installations[].manageUrl` | Opens that installation's repository-access settings on GitHub (new tab)      |
+| "Another account…"        | `appInstallUrl`             | Installs the App on an account that has none                                  |
+| Refresh                   | —                           | Re-runs `listRepos` + `getAccountStatus` in place, without closing the dialog |
+
+The footer is omitted entirely when the status is unknown or nothing is linkable (a platform without `getAccountStatus`, a failed hydrate, or installations that report no `manageUrl` and no install URL) — Studio never renders a dead access link.
 
 The `project.json` file is **required** for project-level features. Studio can still open individual `.json` files for standalone component editing (see §4.3).
 
@@ -792,6 +802,7 @@ Ensure desktop app matches dev-mode capabilities:
 
 ## Changelog
 
+- **0.3.1-draft** (2026-07-25) — Repo picker gains a repository-access footer: per-installation manage links, install-on-another-account, and Refresh.
 - **0.3.0-draft** (2026-07-25) — New Project requires a user-chosen destination: StudioPlatform gains the required createDestination declaration, createProject takes a required destination (path parent or repo owner/name/visibility), and §4.5 defines the create flow. No backend picks a location.
 - **0.2.7-draft** (2026-07-24) — Cloud platform registers inside studio.js via a window.__jxCloud signal (single yjs for collab).
 - **0.2.6-draft** (2026-07-24) — Document packaged static-data staging into app/bun (create templates, starters) and postBuild bundle verification.
@@ -811,4 +822,4 @@ Ensure desktop app matches dev-mode capabilities:
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.3.0-draft_
+_Jx Studio Desktop Architecture Specification v0.3.1-draft_


### PR DESCRIPTION
The picker can only ever list what the Jx Suite GitHub App was granted, so a repository the user expects simply isn't there — with no way out of the dialog. Both modes (Open Project and Add Existing Repository) now carry an access footer: one link per installation to its GitHub repository-access settings, "Another account…" to install the App somewhere new, and Refresh to re-read the list after granting access in the GitHub tab.

- AccountStatus.installations[] gains manageUrl, plumbed from /me through the cloud adapter; getRepoAccessLinks() renders nothing when the status is unknown or nothing is linkable, so no dead link ever appears.
- Refresh re-runs listRepos + getAccountStatus in place. Extracting that path also fixes a listing that settled after dismissal re-opening the closed dialog.

Specs & docs: specs/desktop.md §4.1 documents the footer contract (0.3.1-draft, generated pages regenerated); the welcome-screen page documents the widen → Refresh loop, referenced from projects.md and publish/github.md.