### PR TITLE
feat(schema): make per-project schema composition host-agnostic

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -18,7 +18,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `collab.md`               | 0.1.1-draft  | Partial     | 2026-07-22 |
 | `compiler.md`             | 0.1.23-draft | Partial     | 2026-07-24 |
 | `desktop.md`              | 0.3.1-draft  | Pending     | 2026-07-25 |
-| `extensions.md`           | 0.3.2-draft  | Partial     | 2026-07-25 |
+| `extensions.md`           | 0.3.3-draft  | Partial     | 2026-07-25 |
 | `imports.md`              | 0.1.6-draft  | Partial     | 2026-07-22 |
 | `jx-markdown.md`          | 0.1.7-draft  | Partial     | 2026-07-22 |
 | `parser.md`               | 0.2.4-draft  | Partial     | 2026-07-23 |
@@ -28,7 +28,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `site-architecture.md`    | 0.1.37-draft | Pending     | 2026-07-24 |
 | `spec.md`                 | 0.4.24-draft | Partial     | 2026-07-24 |
 | `studio-ui-guidelines.md` | 0.1.6        | Implemented | 2026-07-22 |
-| `studio.md`               | 0.1.27-draft | Partial     | 2026-07-25 |
+| `studio.md`               | 0.1.28-draft | Partial     | 2026-07-25 |
 
 ## Sections not yet implemented
 

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -72,6 +72,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `extensions.md`
 
+- **0.3.3-draft** (2026-07-25) — Composition is host-agnostic: one pure function with an injected loader, so the cloud session composes the same entry documents in-Worker with no filesystem (§5.5).
 - **0.3.2-draft** (2026-07-25) — $schema bindings must be satisfied by by-id registration, never fetching — an in-document $schema overrides fileMatch and an unresolvable one voids validation entirely (§5.4).
 - **0.3.1-draft** (2026-07-25) — $paths validates against the source union instead of accepting any object (§5.3).
 - **0.3.0-draft** (2026-07-25) — Committed entry documents are single-resource: every $ref a root pointer (§5.2, §5.4).
@@ -257,6 +258,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `studio.md`
 
+- **0.1.28-draft** (2026-07-25) — The Cloud platform target composes per-project schemas server-side (§3.4).
 - **0.1.27-draft** (2026-07-25) — Source-mode schema validation contract: per-project entry documents, offline $schema-id registration, worker self-location (§4.2.1); fetchProjectSchemas in the PAL table (§3.4).
 - **0.1.26-draft** (2026-07-25) — PAL table records the destination members: createDestination, createProject's user-chosen destination, and pickDirectory.
 - **0.1.25-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).

--- a/docs/studio/logic/code.md
+++ b/docs/studio/logic/code.md
@@ -41,7 +41,7 @@ The **Code** entry in the toolbar's mode switcher shows the open file itself as 
 - **Export** in the tab bar saves a copy of the file elsewhere.
 
 :::doc-note
