### PR TITLE
fix(studio): replace native prompts with a Spectrum prompt dialog

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -27,8 +27,8 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `server.md`               | 0.2.1        | Implemented | 2026-07-25 |
 | `site-architecture.md`    | 0.1.37-draft | Pending     | 2026-07-24 |
 | `spec.md`                 | 0.4.24-draft | Partial     | 2026-07-24 |
-| `studio-ui-guidelines.md` | 0.1.6        | Implemented | 2026-07-22 |
-| `studio.md`               | 0.1.28-draft | Partial     | 2026-07-25 |
+| `studio-ui-guidelines.md` | 0.1.7        | Implemented | 2026-07-26 |
+| `studio.md`               | 0.1.29-draft | Partial     | 2026-07-26 |
 
 ## Sections not yet implemented
 

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -249,6 +249,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `studio-ui-guidelines.md`
 
+- **0.1.7** (2026-07-26) — Dialogs and overlay layers (§8.7): the ui/layers.ts contract, showPromptDialog as the replacement for window.prompt(), and a ban on native browser dialogs.
 - **0.1.6** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.1.5** (2026-07-22) — Machine-readable spec status vocabulary + generated status page (`79daba23`).
 - **0.1.4** (2026-07-17) — Color-scheme canvas preview — Auto/Light/Dark tab-bar control (`ccdc1d3e`).
@@ -259,6 +260,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `studio.md`
 
+- **0.1.29-draft** (2026-07-26) — File create/rename/delete naming dialogs (§9.1.1); branch, clone, and nested-selector flows now open Spectrum dialogs instead of native prompts.
 - **0.1.28-draft** (2026-07-25) — The Cloud platform target composes per-project schemas server-side (§3.4).
 - **0.1.27-draft** (2026-07-25) — Source-mode schema validation contract: per-project entry documents, offline $schema-id registration, worker self-location (§4.2.1); fetchProjectSchemas in the PAL table (§3.4).
 - **0.1.26-draft** (2026-07-25) — PAL table records the destination members: createDestination, createProject's user-chosen destination, and pickDirectory.

--- a/docs/studio/design/style-inspector.md
+++ b/docs/studio/design/style-inspector.md
@@ -53,7 +53,7 @@ When a value comes from somewhere earlier in the cascade — the Base tab, an ea
 Two sections close the list:
 
 - **Custom** — any CSS property by name. Type the property, press :kbd[Enter], and fill in its value; each row shows the property's browser default as a placeholder.
-- **Relative Styling** — rules for elements _inside_ the selection (the rows inside a table, the links inside a nav). Click a rule to drill into it and edit it with the full inspector; **+ Add** creates a new one.
+- **Relative Styling** — rules for elements _inside_ the selection (the rows inside a table, the links inside a nav). Click a rule to drill into it and edit it with the full inspector; **+ Add** opens a dialog where you type the selector (`th`, `:hover`, `.active`) and click **Add**.
 
 :::doc-note
 Everything here writes plain CSS into the element's `style` object in the open file — the same nested format documented in **[Styling](/docs/framework/concepts/styling)**.

--- a/docs/studio/interface.md
+++ b/docs/studio/interface.md
@@ -7,6 +7,7 @@ code:
   - packages/studio/src/panels/right-panel.ts
   - packages/studio/src/panels/statusbar.ts
   - packages/studio/src/ui/panel-resize.ts
+  - packages/studio/src/files/files.ts
 ---
 
 # The workspace
@@ -41,7 +42,7 @@ In the desktop app, the window's minimize, maximize, and close controls also liv
 
 The vertical icon strip on the far left picks what the left panel shows. From top to bottom:
 
-- **Files** — the project file tree. Open, rename, and organize the files in your project folder.
+- **Files** — the project file tree. Open, rename, and organize the files in your project folder. **New File…** — from the panel's toolbar, or from a folder's right-click menu — opens a dialog with `untitled.json` pre-filled and the extension left unselected, so typing replaces just the name. Studio picks the starting content from the extension you give it.
 - **Layers** — the element structure of the open page or component, as a tree you can select and reorder. In **Stylebook** mode it lists the style targets instead.
 - **Imports** — the components and packages the open document (or project) pulls in.
 - **Elements** — the palette of elements and components you can insert, organized by category with a search filter.

--- a/docs/studio/projects.md
+++ b/docs/studio/projects.md
@@ -31,7 +31,7 @@ There are three ways to end up with a project open in Studio, all available from
 
 1. **Create a new one.** Click **New Project…** and pick a template or a complete starter site — or jump straight to the starter gallery with **Start from an Example…**. You choose the folder it's created in (on studio.jxsuite.com, the GitHub repository); Studio never picks one for you. The whole modal is walked through in **[Create a project](/docs/studio/projects/create)**.
 2. **Open an existing folder.** Click **Open Project…** and point Studio at a Jx project already on your machine. On studio.jxsuite.com the same button lists the GitHub repositories you can write to instead — pick one and Studio opens it, or use the links in the picker's footer to grant the Jx Suite GitHub App access to more of them. Recently opened projects also appear on the Welcome screen for one-click reopening.
-3. **Clone a repository.** Click **Clone Git Repository…** and paste a repository URL — Studio downloads the project and opens it. On platforms linked to a GitHub account, **Add Existing Repository…** lets you pick from your repositories instead of pasting a URL.
+3. **Clone a repository.** Click **Clone Git Repository…**, paste a repository URL, and click **Clone** — Studio downloads the project and opens it. On platforms linked to a GitHub account, **Add Existing Repository…** lets you pick from your repositories instead of pasting a URL.
 
 :::doc-note
 Because a project is just a folder, "moving to Jx" or "leaving Jx" is copying files. Studio never locks your work into a format only it can read.

--- a/docs/studio/projects/browse.md
+++ b/docs/studio/projects/browse.md
@@ -1,6 +1,8 @@
 ---
 title: "Browse your project"
 description: "The Manage surface in Jx Studio: browse your project, create pages and content, upload media, and define content models."
+code:
+  - packages/studio/src/browse/browse.ts
 ---
 
 # Manage
@@ -17,7 +19,7 @@ Right-click any file to **open**, **rename**, **duplicate**, or **delete** it.
 
 ## Create pages and content
 
-Use **New** to add a Page, Layout, or Component. Studio also lists an entry for each **content type** your project defines, so creating a blog post or a doc is one click — Studio pre-fills the frontmatter from that type's schema.
+Use **New** to add a Page, Layout, or Component. Studio asks for a name in a dialog — it tells you which folder the file lands in, and turns what you type into a file name (`About Us` becomes `about-us`). Studio also lists an entry for each **content type** your project defines, so creating a blog post or a doc is one click — Studio pre-fills the frontmatter from that type's schema.
 
 ## Upload media
 

--- a/docs/studio/projects/content-types.md
+++ b/docs/studio/projects/content-types.md
@@ -46,7 +46,7 @@ With a type selected, edit its name in the editor's header to rename it, or clic
 Back in the [Manage view](/docs/studio/projects/browse), the **New** menu lists an item for every content type you've defined:
 
 1. Click **New** and pick the type — for example **Blog-posts**.
-2. Name the entry. Studio creates the file in the type's source folder with every schema field pre-filled with a sensible blank, and opens it.
+2. Name the entry in the dialog and click **Create**. Studio creates the file in the type's source folder with every schema field pre-filled with a sensible blank, and opens it.
 
 Entries show up under Manage's **Content** filter labeled with their type, and when you open one, Studio recognizes which type it belongs to and presents its fields as a form — see **[Frontmatter and page metadata](/docs/studio/editing/frontmatter)**.
 

--- a/docs/studio/projects/media.md
+++ b/docs/studio/projects/media.md
@@ -17,7 +17,7 @@ Your site's media — images, video, audio, PDFs, and fonts — lives in the pro
 1. Drag files from your computer anywhere onto the Manage view — or click **Upload** and pick them in the file dialog. You can drop several at once.
 2. The new files appear in the **Media** section immediately, ready to use.
 
-Studio accepts images (including SVG), video, audio, PDFs, and font files. Right-click any asset to **rename**, **duplicate**, or **delete** it.
+Studio accepts images (including SVG), video, audio, PDFs, and font files. Right-click any asset to **rename**, **duplicate**, or **delete** it. Renaming preselects just the name, so typing replaces `hero` in `hero.jpg` and leaves the extension alone.
 
 ![The Manage view highlighted as a drop target while files are dragged onto it](../../images/media-upload.png)
 

--- a/docs/studio/projects/pages-layouts-components.md
+++ b/docs/studio/projects/pages-layouts-components.md
@@ -35,7 +35,7 @@ All three are created the same way, from the [Manage view](/docs/studio/projects
 
 1. Click **Manage** in the toolbar.
 2. Click **New** and choose **Page**, **Layout**, or **Component**. (The menu also lists your project's content types — see [Browse your project](/docs/studio/projects/browse).)
-3. Type a name. Studio turns it into a file name (`About Us` becomes `about-us`), writes the file into the matching folder, and opens it in a tab, ready to edit.
+3. Type a name in the dialog and click **Create**. Studio turns it into a file name (`About Us` becomes `about-us`), writes the file into the matching folder, and opens it in a tab, ready to edit.
 
 ![Jx Studio Manage Files modal with live previews of every project file](../../images/mode-manage.png)
 

--- a/docs/studio/publish/source-control.md
+++ b/docs/studio/publish/source-control.md
@@ -49,7 +49,7 @@ A project with no remote yet shows **Local only (no remote)** here, with a **Pub
 
 ## Branches
 
-The **Active branch** row shows which branch you're on. Use its picker to switch to another branch, or choose **+ New branch…** and type a name to create one. Branches let you try a redesign on the side and only merge it when it's ready.
+The **Active branch** row shows which branch you're on. Use its picker to switch to another branch, or choose **+ New branch…** — Studio opens a **New Branch** dialog; type a name and click **Create**. Branches let you try a redesign on the side and only merge it when it's ready.
 
 ## History
 

--- a/packages/studio/src/browse/browse.ts
+++ b/packages/studio/src/browse/browse.ts
@@ -20,7 +20,7 @@ import { statusMessage } from "../panels/statusbar";
 import { componentRegistry } from "../files/components";
 import { rectOf } from "../utils/geometry";
 
-import { renderPopover, showDialog } from "../ui/layers";
+import { renderPopover, showDialog, showPromptDialog } from "../ui/layers";
 import { loopbackAssetSrc } from "../canvas/canvas-origin";
 import { renderComponentPreview } from "../panels/component-preview";
 import { buildScope, renderNode, setSkipServerFunctions } from "@jxsuite/runtime";
@@ -322,8 +322,13 @@ async function handleNewEntity(
     return;
   }
 
-  // oxlint-disable-next-line no-alert -- native prompt is the intended quick-input UX here
-  const name = prompt(`${typeInfo.label} name:`, "untitled");
+  const name = await showPromptDialog(`New ${typeInfo.label}`, {
+    confirmLabel: "Create",
+    message: `Creating in ${typeInfo.dir}/`,
+    placeholder: "untitled",
+    validate: (v) => (v.trim() ? "" : `Enter a ${typeInfo.label.toLowerCase()} name.`),
+    value: "untitled",
+  });
   if (!name) {
     return;
   }
@@ -571,57 +576,11 @@ async function browseDeleteFile(
  * @returns {Promise<string | null>}
  */
 function showRenameDialog(currentName: string): Promise<string | null> {
-  let value = currentName;
-
-  return showDialog<string | null>((done) => {
-    function confirm() {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return;
-      }
-      done(trimmed);
-    }
-
-    const tpl = html`
-      <sp-dialog-wrapper
-        open
-        underlay
-        headline="Rename"
-        confirm-label="Rename"
-        cancel-label="Cancel"
-        size="s"
-        @confirm=${confirm}
-        @cancel=${() => done(null)}
-        @close=${() => done(null)}
-      >
-        <sp-textfield
-          style="width:100%"
-          value=${value}
-          @input=${(e: Event) => {
-            value = (e.target as HTMLInputElement).value || "";
-          }}
-          @keydown=${(e: KeyboardEvent) => {
-            if (e.key === "Enter") {
-              confirm();
-            }
-          }}
-        ></sp-textfield>
-      </sp-dialog-wrapper>
-    `;
-
-    requestAnimationFrame(() => {
-      const layer = document.querySelector("#layer-dialog");
-      const tf = layer?.querySelector("sp-textfield") as HTMLElement | null;
-      if (tf) {
-        tf.focus();
-        const input = tf.shadowRoot?.querySelector("input");
-        if (input) {
-          input.select();
-        }
-      }
-    });
-
-    return tpl;
+  return showPromptDialog("Rename", {
+    confirmLabel: "Rename",
+    select: "stem",
+    validate: (v) => (v.trim() ? "" : "Enter a file name."),
+    value: currentName,
   });
 }
 

--- a/packages/studio/src/files/files.ts
+++ b/packages/studio/src/files/files.ts
@@ -4,14 +4,17 @@
  * File tree management — project loading, file tree rendering, and file CRUD.
  *
  * Functions that mutate state accept a context object with callbacks, following the same pattern as
- * file-ops.js.
+ * file-ops.js. Every name the user supplies (new file, rename) is collected with the Spectrum
+ * prompt dialog from ui/layers.ts — never a native browser prompt (studio-ui-guidelines.md §8.7).
+ *
+ * @docs studio/interface
  */
 
 import { html, nothing } from "lit-html";
 import { errorMessage } from "@jxsuite/schema/parse";
 import { classMap } from "lit-html/directives/class-map.js";
 import { ref } from "lit-html/directives/ref.js";
-import { renderPopover, showConfirmDialog, showDialog } from "../ui/layers";
+import { renderPopover, showConfirmDialog, showPromptDialog } from "../ui/layers";
 import { createState, projectState, requireProjectState, setProjectState } from "../store";
 import { getPlatform } from "../platform";
 import { statusMessage } from "../panels/statusbar";
@@ -834,8 +837,14 @@ function showFileContextMenu(
 // ─── File CRUD ────────────────────────────────────────────────────────────────
 
 async function createNewFile(dirPath: string, renderLeftPanel: () => void) {
-  // oxlint-disable-next-line no-alert -- native prompt is the intended quick-input UX here
-  const name = prompt("File name:", "untitled.json");
+  const name = await showPromptDialog("New File", {
+    confirmLabel: "Create",
+    message: dirPath === "." ? "Creating in the project root." : `Creating in ${dirPath}/`,
+    placeholder: "untitled.json",
+    select: "stem",
+    validate: (v) => (v.trim() ? "" : "Enter a file name."),
+    value: "untitled.json",
+  });
   if (!name) {
     return;
   }
@@ -861,53 +870,11 @@ async function createNewFile(dirPath: string, renderLeftPanel: () => void) {
 
 /** @param {string} currentName @returns {Promise<string | null>} */
 function showRenameFileDialog(currentName: string): Promise<string | null> {
-  let value = currentName;
-  return showDialog<string | null>((done) => {
-    function confirm() {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return;
-      }
-      done(trimmed);
-    }
-    const tpl = html`
-      <sp-dialog-wrapper
-        open
-        underlay
-        headline="Rename"
-        confirm-label="Rename"
-        cancel-label="Cancel"
-        size="s"
-        @confirm=${confirm}
-        @cancel=${() => done(null)}
-        @close=${() => done(null)}
-      >
-        <sp-textfield
-          style="width:100%"
-          value=${currentName}
-          @input=${(e: Event) => {
-            value = (e.target as HTMLInputElement).value || "";
-          }}
-          @keydown=${(e: KeyboardEvent) => {
-            if (e.key === "Enter") {
-              confirm();
-            }
-          }}
-        ></sp-textfield>
-      </sp-dialog-wrapper>
-    `;
-    requestAnimationFrame(() => {
-      const layer = document.querySelector("#layer-dialog");
-      const tf = layer?.querySelector("sp-textfield") as HTMLElement | null;
-      if (tf) {
-        tf.focus();
-        const input = tf.shadowRoot?.querySelector("input");
-        if (input) {
-          input.select();
-        }
-      }
-    });
-    return tpl;
+  return showPromptDialog("Rename", {
+    confirmLabel: "Rename",
+    select: "stem",
+    validate: (v) => (v.trim() ? "" : "Enter a file name."),
+    value: currentName,
   });
 }
 

--- a/packages/studio/src/panels/git-panel.ts
+++ b/packages/studio/src/panels/git-panel.ts
@@ -21,7 +21,7 @@ import { formatForPath } from "../format/format-host";
 import { projectState, renderOnly, updateUi } from "../store";
 import { activeTab } from "../workspace/workspace";
 import { view } from "../view";
-import { showConfirmDialog, showDialog } from "../ui/layers";
+import { showConfirmDialog, showPromptDialog } from "../ui/layers";
 import { statusMessage } from "./statusbar";
 import { publishToGithub } from "../github/github-publish";
 import { pullWithPackageSync } from "../packages/pull-package-sync";
@@ -95,32 +95,12 @@ export async function cloneRepository(ctx: { openRecentProject: (root: string) =
     return;
   }
 
-  const url = await showDialog<string | null>(
-    (done) => html`
-      <sp-underlay open @close=${() => done(null)}></sp-underlay>
-      <sp-dialog-wrapper
-        headline="Clone Git Repository"
-        confirmLabel="Clone"
-        cancelLabel="Cancel"
-        open
-        @confirm=${(e: Event) => {
-          const input = ((e.target as HTMLElement).parentElement as HTMLElement).querySelector(
-            "sp-textfield",
-          ) as HTMLInputElement | null;
-          done(input?.value?.trim() || null);
-        }}
-        @cancel=${() => done(null)}
-        @close=${() => done(null)}
-      >
-        <sp-textfield
-          label="Repository URL"
-          placeholder="https://github.com/user/repo.git"
-          style="width: 100%"
-          autofocus
-        ></sp-textfield>
-      </sp-dialog-wrapper>
-    `,
-  );
+  const url = await showPromptDialog("Clone Git Repository", {
+    confirmLabel: "Clone",
+    message: "Repository URL",
+    placeholder: "https://github.com/user/repo.git",
+    validate: (v) => (v.trim() ? "" : "Enter a repository URL."),
+  });
 
   if (!url) {
     return;
@@ -434,10 +414,14 @@ export function renderGitPanel(
           const val = (e.target as HTMLInputElement).value;
           if (val === "__new__") {
             (e.target as HTMLInputElement).value = branches?.current || "";
-            // oxlint-disable-next-line no-alert -- native prompt is the intended quick-input UX here
-            const name = prompt("New branch name:");
-            if (name?.trim()) {
-              await gitAction("gitCreateBranch", name.trim());
+            const name = await showPromptDialog("New Branch", {
+              confirmLabel: "Create",
+              message: `Branching from ${branches?.current || status?.branch || "the current branch"}.`,
+              placeholder: "feature/my-change",
+              validate: (v) => (v.trim() ? "" : "Enter a branch name."),
+            });
+            if (name) {
+              await gitAction("gitCreateBranch", name);
             }
             return;
           }

--- a/packages/studio/src/panels/style-panel.ts
+++ b/packages/studio/src/panels/style-panel.ts
@@ -22,6 +22,7 @@ import {
 } from "../tabs/transact";
 import { inferInputType, propLabel } from "../utils/studio-utils";
 import { renderFieldRow } from "../ui/field-row";
+import { showPromptDialog } from "../ui/layers";
 import { renderDynamicSlot } from "../ui/dynamic-slot";
 import { parseMediaEntries, schemeOfQuery } from "../utils/canvas-media";
 import { getEffectiveMedia, getEffectiveStyle } from "../site-context";
@@ -876,11 +877,15 @@ function styleSidebarTemplate(
               )}
               <button
                 style="padding:6px 10px;background:none;border:1px dashed var(--spectrum-gray-400, #333);border-radius:var(--radius);color:var(--spectrum-gray-700, #a1a1aa);font-size:var(--spectrum-font-size-75, 12px);cursor:pointer"
-                @click=${() => {
-                  // oxlint-disable-next-line no-alert -- native prompt is the intended quick-input UX here
-                  const name = prompt("Selector name (e.g. th, :hover, .active):");
-                  if (name && name.trim()) {
-                    commitStyle(name.trim(), {});
+                @click=${async () => {
+                  const name = await showPromptDialog("Add Nested Selector", {
+                    confirmLabel: "Add",
+                    message: "Enter a selector to nest under the current rule.",
+                    placeholder: "th, :hover, .active",
+                    validate: (v) => (v.trim() ? "" : "Enter a selector."),
+                  });
+                  if (name) {
+                    commitStyle(name, {});
                   }
                 }}
               >

--- a/packages/studio/src/ui/layers.ts
+++ b/packages/studio/src/ui/layers.ts
@@ -1,5 +1,14 @@
 /// <reference lib="dom" />
+/**
+ * The overlay layers — the only sanctioned way to open a popover, modal, or dialog in Studio.
+ *
+ * Everything renders into one of the three fixed hosts declared in index.html (#layer-popover,
+ * #layer-modal, #layer-dialog), bound once at boot by initLayers(). Native browser dialogs
+ * (`prompt`, `confirm`, `alert`) are not permitted anywhere in Studio — use `showPromptDialog`,
+ * `showConfirmDialog`, or `showSaveDiscardDialog`. See studio-ui-guidelines.md §8.7.
+ */
 import { html, render as litRender, nothing } from "lit-html";
+import { ref } from "lit-html/directives/ref.js";
 import type { TemplateResult } from "lit-html";
 
 let _popoverLayer: HTMLElement;
@@ -116,6 +125,161 @@ export function showSaveDiscardDialog(
       </sp-dialog-wrapper>
     `,
   );
+}
+
+/** Options accepted by {@link showPromptDialog}. */
+export interface PromptDialogOptions {
+  /** Label on the confirming button. */
+  confirmLabel?: string;
+  /** Label on the dismissing button. */
+  cancelLabel?: string;
+  /** Explanatory copy rendered above the text field. */
+  message?: string | TemplateResult;
+  /** Placeholder shown while the field is empty. */
+  placeholder?: string;
+  /** How much of the pre-filled value to select once the field takes focus. */
+  select?: "all" | "stem" | "none";
+  /**
+   * Validate the raw field value. Return an empty string when valid, or a message to show as
+   * negative help text (which also blocks confirmation). Defaults to "must not be blank".
+   */
+  validate?: (value: string) => string;
+  /** Pre-filled value. */
+  value?: string;
+}
+
+/**
+ * Show a single-field text-entry dialog — the Spectrum replacement for `window.prompt()`.
+ *
+ * Resolves the trimmed value, or `null` when cancelled/dismissed. Confirming with an invalid value
+ * keeps the dialog open and surfaces the validation message as negative help text.
+ *
+ * @param {string} headline
+ * @param {PromptDialogOptions} [opts]
+ * @returns {Promise<string | null>}
+ */
+export function showPromptDialog(
+  headline: string,
+  opts: PromptDialogOptions = {},
+): Promise<string | null> {
+  const {
+    cancelLabel = "Cancel",
+    confirmLabel = "OK",
+    message,
+    placeholder = "",
+    select = "all",
+    validate,
+    value: initialValue = "",
+  } = opts;
+
+  const check = (candidate: string) =>
+    validate ? validate(candidate) : candidate.trim() ? "" : "Enter a value.";
+
+  let value = initialValue;
+  let error = "";
+  let wrapperEl: HTMLElement | null = null;
+  let focusRequested = false;
+
+  return showDialog<string | null>((done) => {
+    function rerender() {
+      // Resolved lazily: lit commits element refs before inserting the fragment, so the host is
+      // Only reachable once the first render has landed.
+      const host = wrapperEl?.parentElement;
+      if (host) {
+        litRender(buildTpl(), host);
+      }
+    }
+
+    function confirm() {
+      error = check(value);
+      if (error) {
+        rerender();
+        return;
+      }
+      done(value.trim());
+    }
+
+    function onInput(e: Event) {
+      value = (e.target as HTMLInputElement).value || "";
+      const next = check(value);
+      if (next !== error) {
+        error = next;
+        rerender();
+      }
+    }
+
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Enter") {
+        confirm();
+      }
+    }
+
+    /** Capture the dialog element so validation errors can re-render in place. */
+    function onWrapperRef(el?: Element) {
+      if (el) {
+        wrapperEl = el as HTMLElement;
+      }
+    }
+
+    /** Focus (and optionally select) the field once, on first render only. */
+    function onFieldRef(el?: Element) {
+      if (!el || focusRequested) {
+        return;
+      }
+      focusRequested = true;
+      const field = el as HTMLElement;
+      requestAnimationFrame(() => {
+        field.focus();
+        const input = field.shadowRoot?.querySelector("input");
+        if (!input || select === "none") {
+          return;
+        }
+        if (select === "stem") {
+          const dot = input.value.lastIndexOf(".");
+          input.setSelectionRange(0, dot > 0 ? dot : input.value.length);
+          return;
+        }
+        input.select();
+      });
+    }
+
+    function buildTpl() {
+      return html`
+        <sp-dialog-wrapper
+          open
+          underlay
+          headline=${headline}
+          confirm-label=${confirmLabel}
+          cancel-label=${cancelLabel}
+          size="s"
+          @confirm=${confirm}
+          @cancel=${() => done(null)}
+          @close=${() => done(null)}
+          ${ref(onWrapperRef)}
+        >
+          ${
+            // Spectrum resets <p> margins to 0, so without this the copy sits flush on the field.
+            message ? html`<p style="margin:0 0 8px">${message}</p>` : nothing
+          }
+          <sp-textfield
+            style="width:100%"
+            placeholder=${placeholder}
+            value=${value}
+            ?invalid=${Boolean(error)}
+            @input=${onInput}
+            @keydown=${onKeydown}
+            ${ref(onFieldRef)}
+          >
+            ${error
+              ? html`<sp-help-text slot="negative-help-text">${error}</sp-help-text>`
+              : nothing}
+          </sp-textfield>
+        </sp-dialog-wrapper>
+      `;
+    }
+
+    return buildTpl();
+  });
 }
 
 /**

--- a/packages/studio/tests/browse-gaps.test.ts
+++ b/packages/studio/tests/browse-gaps.test.ts
@@ -1,7 +1,7 @@
 /**
- * Gap tests for src/browse/browse.ts — covers the rename dialog's input.select() path (line 620),
- * which requires the sp-textfield shadow root to contain an <input> when the focus rAF fires, plus
- * a few never-invoked event handlers (search submit prevention, rename dialog close).
+ * Gap tests for src/browse/browse.ts — covers the rename dialog's focus/select path, which requires
+ * the sp-textfield shadow root to contain an <input> when the focus rAF fires, plus a few
+ * never-invoked event handlers (search submit prevention, rename dialog close).
  */
 import { flush, installMockPlatform, pointer, resetStudioState } from "./harness";
 import type { MockPlatformState } from "./harness";
@@ -81,7 +81,7 @@ beforeEach(() => {
 // ─── Rename dialog focus/select ──────────────────────────────────────────────
 
 describe("rename dialog focus", () => {
-  test("selects the shadow-root input contents when the focus rAF fires", async () => {
+  test("selects the file-name stem in the shadow-root input when the focus rAF fires", async () => {
     const container = await mount();
     await openRenameDialogWithoutFlush(container);
 
@@ -90,14 +90,16 @@ describe("rename dialog focus", () => {
     expect(tf).not.toBeNull();
     const shadow = tf.shadowRoot ?? tf.attachShadow({ mode: "open" });
     const input = document.createElement("input");
-    let selected = 0;
-    input.select = () => {
-      selected += 1;
+    input.value = "logo.png";
+    const ranges: number[][] = [];
+    input.setSelectionRange = (start, end) => {
+      ranges.push([start ?? 0, end ?? 0]);
     };
     shadow.append(input);
 
     await flush();
-    expect(selected).toBe(1);
+    // "logo.png" → the extension stays out of the selection so a retype keeps it.
+    expect(ranges).toEqual([[0, 4]]);
 
     dialogLayer().querySelector("sp-dialog-wrapper")?.dispatchEvent(new Event("cancel"));
     await flush();

--- a/packages/studio/tests/browse.test.ts
+++ b/packages/studio/tests/browse.test.ts
@@ -5,7 +5,14 @@
  * "New +" entity menu (including content types), uploads, and the per-file context menu
  * (open/rename/duplicate/delete) with its Spectrum dialogs.
  */
-import { flush, installMockPlatform, pointer, resetStudioState } from "./harness";
+import {
+  answerPromptDialog,
+  flush,
+  installMockPlatform,
+  pointer,
+  resetStudioState,
+  topDialog,
+} from "./harness";
 import type { MockPlatformState } from "./harness";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { initLayers } from "../src/ui/layers";
@@ -567,25 +574,24 @@ function newMenu(container: HTMLElement): HTMLElement & { value: string } {
   };
 }
 
-async function chooseNewEntity(container: HTMLElement, value: string) {
+/**
+ * Pick an entity type from the "New +" menu. When `answer` is supplied the resulting name dialog is
+ * answered with it (`null` cancels). Returns the dialog's headline, or null when none opened.
+ */
+async function chooseNewEntity(container: HTMLElement, value: string, answer?: string | null) {
   const menu = newMenu(container);
   menu.value = value;
   menu.dispatchEvent(new Event("change", { bubbles: false }));
   await flush(4);
+  const headline = topDialog()?.getAttribute("headline") ?? null;
+  if (answer !== undefined) {
+    await answerPromptDialog(answer);
+    await flush(2);
+  }
+  return headline;
 }
 
 describe("new entity menu", () => {
-  let promptValue: string | null = "untitled";
-  let promptCalls: string[];
-  beforeEach(() => {
-    promptCalls = [];
-    promptValue = "untitled";
-    globalThis.prompt = (message?: string) => {
-      promptCalls.push(message ?? "");
-      return promptValue;
-    };
-  });
-
   test("lists base entity types plus content types behind a divider", async () => {
     const container = await mountWithDefaults();
     const items = [...container.querySelectorAll("overlay-trigger sp-menu-item")].map((i) =>
@@ -597,32 +603,53 @@ describe("new entity menu", () => {
 
   test("creates a page as JSON by default and opens it", async () => {
     const container = await mountWithDefaults();
-    promptValue = "My Page!";
-    await chooseNewEntity(container, "page");
-    expect(promptCalls).toEqual(["Page name:"]);
+    const headline = await chooseNewEntity(container, "page", "My Page!");
+    expect(headline).toBe("New Page");
     expect(state.files.get("pages/my-page.json")).toBe(
       JSON.stringify({ children: [], tagName: "div" }, null, "\t"),
     );
     expect(opened).toContain("pages/my-page.json");
   });
 
+  test("the name dialog is a Spectrum dialog, prefilled and scoped to the target directory", async () => {
+    const container = await mountWithDefaults();
+    await chooseNewEntity(container, "page");
+
+    const wrapper = topDialog();
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.getAttribute("confirm-label")).toBe("Create");
+    expect(wrapper!.textContent).toContain("Creating in pages/");
+    expect(wrapper!.querySelector("sp-textfield")!.getAttribute("value")).toBe("untitled");
+
+    await answerPromptDialog(null);
+  });
+
+  test("a blank name keeps the dialog open and creates nothing", async () => {
+    const container = await mountWithDefaults();
+    const before = writeCalls().length;
+    await chooseNewEntity(container, "page", "  ");
+
+    expect(writeCalls().length).toBe(before);
+    expect(topDialog()).not.toBeNull();
+    expect(topDialog()!.querySelector("sp-help-text")?.textContent).toContain("Enter a page name.");
+
+    await answerPromptDialog(null);
+  });
+
   test("uses format extension and newFileTemplate when a format is registered", async () => {
     setFormats([MD_FORMAT]);
     const container = await mountWithDefaults();
-    promptValue = "Read Me";
-    await chooseNewEntity(container, "content");
+    await chooseNewEntity(container, "content", "Read Me");
     expect(state.files.get("content/read-me.md")).toBe("# New file\n");
 
-    promptValue = "Landing";
-    await chooseNewEntity(container, "page");
+    await chooseNewEntity(container, "page", "Landing");
     expect(state.files.get("pages/landing.md")).toBe("# New file\n");
   });
 
   test("content-type creation writes frontmatter from the schema", async () => {
     setFormats([MD_FORMAT]);
     const container = await mountWithDefaults();
-    promptValue = "Hello World";
-    await chooseNewEntity(container, "contentType:posts");
+    await chooseNewEntity(container, "contentType:posts", "Hello World");
     const content = state.files.get("content/posts/hello-world.md");
     expect(content).toBeDefined();
     expect(content).toStartWith("---\n");
@@ -642,15 +669,13 @@ describe("new entity menu", () => {
     });
     invalidateBrowseCache();
     const container = await mountWithDefaults();
-    promptValue = "A B";
-    await chooseNewEntity(container, "contentType:plain");
+    await chooseNewEntity(container, "contentType:plain", "A B");
     expect(state.files.get("stuff/a-b.md")).toBe("---\ntitle: Untitled\n---\n\n");
   });
 
   test("content type without source uses its name as directory and JSON fallback", async () => {
     const container = await mountWithDefaults();
-    promptValue = "Sketch";
-    await chooseNewEntity(container, "contentType:draft");
+    await chooseNewEntity(container, "contentType:draft", "Sketch");
     expect(state.files.get("draft/sketch.json")).toBe(
       JSON.stringify({ children: [], tagName: "div" }, null, "\t"),
     );
@@ -662,30 +687,27 @@ describe("new entity menu", () => {
     });
     invalidateBrowseCache();
     const container = await mountWithDefaults();
-    promptValue = "Row One";
-    await chooseNewEntity(container, "contentType:records");
+    await chooseNewEntity(container, "contentType:records", "Row One");
     expect(state.files.has("data/row-one.json")).toBe(true);
   });
 
-  test("cancelled prompt creates nothing", async () => {
+  test("cancelled dialog creates nothing", async () => {
     const container = await mountWithDefaults();
-    promptValue = null;
     const before = writeCalls().length;
-    await chooseNewEntity(container, "page");
+    await chooseNewEntity(container, "page", null);
     expect(writeCalls().length).toBe(before);
     expect(opened).toEqual([]);
+    expect(topDialog()).toBeNull();
   });
 
-  test("unknown type key is ignored before prompting", async () => {
+  test("unknown type key is ignored before the dialog opens", async () => {
     const container = await mountWithDefaults();
-    await chooseNewEntity(container, "bogus");
-    expect(promptCalls).toEqual([]);
+    expect(await chooseNewEntity(container, "bogus")).toBeNull();
   });
 
   test("names are slugified", async () => {
     const container = await mountWithDefaults();
-    promptValue = "Wild  Name?? 42";
-    await chooseNewEntity(container, "component");
+    await chooseNewEntity(container, "component", "Wild  Name?? 42");
     expect(state.files.has("components/wild-name-42.json")).toBe(true);
   });
 });

--- a/packages/studio/tests/files-tree.test.ts
+++ b/packages/studio/tests/files-tree.test.ts
@@ -3,7 +3,14 @@
  * search), keyboard navigation, the context menu with rename/delete dialogs, and drag-and-drop (via
  * a mocked pragmatic-drag-and-drop adapter so registrations and drops are deterministic).
  */
-import { flush, installMockPlatform, key, pointer, renderInto } from "./harness";
+import {
+  answerPromptDialog,
+  flush,
+  installMockPlatform,
+  key,
+  pointer,
+  renderInto,
+} from "./harness";
 import type { MockPlatformState } from "./harness";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { requireProjectState, setProjectState } from "../src/store";
@@ -162,7 +169,6 @@ async function dismissOutside(): Promise<void> {
 }
 
 let host: HTMLElement;
-const origPrompt = globalThis.prompt;
 
 beforeEach(() => {
   closeAllTabs();
@@ -189,7 +195,6 @@ beforeEach(() => {
 afterEach(async () => {
   await dismissOutside();
   host.remove();
-  globalThis.prompt = origPrompt;
 });
 
 // ─── renderFilesTemplate — empty / welcome states ─────────────────────────────
@@ -386,22 +391,61 @@ describe("file tree listing", () => {
 // ─── New file ─────────────────────────────────────────────────────────────────
 
 describe("createNewFile (toolbar + context menu)", () => {
-  async function clickNewFile(out: HTMLElement) {
+  /** Open the New File dialog from the toolbar and answer it (null cancels). */
+  async function clickNewFile(out: HTMLElement, answer: string | null) {
     pointer(out.querySelector('sp-action-button[label="New File"]')!, "click");
     await flush();
+    await answerPromptDialog(answer);
   }
 
-  test("cancelled prompt writes nothing", async () => {
-    const { state } = installFsPlatform();
+  test("opens a Spectrum prompt dialog rather than a native prompt", async () => {
+    installFsPlatform();
     siteState();
     seedTreeState();
-    globalThis.prompt = () => null;
     const { ctx } = makeTreeCtx();
     const out = await renderInto(renderFilesTemplate(ctx), host);
 
-    await clickNewFile(out);
+    pointer(out.querySelector('sp-action-button[label="New File"]')!, "click");
+    await flush();
+
+    const wrapper = dialogWrapper();
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.getAttribute("headline")).toBe("New File");
+    expect(wrapper!.getAttribute("confirm-label")).toBe("Create");
+    expect(wrapper!.querySelector("sp-textfield")!.getAttribute("value")).toBe("untitled.json");
+
+    await answerPromptDialog(null);
+  });
+
+  test("cancelled dialog writes nothing", async () => {
+    const { state } = installFsPlatform();
+    siteState();
+    seedTreeState();
+    const { ctx } = makeTreeCtx();
+    const out = await renderInto(renderFilesTemplate(ctx), host);
+
+    await clickNewFile(out, null);
 
     expect(state.calls.filter(([name]) => name === "writeFile")).toHaveLength(0);
+    expect(dialogWrapper()).toBeNull();
+  });
+
+  test("a blank name keeps the dialog open and writes nothing", async () => {
+    const { state } = installFsPlatform();
+    siteState();
+    seedTreeState();
+    const { ctx } = makeTreeCtx();
+    const out = await renderInto(renderFilesTemplate(ctx), host);
+
+    await clickNewFile(out, "   ");
+
+    expect(state.calls.filter(([name]) => name === "writeFile")).toHaveLength(0);
+    expect(dialogWrapper()).not.toBeNull();
+    expect(dialogWrapper()!.querySelector("sp-help-text")?.textContent).toContain(
+      "Enter a file name.",
+    );
+
+    await answerPromptDialog(null);
   });
 
   test("unknown extension gets the default JSON scaffold", async () => {
@@ -409,11 +453,10 @@ describe("createNewFile (toolbar + context menu)", () => {
     const { state } = installFsPlatform();
     siteState();
     seedTreeState();
-    globalThis.prompt = () => "untitled.json";
     const { counters, ctx } = makeTreeCtx();
     const out = await renderInto(renderFilesTemplate(ctx), host);
 
-    await clickNewFile(out);
+    await clickNewFile(out, "untitled.json");
 
     expect(JSON.parse(state.files.get("untitled.json")!)).toEqual({
       children: [{ children: [], tagName: "p" }],
@@ -426,13 +469,24 @@ describe("createNewFile (toolbar + context menu)", () => {
     const { state } = installFsPlatform();
     siteState();
     seedTreeState();
-    globalThis.prompt = () => "note.md";
     const { ctx } = makeTreeCtx();
     const out = await renderInto(renderFilesTemplate(ctx), host);
 
-    await clickNewFile(out);
+    await clickNewFile(out, "note.md");
 
     expect(state.files.get("note.md")).toBe("---\ntitle: Untitled\n---\n\n");
+  });
+
+  test("the entered name is trimmed before it becomes a path", async () => {
+    const { state } = installFsPlatform();
+    siteState();
+    seedTreeState();
+    const { ctx } = makeTreeCtx();
+    const out = await renderInto(renderFilesTemplate(ctx), host);
+
+    await clickNewFile(out, "  spaced.md  ");
+
+    expect(state.files.has("spaced.md")).toBe(true);
   });
 
   test("format without a template creates an empty file", async () => {
@@ -440,11 +494,10 @@ describe("createNewFile (toolbar + context menu)", () => {
     const { state } = installFsPlatform();
     siteState();
     seedTreeState();
-    globalThis.prompt = () => "bare.md";
     const { ctx } = makeTreeCtx();
     const out = await renderInto(renderFilesTemplate(ctx), host);
 
-    await clickNewFile(out);
+    await clickNewFile(out, "bare.md");
 
     expect(state.files.get("bare.md")).toBe("");
   });
@@ -460,11 +513,10 @@ describe("createNewFile (toolbar + context menu)", () => {
     );
     siteState();
     seedTreeState();
-    globalThis.prompt = () => "fail.json";
     const { counters, ctx } = makeTreeCtx();
     const out = await renderInto(renderFilesTemplate(ctx), host);
 
-    await clickNewFile(out);
+    await clickNewFile(out, "fail.json");
 
     expect(state.files.has("fail.json")).toBe(false);
     expect(counters.left).toBe(0);
@@ -474,7 +526,6 @@ describe("createNewFile (toolbar + context menu)", () => {
     const { state } = installFsPlatform();
     siteState();
     seedTreeState();
-    globalThis.prompt = () => "inner.md";
     const { ctx } = makeTreeCtx();
     const out = await renderInto(renderFilesTemplate(ctx), host);
 
@@ -482,6 +533,9 @@ describe("createNewFile (toolbar + context menu)", () => {
     await flush();
     await clickMenuItem("New File…");
     await flush();
+
+    expect(dialogWrapper()?.textContent).toContain("Creating in pages/");
+    await answerPromptDialog("inner.md");
 
     expect(state.files.get("pages/inner.md")).toBe("---\ntitle: Untitled\n---\n\n");
   });

--- a/packages/studio/tests/git-panel-gaps.test.ts
+++ b/packages/studio/tests/git-panel-gaps.test.ts
@@ -22,6 +22,8 @@ let confirmCalls: string[] = [];
 let confirmResult = true;
 let publishCalls: unknown[] = [];
 let dialogHosts: HTMLElement[] = [];
+let promptCalls: { headline: string; opts: Record<string, any> }[] = [];
+let promptResult: string | null = null;
 
 void mock.module("../src/platform.js", () => ({
   getPlatform: () => mockPlatform,
@@ -59,6 +61,12 @@ void mock.module("../src/ui/layers.js", () => ({
         host,
       );
     }),
+  // The prompt dialog's own rendering/validation is covered in tests/ui-layers-gaps.test.ts; here
+  // Only the options the panel passes and how it handles the resolved value matter.
+  showPromptDialog: async (headline: string, opts: Record<string, any> = {}) => {
+    promptCalls.push({ headline, opts });
+    return promptResult;
+  },
 }));
 
 void mock.module("../src/panels/statusbar.js", () => ({
@@ -185,6 +193,8 @@ beforeEach(() => {
   confirmCalls = [];
   confirmResult = true;
   publishCalls = [];
+  promptCalls = [];
+  promptResult = null;
   for (const host of dialogHosts) {
     host.remove();
   }
@@ -265,52 +275,40 @@ describe("cloneRepository", () => {
   test("reports unsupported platform when gitClone is missing", async () => {
     await cloneRepository(noopCtx);
     expect(statusMessages).toContain("Clone not supported on this platform");
-    expect(dialogHosts).toEqual([]);
+    expect(promptCalls).toEqual([]);
   });
 
-  test("confirm with URL clones and opens the project", async () => {
+  test("asks for the URL through the Spectrum prompt dialog", async () => {
+    mockPlatform.gitClone = log("gitClone", async () => ({ ok: true, root: "/x" }));
+    await cloneRepository(noopCtx);
+    expect(promptCalls).toHaveLength(1);
+    const { headline, opts } = promptCalls[0]!;
+    expect(headline).toBe("Clone Git Repository");
+    expect(opts.confirmLabel).toBe("Clone");
+    expect(opts.placeholder).toBe("https://github.com/user/repo.git");
+    expect(opts.validate("")).toBe("Enter a repository URL.");
+    expect(opts.validate("https://github.com/u/r.git")).toBe("");
+  });
+
+  test("a confirmed URL clones and opens the project", async () => {
     mockPlatform.gitClone = log("gitClone", async () => ({ ok: true, root: "/tmp/clone" }));
+    promptResult = "https://github.com/u/r.git";
     const opened: string[] = [];
-    const promise = cloneRepository({
+    await cloneRepository({
       openRecentProject: async (root: string) => {
         opened.push(root);
       },
     });
-    await flush();
-    const host = dialogHosts.at(-1)!;
-    (host.querySelector("sp-textfield") as any).value = " https://github.com/u/r.git ";
-    host.querySelector("sp-dialog-wrapper")!.dispatchEvent(new Event("confirm"));
-    await promise;
     expect(calls).toContainEqual(["gitClone", "https://github.com/u/r.git"]);
     expect(opened).toEqual(["/tmp/clone"]);
     expect(statusMessages).toContain("Cloning repository...");
     expect(statusMessages).toContain("Clone complete");
   });
 
-  test("cancel dismisses without cloning", async () => {
+  test("a dismissed dialog clones nothing", async () => {
     mockPlatform.gitClone = log("gitClone", async () => ({ ok: true, root: "/x" }));
-    const promise = cloneRepository(noopCtx);
-    await flush();
-    dialogHosts.at(-1)!.querySelector("sp-dialog-wrapper")!.dispatchEvent(new Event("cancel"));
-    await promise;
-    expect(callNames()).not.toContain("gitClone");
-  });
-
-  test("underlay close dismisses without cloning", async () => {
-    mockPlatform.gitClone = log("gitClone", async () => ({ ok: true, root: "/x" }));
-    const promise = cloneRepository(noopCtx);
-    await flush();
-    dialogHosts.at(-1)!.querySelector("sp-underlay")!.dispatchEvent(new Event("close"));
-    await promise;
-    expect(callNames()).not.toContain("gitClone");
-  });
-
-  test("confirm with empty URL resolves to null and skips clone", async () => {
-    mockPlatform.gitClone = log("gitClone", async () => ({ ok: true, root: "/x" }));
-    const promise = cloneRepository(noopCtx);
-    await flush();
-    dialogHosts.at(-1)!.querySelector("sp-dialog-wrapper")!.dispatchEvent(new Event("confirm"));
-    await promise;
+    promptResult = null;
+    await cloneRepository(noopCtx);
     expect(callNames()).not.toContain("gitClone");
   });
 
@@ -318,12 +316,8 @@ describe("cloneRepository", () => {
     mockPlatform.gitClone = log("gitClone", async () => {
       throw new Error("denied");
     });
-    const promise = cloneRepository(noopCtx);
-    await flush();
-    const host = dialogHosts.at(-1)!;
-    (host.querySelector("sp-textfield") as any).value = "https://github.com/u/r.git";
-    host.querySelector("sp-dialog-wrapper")!.dispatchEvent(new Event("confirm"));
-    await promise;
+    promptResult = "https://github.com/u/r.git";
+    await cloneRepository(noopCtx);
     expect(statusMessages.some((m) => m.includes("Clone failed") && m.includes("denied"))).toBe(
       true,
     );
@@ -331,17 +325,13 @@ describe("cloneRepository", () => {
 
   test("clone result without root does not open a project", async () => {
     mockPlatform.gitClone = log("gitClone", async () => ({ ok: false, root: "" }));
+    promptResult = "https://github.com/u/r.git";
     const opened: string[] = [];
-    const promise = cloneRepository({
+    await cloneRepository({
       openRecentProject: async (root: string) => {
         opened.push(root);
       },
     });
-    await flush();
-    const host = dialogHosts.at(-1)!;
-    (host.querySelector("sp-textfield") as any).value = "https://github.com/u/r.git";
-    host.querySelector("sp-dialog-wrapper")!.dispatchEvent(new Event("confirm"));
-    await promise;
     expect(opened).toEqual([]);
     expect(statusMessages).not.toContain("Clone complete");
   });
@@ -500,33 +490,31 @@ describe("branch selector", () => {
     expect(callNames()).not.toContain("gitCheckout");
   });
 
-  test("new-branch option prompts and creates a trimmed branch", async () => {
+  test("new-branch option opens the prompt dialog and creates the branch", async () => {
     seedRepoUi();
     const div = renderPanel();
-    const originalPrompt = (globalThis as any).prompt;
-    (globalThis as any).prompt = () => "  feat-x  ";
-    try {
-      const picker = changeBranch(div, "__new__");
-      await flush();
-      expect(picker.value).toBe("main");
-      expect(calls).toContainEqual(["gitCreateBranch", "feat-x"]);
-    } finally {
-      (globalThis as any).prompt = originalPrompt;
-    }
+    promptResult = "feat-x";
+    const picker = changeBranch(div, "__new__");
+    await flush();
+
+    expect(picker.value).toBe("main");
+    expect(promptCalls).toHaveLength(1);
+    const { headline, opts } = promptCalls[0]!;
+    expect(headline).toBe("New Branch");
+    expect(opts.confirmLabel).toBe("Create");
+    expect(opts.message).toContain("main");
+    expect(opts.validate("  ")).toBe("Enter a branch name.");
+    expect(opts.validate("feat-x")).toBe("");
+    expect(calls).toContainEqual(["gitCreateBranch", "feat-x"]);
   });
 
-  test("cancelled new-branch prompt creates nothing", async () => {
+  test("a dismissed new-branch dialog creates nothing", async () => {
     seedRepoUi();
     const div = renderPanel();
-    const originalPrompt = (globalThis as any).prompt;
-    (globalThis as any).prompt = () => null;
-    try {
-      changeBranch(div, "__new__");
-      await flush();
-      expect(callNames()).not.toContain("gitCreateBranch");
-    } finally {
-      (globalThis as any).prompt = originalPrompt;
-    }
+    promptResult = null;
+    changeBranch(div, "__new__");
+    await flush();
+    expect(callNames()).not.toContain("gitCreateBranch");
   });
 });
 

--- a/packages/studio/tests/git-panel-states.test.ts
+++ b/packages/studio/tests/git-panel-states.test.ts
@@ -24,6 +24,7 @@ void mock.module("../src/view.js", () => ({
 void mock.module("../src/ui/layers.js", () => ({
   showConfirmDialog: async () => true,
   showDialog: async () => null,
+  showPromptDialog: async () => null,
 }));
 
 void mock.module("../src/panels/statusbar.js", () => ({

--- a/packages/studio/tests/harness.ts
+++ b/packages/studio/tests/harness.ts
@@ -239,6 +239,37 @@ export function setValue(el: HTMLInputElement | HTMLTextAreaElement, value: stri
   el.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+// ─── Dialog helpers ───────────────────────────────────────────────────────────
+
+/** The topmost `sp-dialog-wrapper` currently mounted in the #layer-dialog layer, if any. */
+export function topDialog(): HTMLElement | null {
+  const wrappers = [...document.querySelectorAll("#layer-dialog sp-dialog-wrapper")];
+  return (wrappers.at(-1) as HTMLElement | undefined) ?? null;
+}
+
+/**
+ * Drive an open `showPromptDialog()`: type `value` into its field and confirm, or pass `null` to
+ * cancel. Returns the dialog element it acted on, or null when no dialog is open.
+ */
+export async function answerPromptDialog(value: string | null): Promise<HTMLElement | null> {
+  const wrapper = topDialog();
+  if (!wrapper) {
+    return null;
+  }
+  if (value === null) {
+    wrapper.dispatchEvent(new Event("cancel"));
+  } else {
+    const field = wrapper.querySelector("sp-textfield") as HTMLInputElement | null;
+    if (field) {
+      field.value = value;
+      field.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+    wrapper.dispatchEvent(new Event("confirm"));
+  }
+  await flush();
+  return wrapper;
+}
+
 // ─── New Project modal field accessors ───────────────────────────────────────
 // The Parameters step renders a destination block between the name and description whose shape
 // Depends on the platform's `createDestination` (specs/desktop.md §4.5), so positional indexing

--- a/packages/studio/tests/style-panel.test.ts
+++ b/packages/studio/tests/style-panel.test.ts
@@ -1,4 +1,11 @@
-import { renderInto, resetStudioState, resetWorkspaceWithTab } from "./harness";
+import {
+  answerPromptDialog,
+  flush,
+  renderInto,
+  resetStudioState,
+  resetWorkspaceWithTab,
+  topDialog,
+} from "./harness";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as storeActual from "../src/store";
 import { activeTab, closeAllTabs } from "../src/workspace/workspace";
@@ -21,12 +28,24 @@ void mock.module("../src/panels/stylebook-panel", () => ({
 
 const { _fieldRow, renderStylePanelTemplate } = await import("../src/panels/style-panel");
 const { initCssData } = await import("../src/panels/style-utils");
+const { initLayers } = await import("../src/ui/layers");
 const { getNodeAtPath } = await import("../src/store");
 const { resetSlotModeMemory } = await import("../src/ui/dynamic-slot");
 
 // Happy-dom may not provide requestAnimationFrame in all versions.
 (globalThis as Record<string, unknown>).requestAnimationFrame ??= (cb: (t: number) => void) =>
   setTimeout(() => cb(0), 0);
+
+// The nested-selector "+ Add" affordance opens a real Spectrum prompt dialog, so the panel needs
+// The overlay layers mounted.
+for (const id of ["layer-popover", "layer-modal", "layer-dialog"]) {
+  if (!document.querySelector(`#${id}`)) {
+    const el = document.createElement("div");
+    el.id = id;
+    document.body.append(el);
+  }
+}
+initLayers();
 
 const MEDIA = { md: "(min-width: 768px)", sm: "(min-width: 640px)" };
 
@@ -774,32 +793,44 @@ describe("relative styling section", () => {
     expect(table.textTransform).toBe("uppercase");
   });
 
-  test("+ Add prompts for a name and creates an empty rule; blank or cancel is ignored", async () => {
+  test("+ Add opens a selector dialog and creates an empty rule; blank or cancel is ignored", async () => {
     nestedTab();
-    const originalPrompt = globalThis.prompt;
-    try {
-      globalThis.prompt = () => " td ";
-      let c = await renderPanel();
-      let section = accordionItem(c, "Relative Styling");
-      const addBtn = [...section!.querySelectorAll("button")].find((b) =>
-        b.textContent?.includes("+ Add"),
-      );
-      click(addBtn);
-      const table = selectedNode().style?.table as Record<string, unknown>;
-      expect(table.td).toEqual({});
 
-      globalThis.prompt = () => null;
-      c = await renderPanel();
-      section = accordionItem(c, "Relative Styling");
+    /** Click the section's "+ Add" and let the prompt dialog render. */
+    async function clickAdd(container: HTMLElement) {
+      const section = accordionItem(container, "Relative Styling");
       click([...section!.querySelectorAll("button")].find((b) => b.textContent?.includes("+ Add")));
-      globalThis.prompt = () => "   ";
-      click([...section!.querySelectorAll("button")].find((b) => b.textContent?.includes("+ Add")));
-      expect(
-        Object.keys(selectedNode().style?.table as Record<string, unknown>).toSorted(),
-      ).toEqual(["td", "textTransform", "th"].toSorted());
-    } finally {
-      globalThis.prompt = originalPrompt;
+      await flush();
     }
+
+    let c = await renderPanel();
+    await clickAdd(c);
+
+    // A Spectrum dialog, not a native prompt.
+    expect(topDialog()).not.toBeNull();
+    expect(topDialog()!.getAttribute("headline")).toBe("Add Nested Selector");
+    expect(topDialog()!.getAttribute("confirm-label")).toBe("Add");
+
+    await answerPromptDialog(" td ");
+    const table = selectedNode().style?.table as Record<string, unknown>;
+    expect(table.td).toEqual({});
+
+    // Cancelling adds nothing.
+    c = await renderPanel();
+    await clickAdd(c);
+    await answerPromptDialog(null);
+
+    // A blank selector is rejected in place, leaving the dialog open and the style untouched.
+    c = await renderPanel();
+    await clickAdd(c);
+    await answerPromptDialog("   ");
+    expect(topDialog()).not.toBeNull();
+    expect(topDialog()!.querySelector("sp-help-text")?.textContent).toContain("Enter a selector.");
+    await answerPromptDialog(null);
+
+    expect(Object.keys(selectedNode().style?.table as Record<string, unknown>).toSorted()).toEqual(
+      ["td", "textTransform", "th"].toSorted(),
+    );
   });
 
   test("absent in base mode and toggle persists nested open state", async () => {

--- a/packages/studio/tests/ui-layers-gaps.test.ts
+++ b/packages/studio/tests/ui-layers-gaps.test.ts
@@ -13,6 +13,7 @@ import {
   renderPopover,
   showConfirmDialog,
   showDialog,
+  showPromptDialog,
   showSaveDiscardDialog,
 } from "../src/ui/layers";
 
@@ -126,6 +127,173 @@ describe("layers after init", () => {
         new Event("close"),
       );
       expect(await p2).toBe("cancel");
+    });
+  });
+
+  describe("showPromptDialog", () => {
+    function wrapper(): HTMLElement {
+      return layer("dialog").querySelector("sp-dialog-wrapper") as HTMLElement;
+    }
+    function field(): HTMLElement {
+      return layer("dialog").querySelector("sp-textfield") as HTMLElement;
+    }
+    /** Type into the field the way the sp-textfield input event reaches the handler. */
+    function type(text: string): void {
+      (field() as unknown as { value: string }).value = text;
+      field().dispatchEvent(new Event("input", { bubbles: true }));
+    }
+    /** Give the field a shadow-root <input> so the focus rAF has something to select. */
+    function stubShadowInput(value: string): { input: HTMLInputElement; ranges: number[][] } {
+      const tf = field();
+      const shadow = tf.shadowRoot ?? tf.attachShadow({ mode: "open" });
+      const input = document.createElement("input");
+      input.value = value;
+      const ranges: number[][] = [];
+      input.select = () => {
+        ranges.push([0, -1]);
+      };
+      input.setSelectionRange = (start, end) => {
+        ranges.push([start ?? 0, end ?? 0]);
+      };
+      shadow.append(input);
+      return { input, ranges };
+    }
+
+    test("confirm resolves the trimmed value; defaults render OK/Cancel", async () => {
+      const promise = showPromptDialog("Name it");
+      expect(wrapper().getAttribute("headline")).toBe("Name it");
+      expect(wrapper().getAttribute("confirm-label")).toBe("OK");
+      expect(wrapper().getAttribute("cancel-label")).toBe("Cancel");
+      // No message option → no explanatory paragraph.
+      expect(wrapper().querySelector("p")).toBeNull();
+
+      type("  spaced  ");
+      wrapper().dispatchEvent(new Event("confirm"));
+      expect(await promise).toBe("spaced");
+      expect(layer("dialog").querySelector("sp-dialog-wrapper")).toBeNull();
+    });
+
+    test("cancel and close both resolve null", async () => {
+      const cancelled = showPromptDialog("A");
+      wrapper().dispatchEvent(new Event("cancel"));
+      expect(await cancelled).toBeNull();
+
+      const closed = showPromptDialog("B");
+      wrapper().dispatchEvent(new Event("close"));
+      expect(await closed).toBeNull();
+    });
+
+    test("Enter in the field confirms; other keys do not", async () => {
+      const promise = showPromptDialog("C", { value: "seed" });
+      field().dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "a" }));
+      expect(layer("dialog").querySelector("sp-dialog-wrapper")).not.toBeNull();
+      field().dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+      expect(await promise).toBe("seed");
+    });
+
+    test("a blank value blocks confirm and shows the default help text", async () => {
+      const promise = showPromptDialog("D");
+      wrapper().dispatchEvent(new Event("confirm"));
+      expect(layer("dialog").querySelector("sp-dialog-wrapper")).not.toBeNull();
+      expect(field().getAttribute("invalid")).not.toBeNull();
+      expect(layer("dialog").querySelector("sp-help-text")?.textContent).toContain(
+        "Enter a value.",
+      );
+
+      // Typing something valid clears the error in place, then confirm goes through.
+      type("ok");
+      expect(layer("dialog").querySelector("sp-help-text")).toBeNull();
+      wrapper().dispatchEvent(new Event("confirm"));
+      expect(await promise).toBe("ok");
+    });
+
+    test("a custom validate() message blocks confirm until it passes", async () => {
+      const promise = showPromptDialog("E", {
+        confirmLabel: "Create",
+        message: "Pick a slug",
+        validate: (v) => (v.startsWith("x") ? "" : "Must start with x."),
+        value: "nope",
+      });
+      expect(wrapper().querySelector("p")?.textContent).toContain("Pick a slug");
+      expect(wrapper().getAttribute("confirm-label")).toBe("Create");
+
+      wrapper().dispatchEvent(new Event("confirm"));
+      expect(layer("dialog").querySelector("sp-help-text")?.textContent).toContain(
+        "Must start with x.",
+      );
+
+      type("xyz");
+      wrapper().dispatchEvent(new Event("confirm"));
+      expect(await promise).toBe("xyz");
+    });
+
+    test("input that leaves the error state unchanged does not re-render", async () => {
+      const promise = showPromptDialog("F");
+      const before = field();
+      type("aa");
+      type("bb");
+      // Still valid throughout, so lit never rebuilt the tree.
+      expect(field()).toBe(before);
+      expect(field().getAttribute("value")).toBe("");
+      wrapper().dispatchEvent(new Event("confirm"));
+      expect(await promise).toBe("bb");
+    });
+
+    test("select:'all' selects the whole value once the rAF fires", async () => {
+      const promise = showPromptDialog("G", { value: "hello" });
+      const { ranges } = stubShadowInput("hello");
+      await flush();
+      expect(ranges).toEqual([[0, -1]]);
+
+      // The focus ref only fires once — a re-render must not re-select mid-edit.
+      type("");
+      await flush();
+      expect(ranges).toEqual([[0, -1]]);
+
+      wrapper().dispatchEvent(new Event("cancel"));
+      await promise;
+    });
+
+    test("select:'stem' stops at the last dot, and falls back to the full value without one", async () => {
+      const dotted = showPromptDialog("H", { select: "stem", value: "note.md" });
+      const withDot = stubShadowInput("note.md");
+      await flush();
+      expect(withDot.ranges).toEqual([[0, 4]]);
+      wrapper().dispatchEvent(new Event("cancel"));
+      await dotted;
+
+      const bare = showPromptDialog("H", { select: "stem", value: "README" });
+      const noDot = stubShadowInput("README");
+      await flush();
+      expect(noDot.ranges).toEqual([[0, 6]]);
+      wrapper().dispatchEvent(new Event("cancel"));
+      await bare;
+
+      // A leading dot is an extension-less dotfile, not a stem boundary.
+      const dotfile = showPromptDialog("H", { select: "stem", value: ".env" });
+      const leading = stubShadowInput(".env");
+      await flush();
+      expect(leading.ranges).toEqual([[0, 4]]);
+      wrapper().dispatchEvent(new Event("cancel"));
+      await dotfile;
+    });
+
+    test("select:'none' focuses without selecting", async () => {
+      const promise = showPromptDialog("I", { select: "none", value: "keep" });
+      const { ranges } = stubShadowInput("keep");
+      await flush();
+      expect(ranges).toEqual([]);
+      wrapper().dispatchEvent(new Event("cancel"));
+      await promise;
+    });
+
+    test("a textfield with no shadow input is tolerated", async () => {
+      const promise = showPromptDialog("J", { placeholder: "type here", value: "v" });
+      expect(field().getAttribute("placeholder")).toBe("type here");
+      await flush();
+      expect(layer("dialog").querySelector("sp-dialog-wrapper")).not.toBeNull();
+      wrapper().dispatchEvent(new Event("cancel"));
+      expect(await promise).toBeNull();
     });
   });
 

--- a/specs/studio-ui-guidelines.md
+++ b/specs/studio-ui-guidelines.md
@@ -1,8 +1,8 @@
 # Jx Studio UI/UX Interface Guidelines
 
-**Version:** 0.1.6
+**Version:** 0.1.7
 **Status:** Implemented
-**Updated:** 2026-07-22
+**Updated:** 2026-07-26
 **Applies to:** `packages/studio/`
 
 ---
@@ -289,12 +289,13 @@ const collapsed = new Set();
 
 ### 6.1 Spectrum Components in Use
 
-Registered in `packages/studio/src/ui/spectrum.js`:
+Registered in `packages/studio/src/ui/spectrum.ts`:
 
 **Layout:** `sp-theme`, `sp-tabs`, `sp-tab`, `sp-tab-panel`, `sp-divider`
-**Inputs:** `sp-textfield`, `sp-number-field`, `sp-picker`, `sp-combobox`, `sp-checkbox`, `sp-switch`, `sp-field-label`, `sp-search`
+**Inputs:** `sp-textfield`, `sp-number-field`, `sp-picker`, `sp-combobox`, `sp-checkbox`, `sp-switch`, `sp-field-label`, `sp-search`, `sp-help-text`
 **Actions:** `sp-action-button`, `sp-action-group`, `sp-action-bar`, `sp-picker-button`
 **Overlays:** `sp-overlay`, `sp-popover`, `sp-tooltip`
+**Dialogs:** `sp-dialog`, `sp-dialog-wrapper`, `sp-underlay`
 **Menus:** `sp-menu`, `sp-menu-item`, `sp-menu-divider`, `sp-menu-group`
 **Data:** `sp-accordion`, `sp-accordion-item`, `sp-swatch`, `sp-swatch-group`
 **Color:** `sp-color-area`, `sp-color-slider`, `sp-color-handle`
@@ -373,6 +374,47 @@ Fixed-position toolbar that follows the selected element:
 - Shows element tag name, drag handle, and context actions
 - Z-index: 100
 - Shadow: standard elevation shadow
+
+### 8.7 Dialogs and Overlay Layers
+
+Studio renders every transient surface into one of three fixed, full-viewport hosts declared in
+`packages/studio/index.html` — `#layer-popover`, `#layer-modal`, `#layer-dialog` — bound once at boot
+by `initLayers()`. Each host is `pointer-events: none`; individual slots re-enable pointer events, so
+the layers never swallow canvas input.
+
+`packages/studio/src/ui/layers.ts` is the only sanctioned way to open one:
+
+| Helper                  | Resolves                               | Use for                                          |
+| ----------------------- | -------------------------------------- | ------------------------------------------------ |
+| `showDialog<T>`         | `T` (whatever `done()` is called with) | Bespoke dialog bodies (multi-field forms)        |
+| `showConfirmDialog`     | `boolean`                              | Confirm / cancel, `destructive: true` for danger |
+| `showSaveDiscardDialog` | `"save" \| "discard" \| "cancel"`      | Unsaved-work decisions                           |
+| `showPromptDialog`      | `string \| null` (trimmed)             | Single-value text entry                          |
+| `openModal`             | handle with `update()` / `close()`     | Persistent modals (New Project, About)           |
+| `renderPopover`         | handle with `update()` / `dismiss()`   | Anchored popovers and context menus              |
+
+**Native browser dialogs are not permitted.** `window.prompt()`, `window.confirm()`, and
+`window.alert()` are unstyled, untranslatable, block the entire renderer, and are unavailable in
+sandboxed contexts. The `no-alert` lint rule (oxlint `restriction` category, enabled repo-wide in
+`.oxlintrc.json`) enforces this; suppressing it requires justification in the change set.
+
+`showPromptDialog(headline, opts)` is the replacement for `window.prompt()`:
+
+- `value` pre-fills the field; `select` controls what is highlighted on focus — `"all"`, `"stem"`
+  (everything before the last dot, so renaming a file keeps its extension), or `"none"`.
+- `validate(value)` returns `""` for valid input, or a message. A non-empty message renders as
+  `sp-help-text[slot="negative-help-text"]`, marks the field `invalid`, and blocks confirmation
+  without closing the dialog. The default rejects blank input.
+- `message` renders explanatory copy above the field; `placeholder`, `confirmLabel`, and
+  `cancelLabel` follow the usual Spectrum semantics.
+- Confirming resolves the **trimmed** value; cancel, close, and dismissal all resolve `null`.
+- <kbd>Enter</kbd> in the field confirms. The field takes focus on open, once — re-renders triggered
+  by validation must not steal the caret back.
+
+Dialog attributes are kebab-case on `sp-dialog-wrapper` (`confirm-label`, `cancel-label`,
+`secondary-label`). The camelCase property names are not observed attributes; using them silently
+renders a dialog with no buttons.
+
 - Auto-hides when no selection
 
 ---
@@ -425,9 +467,12 @@ When building new UI in Studio, verify:
 - [ ] State mutations are immutable (produce new objects)
 - [ ] Custom components use light DOM (`createRenderRoot() { return this; }`)
 - [ ] Event handlers call `e.stopPropagation()` when wrapping Spectrum events in light DOM components
+- [ ] Text entry and confirmation go through `ui/layers.ts` (§8.7) — never `prompt()`, `confirm()`, or `alert()`
+- [ ] `sp-dialog-wrapper` labels use kebab-case attributes (`confirm-label`, not `confirmLabel`)
 
 ## Changelog
 
+- **0.1.7** (2026-07-26) — Dialogs and overlay layers (§8.7): the ui/layers.ts contract, showPromptDialog as the replacement for window.prompt(), and a ban on native browser dialogs.
 - **0.1.6** (2026-07-22) — Proper spec versioning (`fb0f3ec7`).
 - **0.1.5** (2026-07-22) — Machine-readable spec status vocabulary + generated status page (`79daba23`).
 - **0.1.4** (2026-07-17) — Color-scheme canvas preview — Auto/Light/Dark tab-bar control (`ccdc1d3e`).

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -2,9 +2,9 @@
 
 ## Visual Builder for Jx Documents
 
-**Version:** 0.1.28-draft
+**Version:** 0.1.29-draft
 **Status:** Partial
-**Updated:** 2026-07-25
+**Updated:** 2026-07-26
 **License:** MIT
 
 ---
@@ -286,7 +286,7 @@ Each file row displays:
 
 #### Branch Management
 
-The branch picker lists all local branches and includes a "+ New branch..." option that prompts for a name and creates + checks out a new branch.
+The branch picker lists all local branches and includes a "+ New branch..." option that opens a New Branch dialog (`showPromptDialog`, studio-ui-guidelines.md §8.7) and creates + checks out the branch on confirm. Cloning a repository asks for its URL through the same dialog.
 
 #### Server Endpoints
 
@@ -437,7 +437,7 @@ Color-scheme variants add **no extra tabs**: the tab-bar Auto/Light/Dark control
 
 #### Nested Selector Context
 
-Nested CSS selectors (`:hover`, `:focus`, `:active`, `& childTag`) are editable as separate style contexts. The selector picker is inline in the media tabs toolbar bar, right-aligned.
+Nested CSS selectors (`:hover`, `:focus`, `:active`, `& childTag`) are editable as separate style contexts. The selector picker is inline in the media tabs toolbar bar, right-aligned. The Relative Styling section's "+ Add" affordance opens an Add Nested Selector dialog (`showPromptDialog`, studio-ui-guidelines.md §8.7) and creates an empty rule for the entered selector.
 
 #### Property Filter Bar
 
@@ -544,6 +544,20 @@ The studio tracks:
 - Selected file path
 - Component discovery results
 
+### 9.1.1 Create, Rename, Delete
+
+Every name the user supplies is collected through the Spectrum dialogs in §8.7 of
+studio-ui-guidelines.md — no native browser prompts:
+
+| Action                                                        | Dialog                                                                                               |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Files panel **New File** (toolbar and directory context menu) | New File — pre-filled `untitled.json`, extension preserved on retype, scoped to the target directory |
+| Files / Browse **Rename**                                     | Rename — pre-filled with the current name                                                            |
+| Browse **New ›** _entity_                                     | New _Type_ — pre-filled `untitled`, slugified into the type's directory                              |
+| Files / Browse **Delete**                                     | Confirmation dialog                                                                                  |
+
+Blank input is rejected in place: the dialog stays open with negative help text rather than closing.
+
 ### 9.2 Server Integration
 
 All file operations go through the Platform Abstraction Layer, which maps to `@jxsuite/server` Studio API endpoints:
@@ -602,6 +616,7 @@ See the [Site Architecture Specification](site-architecture.md) for full design 
 
 ## Changelog
 
+- **0.1.29-draft** (2026-07-26) — File create/rename/delete naming dialogs (§9.1.1); branch, clone, and nested-selector flows now open Spectrum dialogs instead of native prompts.
 - **0.1.28-draft** (2026-07-25) — The Cloud platform target composes per-project schemas server-side (§3.4).
 - **0.1.27-draft** (2026-07-25) — Source-mode schema validation contract: per-project entry documents, offline $schema-id registration, worker self-location (§4.2.1); fetchProjectSchemas in the PAL table (§3.4).
 - **0.1.26-draft** (2026-07-25) — PAL table records the destination members: createDestination, createProject's user-chosen destination, and pickDirectory.
@@ -634,4 +649,4 @@ See the [Site Architecture Specification](site-architecture.md) for full design 
 
 ---
 
-_`@jxsuite/studio` Specification v0.1.28-draft_
+_`@jxsuite/studio` Specification v0.1.29-draft_


### PR DESCRIPTION
Four flows still called window.prompt() — the Files panel's New File…, the Manage modal's New › <type>, the style panel's Relative Styling + Add, and the git panel's + New branch… — each with a copy-pasted no-alert suppression claiming native prompt was the intended UX. Nothing in the specs sanctioned that; studio-ui-guidelines.md §1 has always required Spectrum for all UI chrome. The gap was that the 2026-05-28 confirm-dialogs pass added showConfirmDialog but no prompt equivalent, so text entry had nowhere to go.

Add showPromptDialog() to ui/layers.ts — value, select ("all" | "stem" | "none"), validate (blocks confirm and renders negative help text in place), message, placeholder; resolves the trimmed value or null. Convert all four call sites and fold the two copy-pasted rename dialogs in files.ts and browse.ts into it. oxlint's no-alert rule is now the complete inventory: zero suppressions remain anywhere in the repo.

Also fixes a live bug this surfaced: the Clone Git Repository dialog passed confirmLabel/cancelLabel, but sp-dialog-wrapper only observes the kebab-case confirm-label/cancel-label, so it rendered with no buttons at all.

Two gotchas worth recording, both caught in a real browser:

- lit commits element refs before inserting the fragment, so el.parentElement is null inside a ref callback. The re-render host is resolved lazily instead.
- An inline-arrow ref re-fires on every render, so focus/select is guarded by a flag — otherwise validation re-renders steal the caret mid-edit.

Specs and docs land with the code: studio-ui-guidelines.md gains §8.7 (the layers.ts contract, showPromptDialog, and a ban on native browser dialogs) and studio.md gains §9.1.1 (create/rename/delete naming dialogs). files.ts and browse.ts are wired into docs code: frontmatter so future drift trips docs:sync.