-Studio regenerates those two schema files whenever they are missing or older than `project.json`, so a project you have never run `jx schema` on still validates, and turning an extension on or off updates the rules without a restart.
+You never have to generate those files yourself: Studio refreshes them whenever they are missing or out of date, so a project you have never run `jx schema` on still validates, and turning an extension on or off updates the rules without a restart. In the browser at [studio.jxsuite.com](https://studio.jxsuite.com) the rules are composed for you on the server and nothing is written to your repository at all.
 :::
 
 ## When to drop down

--- a/packages/compiler/src/site/schema-command.ts
+++ b/packages/compiler/src/site/schema-command.ts
@@ -20,8 +20,7 @@ import { createRequire } from "node:module";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import {
   bundleSchema,
-  emitDocumentSchema,
-  emitProjectSchema,
+  composeProjectSchemas,
   flattenSchema,
 } from "@jxsuite/schema/project-schemas";
 import { buildProjectExtensionRegistry } from "./format-host.ts";
@@ -42,48 +41,22 @@ export async function writeProjectSchemas(projectRoot: string) {
   const { config } = loadProjectConfig(projectRoot);
   const registry = await buildProjectExtensionRegistry(projectRoot, config);
 
-  const corePath = coreSchemaRef(projectRoot, CORE_PROJECT_SPECIFIER);
-  const fragments: string[] = [];
-  const pathsValueRefs: string[] = [];
-  const documentFragments: string[] = [];
-  const fieldSchemaRefs: string[] = [];
-  for (const ext of registry.extensions) {
-    const projectFragment = ext.schemas.project;
-    if (projectFragment) {
-      fragments.push(fragmentRef(projectRoot, ext, projectFragment));
-    }
-    const documentFragment = ext.schemas.document;
-    if (documentFragment) {
-      const documentRefs = fragmentDefsRefs(documentFragment);
-      pathsValueRefs.push(...documentRefs);
-      /* The paths union names this fragment's shapes by canonical $id only, so the bundler needs
-         the path handed to it explicitly or those refs stay dangling. A fragment that contributed
-         nothing (no $id, or no $defs) is left out rather than embedded unreferenced. */
-      if (documentRefs.length > 0) {
-        documentFragments.push(fragmentRef(projectRoot, ext, documentFragment));
-      }
-    }
-    // The `schemas.fields` manifest convention: a fragment whose $defs members are extension
-    // Field extras, unioned into the per-project field resource (specs/extensions.md §5.3).
-    const fieldsFragment = ext.schemas.fields;
-    if (fieldsFragment) {
-      fieldSchemaRefs.push(...fragmentDefsRefs(fieldsFragment));
-      fragments.push(fragmentRef(projectRoot, ext, fieldsFragment));
-    }
-  }
-
-  // Bundle then flatten before committing: the emitted relative refs are an intermediate form only.
+  /* Composition itself is host-agnostic (@jxsuite/schema `composeProjectSchemas`) — the filesystem
+     appears only in what this host contributes: project-relative refs for the fragments the
+     registry resolved, and a loader restricted to the project root. The cloud session composes the
+     same two documents from bundled artifacts through the same function. */
   const root = resolve(projectRoot);
-  const loadJson = restrictedSchemaLoader(root);
-  const projectEntry = emitProjectSchema({ corePath, fieldSchemaRefs, fragments });
-  const documentEntry = emitDocumentSchema({
-    corePath: coreSchemaRef(projectRoot, CORE_DOCUMENT_SPECIFIER),
-    pathsValueRefs,
+  const { document: documentSchema, project: projectSchema } = await composeProjectSchemas({
+    baseDir: root,
+    coreDocumentRef: coreSchemaRef(projectRoot, CORE_DOCUMENT_SPECIFIER),
+    coreProjectRef: coreSchemaRef(projectRoot, CORE_PROJECT_SPECIFIER),
+    extensions: registry.extensions.map((ext) => ({
+      document: ext.schemas.document && fragmentRef(projectRoot, ext, ext.schemas.document),
+      fields: ext.schemas.fields && fragmentRef(projectRoot, ext, ext.schemas.fields),
+      project: ext.schemas.project && fragmentRef(projectRoot, ext, ext.schemas.project),
+    })),
+    loadJson: restrictedSchemaLoader(root),
   });
-  const projectSchema = flattenSchema(await bundleSchema(projectEntry, loadJson, root));
-  const documentSchema = flattenSchema(
-    await bundleSchema(documentEntry, loadJson, root, documentFragments),
-  );
 
   const projectSchemaPath = resolve(projectRoot, "project.schema.json");
   const documentSchemaPath = resolve(projectRoot, "document.schema.json");
@@ -239,26 +212,4 @@ function projectRelativeRef(projectRoot: string, absPath: string, conventional: 
     return conventional;
   }
   return rel.startsWith("./") ? rel : `./${rel}`;
-}
-
-/**
- * Canonical "uri#/pointer" refs into a fragment's `$defs` shapes: one per `$defs` entry, addressed
- * by the fragment's own `$id` (refs inside the entry document's embeds resolve against canonical
- * URIs, never file locations). Serves both the document paths union and the fields-extras union.
- *
- * @param {string} fragmentPath - Resolved absolute fragment path
- * @returns {string[]}
- */
-function fragmentDefsRefs(fragmentPath: string): string[] {
-  let fragment: { $id?: unknown; $defs?: Record<string, unknown> };
-  try {
-    fragment = JSON.parse(readFileSync(fragmentPath, "utf8")) as typeof fragment;
-  } catch {
-    return [];
-  }
-  const { $id } = fragment;
-  if (typeof $id !== "string" || !fragment.$defs) {
-    return [];
-  }
-  return Object.keys(fragment.$defs).map((name) => `${$id}#/$defs/${name}`);
 }

--- a/packages/schema/src/project-schemas.ts
+++ b/packages/schema/src/project-schemas.ts
@@ -490,3 +490,119 @@ export function emitDocumentSchema(inputs: DocumentSchemaInputs): Record<string,
     allOf: [{ $ref: corePath }],
   };
 }
+
+// ─── Composition (specs/extensions.md §5.2) ──────────────────────────────────
+
+/** Loader-resolvable refs to one extension's shipped schema fragments, as its manifest names them. */
+export interface ExtensionFragmentRefs {
+  /** Project fragment — plain `properties` for the extension's section keys. */
+  project?: string | undefined;
+  /** Document fragment — its `$defs` become `$paths` source-union members. */
+  document?: string | undefined;
+  /** Fields fragment — its `$defs` become Field-schema union members. */
+  fields?: string | undefined;
+}
+
+export interface ComposeProjectSchemasInputs {
+  /** Ref to the core project fragment (`@jxsuite/schema/schemas/project.core.schema.json`). */
+  coreProjectRef: string;
+  /** Ref to the core document schema (`@jxsuite/schema/schema.json`). */
+  coreDocumentRef: string;
+  /** Enabled extensions in registry order; each contributes the fragments it ships. */
+  extensions: ExtensionFragmentRefs[];
+  /** Loads a ref's JSON. Every ref above and every `$ref` inside resolves through this ALONE. */
+  loadJson: SchemaJsonLoader;
+  /** Directory the refs resolve against ("" for hosts addressing by bare specifier). */
+  baseDir: string;
+}
+
+/**
+ * Compose a project's two committed entry documents from the core schemas and its enabled
+ * extensions' fragments — bundled, then flattened to root JSON pointers (§5.2/§5.4).
+ *
+ * Host-agnostic by construction: every file it needs arrives through `loadJson`, so the same
+ * composition runs over a filesystem (`jx schema`) and over a virtual tree of bundled artifacts
+ * (the cloud session, which has no `node_modules` and no filesystem). That shared path is the point
+ * — a project's schemas must not depend on which host generated them.
+ *
+ * @param {ComposeProjectSchemasInputs} inputs - Core refs, extension fragments, loader, base
+ * @returns {Promise<{ project: Record<string, unknown>; document: Record<string, unknown> }>} The
+ *   self-contained entry documents, ready to write or to hand an editor
+ */
+export async function composeProjectSchemas(inputs: ComposeProjectSchemasInputs): Promise<{
+  project: Record<string, unknown>;
+  document: Record<string, unknown>;
+}> {
+  const { baseDir, coreDocumentRef, coreProjectRef, extensions, loadJson } = inputs;
+
+  const fragments: string[] = [];
+  const pathsValueRefs: string[] = [];
+  const documentFragments: string[] = [];
+  const fieldSchemaRefs: string[] = [];
+  for (const ext of extensions) {
+    if (ext.project) {
+      fragments.push(ext.project);
+    }
+    if (ext.document) {
+      const documentRefs = await fragmentDefsRefs(ext.document, loadJson, baseDir);
+      pathsValueRefs.push(...documentRefs);
+      /* The paths union names this fragment's shapes by canonical $id only, so the bundler needs
+         the path handed to it explicitly or those refs stay dangling. A fragment that contributed
+         nothing (no $id, or no $defs) is left out rather than embedded unreferenced. */
+      if (documentRefs.length > 0) {
+        documentFragments.push(ext.document);
+      }
+    }
+    // The `schemas.fields` manifest convention: a fragment whose $defs members are extension
+    // Field extras, unioned into the per-project field resource (specs/extensions.md §5.3).
+    if (ext.fields) {
+      fieldSchemaRefs.push(...(await fragmentDefsRefs(ext.fields, loadJson, baseDir)));
+      fragments.push(ext.fields);
+    }
+  }
+
+  // Bundle then flatten: the emitted relative refs are an intermediate form only.
+  const projectEntry = emitProjectSchema({ corePath: coreProjectRef, fieldSchemaRefs, fragments });
+  const documentEntry = emitDocumentSchema({ corePath: coreDocumentRef, pathsValueRefs });
+  return {
+    document: flattenSchema(
+      await bundleSchema(documentEntry, loadJson, baseDir, documentFragments),
+    ),
+    project: flattenSchema(await bundleSchema(projectEntry, loadJson, baseDir)),
+  };
+}
+
+/**
+ * Canonical "uri#/pointer" refs into a fragment's `$defs` shapes: one per `$defs` entry, addressed
+ * by the fragment's own `$id` (refs inside the entry document's embeds resolve against canonical
+ * URIs, never file paths). An `$id`-less or `$defs`-less fragment contributes no union members —
+ * that is simply the shape of a fragment declaring only `properties`.
+ *
+ * An UNREADABLE fragment contributes nothing here but still fails the composition, because the
+ * bundler goes on to embed the same ref and throws. That is deliberate: silently dropping it would
+ * emit an entry document that under-validates the project with nothing to show for it. A host that
+ * cannot supply an extension's fragments must leave that extension out of `extensions` entirely —
+ * which is exactly what the cloud session does for packages it does not bundle.
+ *
+ * @param {string} ref - Loader-resolvable ref to the fragment, relative to `baseDir`
+ * @param {SchemaJsonLoader} loadJson - The host's loader
+ * @param {string} baseDir - Directory the ref resolves against
+ * @returns {Promise<string[]>} One ref per `$defs` member, in declaration order
+ */
+async function fragmentDefsRefs(
+  ref: string,
+  loadJson: SchemaJsonLoader,
+  baseDir: string,
+): Promise<string[]> {
+  let fragment: { $id?: unknown; $defs?: Record<string, unknown> };
+  try {
+    fragment = await loadJson(normalizeSchemaPath(`${normalizeSchemaPath(baseDir)}/${ref}`));
+  } catch {
+    return [];
+  }
+  const { $id } = fragment;
+  if (typeof $id !== "string" || !fragment.$defs) {
+    return [];
+  }
+  return Object.keys(fragment.$defs).map((name) => `${$id}#/$defs/${name}`);
+}

--- a/packages/schema/tests/project-schemas.test.ts
+++ b/packages/schema/tests/project-schemas.test.ts
@@ -20,6 +20,7 @@ import {
   PROJECT_CORE_SCHEMA_ID,
   PROJECT_FIELDS_SCHEMA_ID,
   emitDocumentSchema,
+  composeProjectSchemas,
   emitProjectSchema,
 } from "../src/project-schemas";
 import {
@@ -276,5 +277,150 @@ describe("generated core fragment, union defaults, and manifest schema", () => {
     ).toBe(true);
     expect(validate({ classes: {} })).toBe(false); // Missing name
     expect(validate({ extra: true, name: "@x/y" })).toBe(false);
+  });
+});
+
+/* ComposeProjectSchemas is the host-agnostic half of `jx schema`: the filesystem host (the compiler)
+   and the cloud session (a Worker with no filesystem and no node_modules) must produce the SAME two
+   entry documents for the same project, because a project's schemas cannot depend on which host
+   generated them. These tests drive it over an in-memory loader — the shape the cloud uses. */
+describe("composeProjectSchemas (host-agnostic composition)", () => {
+  const CORE_PROJECT = {
+    $id: PROJECT_CORE_SCHEMA_ID,
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    properties: { name: { type: "string" } },
+    type: "object",
+    $defs: {
+      JxFieldSchema: { type: "object" },
+      RelationshipRef: { type: "object" },
+    },
+  };
+  const CORE_DOCUMENT = {
+    $id: "https://jxsuite.com/schema/v1",
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    properties: { tagName: { type: "string" } },
+    type: "object",
+  };
+  const EXT_PROJECT = {
+    $id: "https://jxsuite.com/schema/ext/parser/project/v1",
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    properties: { content: { type: "object" } },
+  };
+  const EXT_DOCUMENT = {
+    $id: "https://jxsuite.com/schema/ext/parser/document/v1",
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $defs: { ContentPathsSource: { type: "object", required: ["contentType"] } },
+  };
+  const EXT_FIELDS = {
+    $id: "https://jxsuite.com/schema/ext/connector/fields/v1",
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $defs: { ColumnExtras: { type: "object" } },
+  };
+
+  /** Bare-specifier loader: exactly what a Worker has — a table, no filesystem. */
+  const FILES: Record<string, object> = {
+    "@jxsuite/connector/schemas/fields.fragment.schema.json": EXT_FIELDS,
+    "@jxsuite/parser/schemas/document.fragment.schema.json": EXT_DOCUMENT,
+    "@jxsuite/parser/schemas/project.fragment.schema.json": EXT_PROJECT,
+    "@jxsuite/schema/schema.json": CORE_DOCUMENT,
+    "@jxsuite/schema/schemas/project.core.schema.json": CORE_PROJECT,
+  };
+  const loadJson = (path: string): Promise<Record<string, unknown>> => {
+    // Refs resolve against baseDir "", so the bundler hands over a leading slash.
+    const file = FILES[path.replace(/^\//, "")];
+    return file
+      ? Promise.resolve(structuredClone(file) as Record<string, unknown>)
+      : Promise.reject(new Error(`No such file: ${path}`));
+  };
+  const compose = (extensions: Parameters<typeof composeProjectSchemas>[0]["extensions"]) =>
+    composeProjectSchemas({
+      baseDir: "",
+      coreDocumentRef: "@jxsuite/schema/schema.json",
+      coreProjectRef: "@jxsuite/schema/schemas/project.core.schema.json",
+      extensions,
+      loadJson,
+    });
+
+  test("composes self-contained entry documents with no external refs left", async () => {
+    const { document, project } = await compose([
+      {
+        document: "@jxsuite/parser/schemas/document.fragment.schema.json",
+        project: "@jxsuite/parser/schemas/project.fragment.schema.json",
+      },
+    ]);
+
+    // Self-containment is the contract (§5.4): every ref a root-relative JSON pointer.
+    for (const entry of [project, document]) {
+      const refs: string[] = [];
+      JSON.stringify(entry, (key, value) => {
+        if (key === "$ref" && typeof value === "string") {
+          refs.push(value);
+        }
+        return value as unknown;
+      });
+      expect(refs.length).toBeGreaterThan(0);
+      expect(refs.every((ref) => ref.startsWith("#/"))).toBe(true);
+    }
+  });
+
+  test("both entry documents compile and enforce the composition under ajv", async () => {
+    const { document, project } = await compose([
+      {
+        document: "@jxsuite/parser/schemas/document.fragment.schema.json",
+        project: "@jxsuite/parser/schemas/project.fragment.schema.json",
+      },
+    ]);
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+
+    const validateProject = ajv.compile(project);
+    expect(validateProject({ content: {}, name: "Demo" })).toBe(true);
+    // Closed by `unevaluatedProperties: false` over the composition over core + the extension's fragment.
+    expect(validateProject({ name: "Demo", typodSection: {} })).toBe(false);
+
+    expect(ajv.compile(document)({ tagName: "div" })).toBe(true);
+  });
+
+  test("an extension's document $defs join the paths union; its fragment is embedded", async () => {
+    const { document } = await compose([
+      { document: "@jxsuite/parser/schemas/document.fragment.schema.json" },
+    ]);
+    const serialized = JSON.stringify(document);
+    expect(serialized).toContain("ContentPathsSource");
+    // Referenced by canonical $id only, so it must be embedded explicitly or the ref dangles.
+    expect(new Ajv2020({ allErrors: true, strict: false }).compile(document)).toBeTruthy();
+  });
+
+  test("a fields fragment contributes its $defs to the field union", async () => {
+    const { project } = await compose([
+      { fields: "@jxsuite/connector/schemas/fields.fragment.schema.json" },
+    ]);
+    expect(JSON.stringify(project)).toContain("ColumnExtras");
+  });
+
+  test("no extensions still yields the core-only pair", async () => {
+    const { document, project } = await compose([]);
+    expect(project.$comment).toBe(GENERATED_SCHEMA_COMMENT);
+    expect(document.$comment).toBe(GENERATED_SCHEMA_COMMENT);
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    expect(ajv.compile(project)({ name: "Demo" })).toBe(true);
+    expect(ajv.compile(document)({ tagName: "div" })).toBe(true);
+  });
+
+  /* A fragment the host cannot supply fails LOUDLY rather than being dropped: a silently
+     incomplete entry document would under-validate the project with nothing to show for it. Hosts
+     that cannot supply an extension's fragments leave the extension out of the list instead — what
+     the cloud session does for packages it does not bundle. */
+  test("an unreadable fragment fails the composition rather than being dropped", async () => {
+    await expect(compose([{ fields: "@jxsuite/missing/fields.json" }])).rejects.toThrow(
+      /cannot load \$ref target/,
+    );
+  });
+
+  test("a fragment without $id or $defs contributes no union members", async () => {
+    FILES["@jxsuite/bare/fields.json"] = { type: "object" };
+    const { project } = await compose([{ fields: "@jxsuite/bare/fields.json" }]);
+    const fields = (project.$defs as Record<string, { anyOf?: unknown[] }>).Fields;
+    // Core JxFieldSchema + RelationshipRef only.
+    expect(fields?.anyOf).toHaveLength(2);
   });
 });

--- a/packages/studio/src/platforms/cloud.ts
+++ b/packages/studio/src/platforms/cloud.ts
@@ -24,6 +24,7 @@ import type {
   GitStatusResult,
   PackageInfo,
   ProjectListEntry,
+  ProjectSchemasResponse,
   RenameResult,
   RepoInfo,
   StarterInfo,
@@ -413,6 +414,27 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
         return body.extensions ?? [];
       } catch {
         return [];
+      }
+    },
+
+    /**
+     * The session's generated entry documents, composed server-side from the core schemas and each
+     * enabled extension's fragments (extensions.md §5.2) and returned PRE-BUNDLED — Monaco and the
+     * AI assistant register them as inline objects and never fetch (studio.md §4.2.1).
+     *
+     * Degrades to `{}` rather than throwing: a backend too old to serve the route, or a project
+     * whose extensions the session cannot compose, keeps the bundled core schemas. That fallback
+     * under-suggests extension extras but never reports false errors (§5.3).
+     */
+    async fetchProjectSchemas(): Promise<ProjectSchemasResponse> {
+      try {
+        const res = await api("/project-schemas");
+        if (!res.ok) {
+          return {};
+        }
+        return (await res.json()) as ProjectSchemasResponse;
+      } catch {
+        return {};
       }
     },
 

--- a/packages/studio/tests/cloud-platform.test.ts
+++ b/packages/studio/tests/cloud-platform.test.ts
@@ -830,6 +830,26 @@ describe("formats (session backend registry)", () => {
     expect(await projectless.listExtensions?.()).toEqual([]);
   });
 
+  /* The cloud composes the entry documents server-side from bundled artifacts (it has no
+     node_modules and no filesystem), so the studio just registers what it is handed. Before this
+     member existed the cloud always fell back to the core schemas, and extension sections got no
+     editor validation at all. */
+  test("fetchProjectSchemas reads the session's pre-bundled entry documents", async () => {
+    const project = { $comment: "generated", allOf: [{ $ref: "#/$defs/project-core-v2" }] };
+    const document = { $comment: "generated", allOf: [{ $ref: "#/$defs/v1" }] };
+    const calls = mockFetch({ "/project-schemas": { body: { document, project } } });
+    const p = createCloudPlatform(PROJECT);
+    expect(await p.fetchProjectSchemas?.()).toEqual({ document, project });
+    expect(calls.every((c) => c.url === `${BASE}/project-schemas`)).toBe(true);
+  });
+
+  test("fetchProjectSchemas degrades to the core-schema fallback, never throwing", async () => {
+    mockFetch({ "/project-schemas": { status: 404, body: { error: "no such route" } } });
+    expect(await createCloudPlatform(PROJECT).fetchProjectSchemas?.()).toEqual({});
+    // Project-less mode has no session to ask.
+    expect(await createCloudPlatform(null).fetchProjectSchemas?.()).toEqual({});
+  });
+
   test("formatAction posts to the session format route and unwraps result", async () => {
     const calls = mockFetch({
       "/format": { body: { result: { children: [{ tagName: "h1", textContent: "Hello" }] } } },

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -2,7 +2,7 @@
 
 ## Extension Packages, Schema Composition, and the Capability Contract
 
-**Version:** 0.3.2-draft
+**Version:** 0.3.3-draft
 **Status:** Partial
 **Updated:** 2026-07-25
 **License:** MIT
@@ -375,6 +375,31 @@ names) are emitted by the generator, which is the single aggregation party.
   Where a client fetches the canonical URLs instead (they are served from
   jxsuite.com), it gets the shipped defaults — degradation is
   _under-suggestion_ of extension field extras, never false errors.
+
+### 5.5 Composition is host-agnostic
+
+Composition itself — core fragment plus each enabled extension's fragments,
+bundled then flattened — is one pure function taking an injected JSON loader.
+Every host supplies only the loader and the refs; none supplies the algorithm.
+A project's entry documents therefore cannot depend on which host generated
+them, which is what lets a project move between a laptop, the desktop app and
+the cloud without its validation changing.
+
+The loader is the entire host-specific surface:
+
+| Host                             | Loader                                                                                    | Refs                                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `jx schema`, dev server, desktop | Filesystem, restricted to the project root, with host resolution for `./node_modules/...` | Project-relative paths                                                        |
+| Cloud session                    | A build-time table of bundled artifacts, plus the session's working tree                  | Bare specifiers for bundled packages; tree paths for project-local extensions |
+
+The cloud composes **on demand and writes nothing back**: a cloud project needs
+no committed `*.schema.json` to get full editor validation. Its constraint is
+that a Worker ships a fixed set of extension packages, so an extension the
+platform does not bundle is dropped from the registry before composition rather
+than passed to it — the composer fails loudly on a fragment it cannot load,
+because emitting an entry document that silently under-validates would be worse
+than an error. Dropping the extension instead lands on the §5.3 degradation:
+under-suggestion of that extension's extras, never false errors.
 
 ---
 
@@ -956,6 +981,7 @@ requiring changes to any core package.
 
 ## Changelog
 
+- **0.3.3-draft** (2026-07-25) — Composition is host-agnostic: one pure function with an injected loader, so the cloud session composes the same entry documents in-Worker with no filesystem (§5.5).
 - **0.3.2-draft** (2026-07-25) — $schema bindings must be satisfied by by-id registration, never fetching — an in-document $schema overrides fileMatch and an unresolvable one voids validation entirely (§5.4).
 - **0.3.1-draft** (2026-07-25) — $paths validates against the source union instead of accepting any object (§5.3).
 - **0.3.0-draft** (2026-07-25) — Committed entry documents are single-resource: every $ref a root pointer (§5.2, §5.4).
@@ -973,4 +999,4 @@ requiring changes to any core package.
 
 ---
 
-_Jx Extensions Specification v0.3.2-draft_
+_Jx Extensions Specification v0.3.3-draft_

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -2,7 +2,7 @@
 
 ## Visual Builder for Jx Documents
 
-**Version:** 0.1.27-draft
+**Version:** 0.1.28-draft
 **Status:** Partial
 **Updated:** 2026-07-25
 **License:** MIT
@@ -100,7 +100,8 @@ Three platform targets:
 
 - **DevServer** (`platforms/devserver.js`) — Wraps `/__studio/*` fetch calls for Chrome-based development.
 - **Desktop** (`@jxsuite/desktop`) — ElectroBun app with RPC to Bun process for native file I/O.
-- **Cloud** — Future SaaS target.
+- **Cloud** (`platforms/cloud.js`) — Hosted sessions over the platform's session API; the backend
+  composes per-project schemas in-Worker (extensions.md §5.5), so §4.2.1 holds there too.
 
 Registration: `registerPlatform(impl)` at startup, `getPlatform()` for access.
 
@@ -601,6 +602,7 @@ See the [Site Architecture Specification](site-architecture.md) for full design 
 
 ## Changelog
 
+- **0.1.28-draft** (2026-07-25) — The Cloud platform target composes per-project schemas server-side (§3.4).
 - **0.1.27-draft** (2026-07-25) — Source-mode schema validation contract: per-project entry documents, offline $schema-id registration, worker self-location (§4.2.1); fetchProjectSchemas in the PAL table (§3.4).
 - **0.1.26-draft** (2026-07-25) — PAL table records the destination members: createDestination, createProject's user-chosen destination, and pickDirectory.
 - **0.1.25-draft** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
@@ -632,4 +634,4 @@ See the [Site Architecture Specification](site-architecture.md) for full design 
 
 ---
 
-_`@jxsuite/studio` Specification v0.1.27-draft_
+_`@jxsuite/studio` Specification v0.1.28-draft_


### PR DESCRIPTION
Cloud Studio was the one host with no per-project schema validation: its platform adapter had no fetchProjectSchemas, so it always fell back to the bundled core schemas and extension-contributed sections got no editor validation at all. It could not simply reuse the compiler's implementation — `readBundledProjectSchemas` is built on node:fs, and a Worker has neither a filesystem nor node_modules.

The composition never needed either. Extract it as `composeProjectSchemas`, a pure function over an injected JSON loader, and let each host supply only the loader and the refs:

- `jx schema` / dev server / desktop keep the filesystem loader restricted to the project root, with host resolution for ./node_modules/... refs;
- the cloud session (jx-platform) supplies a build-time table of bundled extension artifacts plus the DO's working tree.

Neither supplies the algorithm, so a project's entry documents cannot depend on which host generated them — the property that lets a project move between a laptop, the desktop app and the cloud without its validation changing. The compiler's output is unchanged: `schema:generate-all` produces byte-identical files before and after (the diff it reports against the committed *.schema.json files reproduces exactly on HEAD — those have been stale for a while, and are left alone here rather than buried under this change).

A fragment the loader cannot read fails the composition rather than being dropped, which the extraction makes explicit and tests. Silently omitting one would emit an entry document that under-validates the project with nothing to show for it; a host that cannot supply an extension's fragments must leave that extension out of the list instead, which is what the cloud does for packages it does not bundle (degrading to §5.3 under-suggestion, never false errors).