### PR TITLE
fix(studio): offer Cloudflare AI enablement wherever credentials are gated

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,7 +17,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.2-draft  | Partial     | 2026-07-25 |
 | `collab.md`               | 0.2.0-draft  | Partial     | 2026-07-28 |
 | `compiler.md`             | 0.1.25-draft | Partial     | 2026-07-30 |
-| `desktop.md`              | 0.3.3-draft  | Pending     | 2026-07-29 |
+| `desktop.md`              | 0.3.4-draft  | Pending     | 2026-07-31 |
 | `extensions.md`           | 0.3.3-draft  | Partial     | 2026-07-25 |
 | `imports.md`              | 0.1.6-draft  | Partial     | 2026-07-22 |
 | `jx-markdown.md`          | 0.1.7-draft  | Partial     | 2026-07-22 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -55,6 +55,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.3.4-draft** (2026-07-31) — List the cfConnect? PAL member in the Publish/identity family — it ships in StudioPlatform and backs the hosted Cloudflare OAuth flow, but the table omitted it.
 - **0.3.3-draft** (2026-07-29) — PAL: launcher-only capabilities (updater, windowControls) stay off the StudioPlatform interface; adapter factories infer their return type and assert conformance instead of annotating it away.
 - **0.3.2-draft** (2026-07-29) — The desktop shell routes Studio preview links to the user's default browser via Utils.openExternal (§3.5).
 - **0.3.1-draft** (2026-07-25) — Repo picker gains a repository-access footer: per-installation manage links, install-on-another-account, and Refresh.

--- a/docs/studio/ai.md
+++ b/docs/studio/ai.md
@@ -7,6 +7,8 @@ code:
   - packages/studio/src/services/ai-settings.ts
   - packages/studio/src/services/tool-executor.ts
   - packages/studio/src/ui/ai-credentials-form.ts
+  - packages/studio/src/ui/ai-managed-connect.ts
+  - packages/studio/src/services/ai-models.ts
 ---
 
 # AI assistant
@@ -31,7 +33,17 @@ Each request gets five working rounds — five turns of thinking and calling too
 
 ## Connect a provider
 
-The first time you open the sidebar (and any time no key is stored), the chat is replaced by the **AI provider key** form:
+The first time you open the sidebar (and any time AI isn't connected yet), the chat is replaced by a short setup screen. It offers whichever routes your Studio supports.
+
+### Connect Cloudflare (Jx Cloud)
+
+On Jx Cloud the screen leads with **Connect Cloudflare**: Studio brokers **Workers AI** on your own Cloudflare account, so you need no API key and no third-party provider account. Click **Connect Cloudflare**, approve the authorization in the Cloudflare window that opens, and you land back in Studio with the assistant unlocked. Inference runs on — and bills to — your own Cloudflare account; Jx only brokers the request.
+
+This option appears only where a platform can run that hosted flow. The desktop app and the dev server show the key form alone.
+
+### Bring your own key
+
+Below the Cloudflare option (or on its own, everywhere else) is the **AI provider key** form:
 
 1. Paste an API key. Any OpenAI-compatible key works — OpenAI itself, a compatible hosted provider, or a local model server.
 2. Pick a **Model**. Click **Fetch models** to list what your key can use, or type a model ID directly.
@@ -41,8 +53,10 @@ The first time you open the sidebar (and any time no key is stored), the chat is
 To change any of this later, click the gear button (**API key & endpoint**) at the bottom of the sidebar. You can also switch models per conversation with the model picker next to the message box.
 
 :::doc-note
-The key, endpoint, and model choice are stored locally on your machine, per browser or app install. If the Studio backend you're running already has a provider key configured (for example a dev server started with an `OPENAI_API_KEY` environment variable), the assistant unlocks without asking for one.
+The key, endpoint, and model choice are stored locally on your machine, per browser or app install. If the Studio backend you're running already holds credentials — a dev server started with an `OPENAI_API_KEY` environment variable, or a Cloudflare account you connected earlier — the assistant unlocks without asking for anything.
 :::
+
+Whichever route you take unlocks the AI features everywhere in Studio, including the [New Project](/docs/studio/projects/create) dialog's **Import** and **Agent** tabs.
 
 ## What leaves your machine
 

--- a/docs/studio/projects/create.md
+++ b/docs/studio/projects/create.md
@@ -25,8 +25,14 @@ The first screen — **Start new project from:** — has up to four tabs:
   - **Mobile First** — the same, with min-width breakpoints: design the phone layout first and adapt up.
   - **Mobile App** — an app shell with bottom navigation.
 - **Starter Site** — a complete, themed website (restaurant, shop, portfolio, blog, and more) that Studio copies in as plain files you own. Browse the full gallery in **[Starter templates](/docs/studio/projects/starters)**.
-- **Import** — recreate an existing website as a Jx project. Give Studio the site's URL and how many pages to crawl; the import is AI-assisted, so this tab asks for an AI provider key before it unlocks. Not every Studio platform offers this tab.
-- **Agent** — describe the site you want in a sentence or two and the AI assistant builds it in the editor while you watch. Like Import, it needs an AI provider key first.
+- **Import** — recreate an existing website as a Jx project. Give Studio the site's URL and how many pages to crawl; the import is AI-assisted, so this tab asks you to connect AI before it unlocks. Not every Studio platform offers this tab.
+- **Agent** — describe the site you want in a sentence or two and the AI assistant builds it in the editor while you watch. Like Import, it needs AI connected first.
+
+Both tabs unlock the moment AI is available, by whichever route your Studio offers — the same options the [AI assistant](/docs/studio/ai) sidebar gives you:
+
+- **Connect Cloudflare** — on Jx Cloud, run Workers AI on your own Cloudflare account with no API key at all. Click the button, approve the Cloudflare authorization, and the tab unlocks when you land back in Studio.
+- **An AI provider key** — paste any OpenAI-compatible key into the form. This is the only route on desktop and the dev server.
+- **Nothing to do** — if the Studio backend already holds a provider key (a dev server started with `OPENAI_API_KEY`, or a Cloudflare account you connected earlier), both tabs are unlocked from the start.
 
 Pick a source and click **Next**.
 

--- a/packages/studio/src/new-project/import-tab.ts
+++ b/packages/studio/src/new-project/import-tab.ts
@@ -1,13 +1,14 @@
 /**
  * The New Project modal's Import source step: an AI-guided clone of an existing site. Gated behind
- * the AI credentials form when no key is stored; otherwise a URL + crawl-options form. The
- * name/directory parameters live on the modal's shared Parameters step; the running pipeline
- * streams its progress into a log here and resolves the modal with the imported project.
+ * the AI credentials gate (key form + the keyless Cloudflare option) until AI is usable — a local
+ * key, or a backend holding its own; otherwise a URL + crawl-options form. The name/directory
+ * parameters live on the modal's shared Parameters step; the running pipeline streams its progress
+ * into a log here and resolves the modal with the imported project.
  */
 
 import { html } from "lit-html";
 import { getPlatform } from "../platform";
-import { getBaseUrl, getModel, getOpenAiKey, hasOpenAiKey } from "../services/ai-settings";
+import { getBaseUrl, getModel, getOpenAiKey } from "../services/ai-settings";
 import { errorMessage } from "@jxsuite/schema/parse";
 import { destinationPath } from "./location-fields";
 import type { TemplateResult } from "lit-html";
@@ -18,6 +19,12 @@ import type { CreateProjectDestination, ImportProgressEvent } from "../types";
 export interface CredsFormLike {
   render: () => TemplateResult;
   startEdit: () => void;
+}
+
+/** Structural view of src/ui/ai-managed-connect's controller (the keyless option beside the form). */
+export interface ManagedConnectLike {
+  canOffer: () => boolean;
+  render: () => unknown;
 }
 
 export interface ImportTabCtx {
@@ -32,8 +39,15 @@ export interface ImportTabCtx {
   rerender: () => void;
   /** Called with the imported project; the modal resolves and closes. */
   onDone: (result: { root: string; config: ProjectConfig }) => void;
-  /** The modal's shared credentials-form instance, rendered while no key is stored. */
+  /** The modal's shared credentials-form instance, rendered while the gate is closed. */
   credsForm: CredsFormLike;
+  /**
+   * Whether AI is usable — a local key OR a backend holding credentials of its own. Also fires the
+   * capability probe while closed, so a managed platform's Cloudflare option can appear.
+   */
+  aiGateOpen: () => boolean;
+  /** The modal's shared keyless "Connect Cloudflare" controller, rendered beside the form. */
+  managedConnect: ManagedConnectLike;
 }
 
 let _url = "";
@@ -253,13 +267,17 @@ export function renderImportStatus(): TemplateResult {
 }
 
 export function renderImportSource(ctx: ImportTabCtx): TemplateResult {
-  if (!hasOpenAiKey()) {
+  if (!ctx.aiGateOpen()) {
     return html`
       <div class="new-project-tab-intro">
-        Importing uses an AI-guided pipeline to clone an existing site. Add an OpenAI-compatible API
-        key to continue.
+        Importing uses an AI-guided pipeline to clone an existing site.
+        ${
+          ctx.managedConnect.canOffer()
+            ? "Connect Cloudflare, or add an OpenAI-compatible API key, to continue."
+            : "Add an OpenAI-compatible API key to continue."
+        }
       </div>
-      <div class="new-project-creds">${ctx.credsForm.render()}</div>
+      <div class="new-project-creds">${ctx.managedConnect.render()} ${ctx.credsForm.render()}</div>
     `;
   }
 

--- a/packages/studio/src/new-project/new-project-modal.ts
+++ b/packages/studio/src/new-project/new-project-modal.ts
@@ -6,7 +6,10 @@
  * (colors, fonts, logo, breakpoints — a creation-time subset of the settings modal), prefilled from
  * the chosen source and customizable before anything is written.
  *
- * Import and Agent are gated behind the AI credentials form until a key is stored.
+ * Import and Agent need working AI, so both are gated until credentials exist — a key stored in
+ * this browser, or a backend that holds its own (managed cloud platforms, env-keyed dev servers).
+ * While gated they offer the same two paths as the assistant sidebar: connect Cloudflare for
+ * Workers AI, or bring a key.
  */
 
 import { html } from "lit-html";
@@ -14,9 +17,10 @@ import { errorMessage } from "@jxsuite/schema/parse";
 import { openModal } from "../ui/layers";
 import { getPlatform } from "../platform";
 import { installUrlOf } from "../platform-errors";
-import { hasOpenAiKey } from "../services/ai-settings";
+import { hasAiCredentials } from "../services/ai-models";
 import { setPendingAgentPrompt } from "../services/agent-seed";
 import { createAiCredentialsForm } from "../ui/ai-credentials-form";
+import { createManagedConnect } from "../ui/ai-managed-connect";
 import { PROJECT_TEMPLATES } from "./templates";
 import { collectDesign, renderDesignFields, resetDesignFields } from "./design-fields";
 import {
@@ -98,20 +102,42 @@ let _resolve: ((result: { root: string; config: ProjectConfig } | null) => void)
 // Before a platform is registered (the form fetches models through the platform on edit).
 let _credsForm: ReturnType<typeof createAiCredentialsForm> | null = null;
 
+function rerenderIfOpen() {
+  if (_handle) {
+    renderModal();
+  }
+}
+
 function credsForm() {
   _credsForm ??= createAiCredentialsForm({
-    onSaved: () => {
-      if (_handle) {
-        renderModal();
-      }
-    },
-    requestRender: () => {
-      if (_handle) {
-        renderModal();
-      }
-    },
+    onSaved: rerenderIfOpen,
+    requestRender: rerenderIfOpen,
   });
   return _credsForm;
+}
+
+/**
+ * The keyless "Connect Cloudflare" option shown beside the key form on managed platforms — the same
+ * controller the assistant sidebar uses. Lazy for the same reason as the form above.
+ */
+let _managedConnect: ReturnType<typeof createManagedConnect> | null = null;
+
+function managedConnect() {
+  _managedConnect ??= createManagedConnect({ requestRender: rerenderIfOpen });
+  return _managedConnect;
+}
+
+/**
+ * The Import and Agent tabs need working AI, which a managed platform can supply without any local
+ * key. Probe on every gated render so the Cloudflare option appears as soon as the backend
+ * answers.
+ */
+function aiGateOpen(): boolean {
+  if (hasAiCredentials()) {
+    return true;
+  }
+  managedConnect().ensureProbe();
+  return false;
 }
 
 /**
@@ -235,8 +261,10 @@ function sourceLabel(): string {
 function renderModal() {
   const platform = getPlatform();
   const importCtx: ImportTabCtx = {
+    aiGateOpen,
     credsForm: credsForm(),
     form: _form,
+    managedConnect: managedConnect(),
     onDone: finish,
     rerender: renderModal,
     resolveDestination: () => validateParams(),
@@ -469,13 +497,17 @@ function renderModal() {
       : html`<div class="new-project-tab-intro">No starter sites are available.</div>`;
 
   const agentSourceTpl = () => {
-    if (!hasOpenAiKey()) {
+    if (!aiGateOpen()) {
       return html`
         <div class="new-project-tab-intro">
-          The agent uses your AI provider to build the site. Add an OpenAI-compatible API key to
-          continue.
+          The agent uses your AI provider to build the site.
+          ${
+            managedConnect().canOffer()
+              ? "Connect Cloudflare, or add an OpenAI-compatible API key, to continue."
+              : "Add an OpenAI-compatible API key to continue."
+          }
         </div>
-        <div class="new-project-creds">${credsForm().render()}</div>
+        <div class="new-project-creds">${managedConnect().render()} ${credsForm().render()}</div>
       `;
     }
     return html`
@@ -597,7 +629,7 @@ function renderModal() {
       `;
     }
     if (_step === "source") {
-      const gated = (_tab === "import" || _tab === "agent") && !hasOpenAiKey();
+      const gated = (_tab === "import" || _tab === "agent") && !aiGateOpen();
       return html`
         <sp-button variant="secondary" @click=${closeNewProjectModal}>Cancel</sp-button>
         ${gated ? "" : html`<sp-button variant="accent" @click=${goNext}>Next</sp-button>`}

--- a/packages/studio/src/panels/ai-panel.ts
+++ b/packages/studio/src/panels/ai-panel.ts
@@ -16,14 +16,14 @@
  * @license MIT
  */
 
-import { html, render as litRender, nothing } from "lit-html";
+import { html, render as litRender } from "lit-html";
 import type { TemplateResult } from "lit-html";
-import { getPlatform } from "../platform";
 import { effect, effectScope } from "../reactivity";
 import { createDocumentAssistant } from "../services/document-assistant";
-import { hasOpenAiKey, setOpenAiKey } from "../services/ai-settings";
-import { fetchAvailableModels, isManagedProxy, isProxyConfigured } from "../services/ai-models";
+import { setOpenAiKey } from "../services/ai-settings";
+import { hasAiCredentials } from "../services/ai-models";
 import { createAiCredentialsForm } from "../ui/ai-credentials-form";
+import { createManagedConnect } from "../ui/ai-managed-connect";
 import { clearMarkdownCache } from "./ai-chat/chat-markdown";
 import { renderChatHeader, renderMessageList } from "./ai-chat/chat-view";
 import { createComposer } from "./ai-chat/composer";
@@ -37,23 +37,6 @@ let mounted = false;
 
 /** Whether the OpenAI key form is showing (gate when no key, or re-edit via the gear). */
 let keyEditing = false;
-
-/**
- * One-time proxy probe: managed platforms (cloud Workers AI) and env-keyed dev servers report
- * `configured` from /models, unlocking the assistant without a locally stored key. Fired lazily on
- * the first gated render.
- */
-let proxyProbe: Promise<void> | null = null;
-
-function ensureProxyProbe() {
-  proxyProbe ??= fetchAvailableModels({ force: true })
-    .catch(() => {
-      // Unreachable proxy — the key gate stays up.
-    })
-    .then(() => {
-      scheduleAiRender();
-    });
-}
 
 /** Which pane the panel shows once the key gate is passed. */
 let view: "chat" | "sessions" = "chat";
@@ -171,56 +154,8 @@ function startEditApiKey() {
 
 // ─── Managed Cloudflare connect (Workers AI) ─────────────────────────────────
 
-let cfConnectBusy = false;
-let cfConnectError = "";
-
-/**
- * Managed platforms broker Workers AI on the user's own Cloudflare account: offer connecting it as
- * the keyless alternative whenever the proxy says managed-but-unconfigured and the platform can run
- * the hosted OAuth flow (the PAL seam — desktop shells can implement cfConnect later).
- */
-function canOfferManagedConnect(): boolean {
-  return isManagedProxy() && !isProxyConfigured() && Boolean(getPlatform().cfConnect);
-}
-
-async function connectCloudflareForAi() {
-  if (cfConnectBusy) {
-    return;
-  }
-  cfConnectBusy = true;
-  cfConnectError = "";
-  scheduleAiRender();
-  try {
-    const connection = await getPlatform().cfConnect?.();
-    if (connection) {
-      // Re-probe: /models flips to configured once the connection lands, opening the gate.
-      await fetchAvailableModels({ force: true });
-    } else {
-      cfConnectError = "Cloudflare connection was not completed.";
-    }
-  } catch (error) {
-    cfConnectError = error instanceof Error ? error.message : String(error);
-  }
-  cfConnectBusy = false;
-  scheduleAiRender();
-}
-
-function renderManagedConnect() {
-  return html`
-    <div class="ai-managed-connect">
-      <div>Use Workers AI on your own Cloudflare account — no API key needed.</div>
-      <sp-button size="s" ?disabled=${cfConnectBusy} @click=${() => void connectCloudflareForAi()}>
-        ${cfConnectBusy ? "Connecting…" : "Connect Cloudflare"}
-      </sp-button>
-      ${
-        cfConnectError
-          ? html`<div class="ai-managed-connect-error">${cfConnectError}</div>`
-          : nothing
-      }
-      <div class="ai-managed-connect-divider">— or bring your own key —</div>
-    </div>
-  `;
-}
+/** Shared with the New Project modal's gates — see ui/ai-managed-connect.ts. */
+const managedConnect = createManagedConnect({ requestRender: scheduleAiRender });
 
 /**
  * The credentials gate: on managed platforms a keyless "Connect Cloudflare" (Workers AI) option
@@ -229,9 +164,7 @@ function renderManagedConnect() {
 function renderKeyGate() {
   return html`
     <div class="ai-tab-body">
-      <div class="ai-status-center">
-        ${canOfferManagedConnect() ? renderManagedConnect() : nothing} ${credsForm.render()}
-      </div>
+      <div class="ai-status-center">${managedConnect.render()} ${credsForm.render()}</div>
     </div>
   `;
 }
@@ -377,9 +310,9 @@ export function renderAiPanelTemplate(): TemplateResult {
   /* The document assistant authenticates via the AI proxy. Gate the chat
      behind the key form until a key is stored locally OR the proxy reports
      itself configured (managed platforms, env-keyed dev servers). */
-  if ((!hasOpenAiKey() && !isProxyConfigured()) || keyEditing) {
+  if (!hasAiCredentials() || keyEditing) {
     if (!keyEditing) {
-      ensureProxyProbe();
+      managedConnect.ensureProbe();
     }
     return renderKeyGate();
   }

--- a/packages/studio/src/services/ai-models.ts
+++ b/packages/studio/src/services/ai-models.ts
@@ -13,7 +13,7 @@
 
 import type { AiModelsResponse } from "@jxsuite/protocol";
 import { getPlatform } from "../platform";
-import { getBaseUrl, getOpenAiKey } from "./ai-settings";
+import { getBaseUrl, getOpenAiKey, hasOpenAiKey } from "./ai-settings";
 
 export interface AiModel {
   id: string;
@@ -25,12 +25,56 @@ let proxyConfigured = false;
 let proxyManaged = false;
 let proxyDefaultModel = "";
 
+/**
+ * One-shot capability probe shared by every credentials gate, plus the hosts to repaint when it
+ * settles. Managed platforms (cloud Workers AI) and env-keyed dev servers report their state from
+ * /models, so the gate cannot know which paths to offer until this has run once.
+ */
+let proxyProbe: Promise<void> | null = null;
+const probeListeners = new Set<() => void>();
+
 /** Drop the cached model list (call after credentials/endpoint changes). */
 export function invalidateModelCache() {
   cache = null;
   proxyConfigured = false;
   proxyManaged = false;
   proxyDefaultModel = "";
+  /* The probe's result IS the three flags above. Clearing them while keeping the settled promise
+     would strand every gate on a permanent "unconfigured, unmanaged" reading — ensureProxyProbe
+     would no-op forever and the managed option would vanish until a full reload. */
+  proxyProbe = null;
+}
+
+/**
+ * Run the capability probe once, repainting `onSettled` when it lands. Idempotent: concurrent and
+ * repeated callers share the single in-flight fetch, and every registered host is notified. Probe
+ * failure is not surfaced — an unreachable proxy simply leaves the gate showing the key form.
+ *
+ * @param {() => void} [onSettled] - Host re-render scheduler, registered for this and later probes.
+ */
+export function ensureProxyProbe(onSettled?: () => void) {
+  if (onSettled) {
+    probeListeners.add(onSettled);
+  }
+  proxyProbe ??= fetchAvailableModels({ force: true })
+    .catch(() => {
+      // Unreachable proxy — the key gate stays up.
+    })
+    .then(() => {
+      for (const notify of probeListeners) {
+        notify();
+      }
+    });
+}
+
+/**
+ * Whether the assistant can run at all: a key stored in this browser, or a backend that holds
+ * credentials itself (managed cloud platforms, env-keyed dev servers). Every credentials gate must
+ * use this rather than `hasOpenAiKey()` alone — gating on the local key locks managed-platform
+ * users out of features their own Cloudflare account is already paying for.
+ */
+export function hasAiCredentials(): boolean {
+  return hasOpenAiKey() || isProxyConfigured();
 }
 
 /**

--- a/packages/studio/src/ui/ai-managed-connect.ts
+++ b/packages/studio/src/ui/ai-managed-connect.ts
@@ -1,0 +1,107 @@
+/// <reference lib="dom" />
+/**
+ * Ai-managed-connect.ts — the keyless "Connect Cloudflare" (Workers AI) option for credentials
+ * gates.
+ *
+ * Companion to ai-credentials-form.ts: managed platforms broker Workers AI on the user's OWN
+ * Cloudflare account, so a gate that renders only the key form strands them — they have no key, and
+ * nothing on screen offers the hosted OAuth flow that would give them working AI. Both hosts that
+ * gate on credentials (the assistant sidebar and the New Project modal's Import/Agent tabs) embed
+ * this alongside the form so both real paths are always on offer.
+ *
+ * State is per-instance (closure-scoped) like the credentials form; the capability probe behind
+ * `ensureProbe` is shared module-wide by services/ai-models.ts.
+ *
+ * @docs studio/ai
+ * @license MIT
+ */
+
+import { html, nothing } from "lit-html";
+import type { TemplateResult } from "lit-html";
+import { getPlatform, hasPlatform } from "../platform";
+import {
+  ensureProxyProbe,
+  fetchAvailableModels,
+  isManagedProxy,
+  isProxyConfigured,
+} from "../services/ai-models";
+
+export interface ManagedConnectOptions {
+  /** Host re-render scheduler — called on connect start/finish and when the probe settles. */
+  requestRender: () => void;
+}
+
+export interface ManagedConnect {
+  /** Whether the keyless path is available and worth offering right now. */
+  canOffer: () => boolean;
+  /** Fire the shared capability probe, repainting the host when it settles. */
+  ensureProbe: () => void;
+  /** The CTA block, or `nothing` when the platform cannot broker AI. */
+  render: () => TemplateResult | typeof nothing;
+}
+
+/**
+ * Create a managed-connect controller bound to a host's render scheduler.
+ *
+ * @param {ManagedConnectOptions} opts
+ * @returns {ManagedConnect}
+ */
+export function createManagedConnect(opts: ManagedConnectOptions): ManagedConnect {
+  let busy = false;
+  let connectError = "";
+
+  /*
+   * Offer the keyless path when the proxy says managed-but-unconfigured and the platform can run
+   * the hosted OAuth flow (the PAL seam — desktop shells can implement cfConnect later). Guarded on
+   * hasPlatform() because gates can render from modules that load before registration.
+   */
+  function canOffer(): boolean {
+    return (
+      isManagedProxy() && !isProxyConfigured() && hasPlatform() && Boolean(getPlatform().cfConnect)
+    );
+  }
+
+  function ensureProbe() {
+    ensureProxyProbe(opts.requestRender);
+  }
+
+  async function connect() {
+    if (busy) {
+      return;
+    }
+    busy = true;
+    connectError = "";
+    opts.requestRender();
+    try {
+      const connection = await getPlatform().cfConnect?.();
+      if (connection) {
+        // Re-probe: /models flips to configured once the connection lands, opening the gate.
+        await fetchAvailableModels({ force: true });
+      } else {
+        connectError = "Cloudflare connection was not completed.";
+      }
+    } catch (error) {
+      connectError = error instanceof Error ? error.message : String(error);
+    }
+    busy = false;
+    opts.requestRender();
+  }
+
+  function render(): TemplateResult | typeof nothing {
+    if (!canOffer()) {
+      return nothing;
+    }
+    return html`
+      <div class="ai-managed-connect">
+        <div>Use Workers AI on your own Cloudflare account — no API key needed.</div>
+        <sp-button size="s" ?disabled=${busy} @click=${() => void connect()}>
+          ${busy ? "Connecting…" : "Connect Cloudflare"}
+        </sp-button>
+        ${connectError ? html`<div class="ai-managed-connect-error">${connectError}</div>` : nothing}
+        <div class="ai-managed-connect-divider">— or bring your own key —</div>
+      </div>
+    `;
+  }
+
+  return { canOffer, ensureProbe, render };
+}

--- a/packages/studio/tests/ai-managed-connect.test.ts
+++ b/packages/studio/tests/ai-managed-connect.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for src/ui/ai-managed-connect.ts — the keyless "Connect Cloudflare" (Workers AI) option
+ * every AI credentials gate embeds beside the key form.
+ *
+ * The regression this guards: a gate that renders only the key form strands managed-platform users,
+ * who have no key and no way to obtain one from inside Studio.
+ */
+import { installMockPlatform } from "./harness";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { render } from "lit-html";
+import { createManagedConnect } from "../src/ui/ai-managed-connect";
+import { fetchAvailableModels, invalidateModelCache } from "../src/services/ai-models";
+
+const { platform } = installMockPlatform();
+
+let fetchImpl: (url: string, init?: RequestInit) => Promise<Response> = async () =>
+  Response.json({ models: [] }, { status: 200 });
+const fetchCalls: string[] = [];
+(globalThis as Record<string, unknown>).fetch = (url: string, init?: RequestInit) => {
+  fetchCalls.push(url);
+  return fetchImpl(url, init);
+};
+
+async function flush(turns = 4) {
+  for (let i = 0; i < turns; i++) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+}
+
+/** A controller wired to re-render itself into a dedicated container. */
+function makeConnect() {
+  const container = document.createElement("div");
+  const mc = createManagedConnect({
+    requestRender: () => {
+      render(mc.render(), container);
+    },
+  });
+  render(mc.render(), container);
+  return { container, mc };
+}
+
+function connectButton(container: HTMLElement) {
+  return [...container.querySelectorAll("sp-button")].find((b) =>
+    b.textContent?.includes("Connect"),
+  ) as HTMLElement | undefined;
+}
+
+/** Put the proxy into managed-but-unconfigured — the state that warrants the offer. */
+async function probeManaged(managed: boolean, configured = false) {
+  fetchImpl = async () => Response.json({ models: [], configured, managed }, { status: 200 });
+  await fetchAvailableModels({ force: true });
+}
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+  invalidateModelCache();
+  fetchCalls.length = 0;
+  delete platform.cfConnect;
+});
+
+describe("canOffer", () => {
+  test("only when the proxy is managed, unconfigured, and the platform can run the flow", async () => {
+    const { mc } = makeConnect();
+    // Nothing probed yet.
+    expect(mc.canOffer()).toBe(false);
+
+    await probeManaged(true);
+    // Managed, but this platform has no hosted OAuth flow (desktop/dev server).
+    expect(mc.canOffer()).toBe(false);
+
+    platform.cfConnect = async () => ({ connected: true });
+    expect(mc.canOffer()).toBe(true);
+
+    // Already connected — the gate is open, so there is nothing to offer.
+    await probeManaged(true, true);
+    expect(mc.canOffer()).toBe(false);
+
+    // Unmanaged backend (OSS dev server): BYOK is the only path.
+    await probeManaged(false);
+    expect(mc.canOffer()).toBe(false);
+  });
+});
+
+describe("render", () => {
+  test("renders nothing until the offer applies, then the CTA", async () => {
+    const { container, mc } = makeConnect();
+    expect(container.querySelector(".ai-managed-connect")).toBeNull();
+
+    await probeManaged(true);
+    platform.cfConnect = async () => ({ connected: true });
+    render(mc.render(), container);
+
+    const cta = container.querySelector(".ai-managed-connect");
+    expect(cta).toBeTruthy();
+    expect(cta!.textContent).toContain("Workers AI");
+    expect(connectButton(container)!.textContent).toContain("Connect Cloudflare");
+    // Both paths stay on offer — the CTA introduces the key form below it.
+    expect(cta!.textContent).toContain("or bring your own key");
+  });
+});
+
+describe("connect", () => {
+  test("runs the platform flow, then re-probes so the gate opens", async () => {
+    await probeManaged(true);
+    const cfConnect = mock(async () => ({ accountId: "acc-1", connected: true }));
+    platform.cfConnect = cfConnect;
+    const { container, mc } = makeConnect();
+    render(mc.render(), container);
+
+    fetchCalls.length = 0;
+    fetchImpl = async () =>
+      Response.json(
+        { models: [{ id: "@cf/meta/llama-4" }], configured: true, managed: true },
+        {
+          status: 200,
+        },
+      );
+    connectButton(container)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush();
+
+    expect(cfConnect).toHaveBeenCalledTimes(1);
+    expect(fetchCalls).toHaveLength(1);
+    // Configured now, so the offer withdraws and the container empties.
+    expect(mc.canOffer()).toBe(false);
+    expect(container.querySelector(".ai-managed-connect")).toBeNull();
+  });
+
+  test("reports an abandoned flow without closing the offer", async () => {
+    await probeManaged(true);
+    platform.cfConnect = async () => null;
+    const { container, mc } = makeConnect();
+    render(mc.render(), container);
+
+    connectButton(container)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush();
+
+    expect(container.querySelector(".ai-managed-connect-error")?.textContent).toContain(
+      "not completed",
+    );
+    expect(mc.canOffer()).toBe(true);
+  });
+
+  test("surfaces a thrown error and re-enables the button", async () => {
+    await probeManaged(true);
+    platform.cfConnect = async () => {
+      throw new Error("popup blocked");
+    };
+    const { container } = makeConnect();
+
+    connectButton(container)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush();
+
+    expect(container.querySelector(".ai-managed-connect-error")?.textContent).toContain(
+      "popup blocked",
+    );
+    expect(connectButton(container)!.hasAttribute("disabled")).toBe(false);
+  });
+
+  test("ignores a second click while a flow is in flight", async () => {
+    await probeManaged(true);
+    let resolveFlow: ((v: { connected: boolean }) => void) | null = null;
+    const cfConnect = mock(
+      async () =>
+        await new Promise<{ connected: boolean }>((resolve) => {
+          resolveFlow = resolve;
+        }),
+    );
+    platform.cfConnect = cfConnect;
+    const { container } = makeConnect();
+
+    connectButton(container)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush(1);
+    // Busy: the button reads "Connecting…" and is disabled.
+    expect(connectButton(container)!.textContent).toContain("Connecting");
+    connectButton(container)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush(1);
+    expect(cfConnect).toHaveBeenCalledTimes(1);
+
+    resolveFlow!({ connected: true });
+    await flush();
+  });
+});
+
+describe("ensureProbe", () => {
+  test("fires the shared capability probe and repaints when it settles", async () => {
+    fetchImpl = async () =>
+      Response.json({ models: [], configured: false, managed: true }, { status: 200 });
+    platform.cfConnect = async () => ({ connected: true });
+    const { container, mc } = makeConnect();
+    expect(container.querySelector(".ai-managed-connect")).toBeNull();
+
+    mc.ensureProbe();
+    await flush();
+
+    // The repaint is the point: the offer must appear without any further user action.
+    expect(fetchCalls).toHaveLength(1);
+    expect(container.querySelector(".ai-managed-connect")).toBeTruthy();
+  });
+});

--- a/packages/studio/tests/ai-models.test.ts
+++ b/packages/studio/tests/ai-models.test.ts
@@ -6,8 +6,10 @@
 import { installMockPlatform } from "./harness";
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
+  ensureProxyProbe,
   fetchAvailableModels,
   getProxyDefaultModel,
+  hasAiCredentials,
   invalidateModelCache,
   isManagedProxy,
   isProxyConfigured,
@@ -22,6 +24,15 @@ const fetchCalls: { url: string; init?: RequestInit | undefined }[] = [];
   fetchCalls.push({ init, url });
   return fetchImpl(url, init);
 };
+
+/** Let the probe's promise chain settle. */
+async function flush(turns = 4) {
+  for (let i = 0; i < turns; i++) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+}
 
 beforeEach(() => {
   globalThis.localStorage.clear();
@@ -121,5 +132,72 @@ describe("proxy state flags", () => {
     invalidateModelCache();
     expect(isProxyConfigured()).toBe(false);
     expect(getProxyDefaultModel()).toBe("");
+  });
+});
+
+describe("hasAiCredentials", () => {
+  test("is true for a stored key OR a backend that holds its own", async () => {
+    expect(hasAiCredentials()).toBe(false);
+
+    globalThis.localStorage.setItem("jx.ai.openaiKey", "sk-stored");
+    expect(hasAiCredentials()).toBe(true);
+
+    // Managed platforms (cloud Workers AI) unlock with no local key at all.
+    globalThis.localStorage.clear();
+    fetchImpl = async () =>
+      Response.json({ models: [], configured: true, managed: true }, { status: 200 });
+    await fetchAvailableModels({ force: true });
+    expect(hasAiCredentials()).toBe(true);
+  });
+});
+
+describe("ensureProxyProbe", () => {
+  test("fetches once for concurrent callers and notifies every listener", async () => {
+    fetchImpl = async () =>
+      Response.json({ models: [], configured: false, managed: true }, { status: 200 });
+    const seen: string[] = [];
+    ensureProxyProbe(() => seen.push("a"));
+    ensureProxyProbe(() => seen.push("b"));
+    ensureProxyProbe(() => seen.push("a")); // Same host re-registering must not double-notify.
+    await flush();
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(seen.toSorted()).toEqual(["a", "a", "b"]);
+    expect(isManagedProxy()).toBe(true);
+  });
+
+  test("swallows probe failure, leaving the gate closed", async () => {
+    fetchImpl = async () => new Response("nope", { status: 500 });
+    let settled = false;
+    ensureProxyProbe(() => {
+      settled = true;
+    });
+    await flush();
+    expect(settled).toBe(true);
+    expect(isManagedProxy()).toBe(false);
+    expect(isProxyConfigured()).toBe(false);
+  });
+
+  test("invalidation re-arms the probe so managed state can be rediscovered", async () => {
+    fetchImpl = async () =>
+      Response.json({ models: [], configured: false, managed: true }, { status: 200 });
+    ensureProxyProbe();
+    await flush();
+    expect(fetchCalls).toHaveLength(1);
+
+    // Already settled: a repeat call is a no-op.
+    ensureProxyProbe();
+    await flush();
+    expect(fetchCalls).toHaveLength(1);
+
+    /* Saving/clearing BYOK credentials invalidates the cache, which clears the managed flag. If the
+       probe stayed settled the gate would never learn managed mode again — the Connect Cloudflare
+       option would vanish until a full page reload. */
+    invalidateModelCache();
+    expect(isManagedProxy()).toBe(false);
+    ensureProxyProbe();
+    await flush();
+    expect(fetchCalls).toHaveLength(2);
+    expect(isManagedProxy()).toBe(true);
   });
 });

--- a/packages/studio/tests/chat-panel.test.ts
+++ b/packages/studio/tests/chat-panel.test.ts
@@ -34,10 +34,13 @@ void mock.module("../src/services/document-assistant", () => ({
   }),
 }));
 
-// Keep the credentials gate deterministic: no managed proxy, no configured proxy, no probe fetch.
+/* Keep the credentials gate deterministic: no managed proxy, no configured proxy, no probe fetch.
+   hasAiCredentials still tracks the stored key, since these tests drive the gate through it. */
 void mock.module("../src/services/ai-models", () => ({
+  ensureProxyProbe: () => {},
   fetchAvailableModels: async () => {},
   getProxyDefaultModel: () => "",
+  hasAiCredentials: () => Boolean(globalThis.localStorage.getItem("jx.ai.openaiKey")),
   invalidateModelCache: () => {},
   isManagedProxy: () => false,
   isProxyConfigured: () => false,

--- a/packages/studio/tests/new-project-agent-tab.test.ts
+++ b/packages/studio/tests/new-project-agent-tab.test.ts
@@ -8,6 +8,7 @@
  */
 import { flush, installMockPlatform, npFillLocation, npName, npPreview, npType } from "./harness";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { invalidateModelCache } from "../src/services/ai-models";
 
 const { closeNewProjectModal, openNewProjectModal } =
   await import("../src/new-project/new-project-modal");
@@ -49,8 +50,16 @@ function switchTab(value: string) {
   tabs.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+/* The credentials gate probes the AI proxy for backend-held credentials. Stub it: the default is an
+   unmanaged, unconfigured backend (BYOK-only), and managed tests override `proxyState`. */
+let proxyState: { configured: boolean; managed: boolean } = { configured: false, managed: false };
+(globalThis as Record<string, unknown>).fetch = async () =>
+  Response.json({ models: [], ...proxyState }, { status: 200 });
+
 beforeEach(() => {
   localStorage.clear();
+  proxyState = { configured: false, managed: false };
+  invalidateModelCache(); // Re-arms the one-shot probe between tests.
 });
 
 afterEach(() => {
@@ -64,6 +73,41 @@ describe("Agent flow", () => {
     switchTab("agent");
     expect(document.querySelector("#layer-modal .new-project-creds")).toBeTruthy();
     expect(footerButtons()).toHaveLength(1); // Cancel only
+  });
+
+  test("offers Connect Cloudflare beside the key form on a managed platform", async () => {
+    /* Regression: the cloud SaaS brokers Workers AI on the user's own account, so a gate that
+       renders only the BYOK form leaves them with no key and no way to get one. */
+    proxyState = { configured: false, managed: true };
+    const { platform } = installMockPlatform();
+    platform.cfConnect = async () => ({ connected: true });
+    void openNewProjectModal();
+    switchTab("agent");
+    await flush();
+
+    const gate = document.querySelector("#layer-modal .new-project-creds");
+    expect(gate?.querySelector(".ai-managed-connect")).toBeTruthy();
+    expect(gate!.textContent).toContain("Connect Cloudflare");
+    // The BYOK form stays — both are real paths.
+    expect(gate!.querySelector(".ai-creds-form")).toBeTruthy();
+    expect(document.querySelector("#layer-modal .new-project-tab-intro")?.textContent).toContain(
+      "Connect Cloudflare, or add an OpenAI-compatible API key",
+    );
+  });
+
+  test("lets a managed platform with AI already connected past the gate without a key", async () => {
+    /* Regression: gating on hasOpenAiKey() alone suppressed the Next button for users whose
+       Cloudflare account was already brokering working AI. */
+    proxyState = { configured: true, managed: true };
+    installMockPlatform();
+    void openNewProjectModal();
+    switchTab("agent");
+    await flush();
+
+    expect(localStorage.getItem("jx.ai.openaiKey")).toBeNull();
+    expect(document.querySelector("#layer-modal .new-project-creds")).toBeNull();
+    expect(promptField()).toBeTruthy();
+    expect(footerButtons().map((b) => b.textContent?.trim())).toContain("Next");
   });
 
   test("shows the prompt once a key is stored and requires it before Next", () => {

--- a/packages/studio/tests/new-project-import-tab.test.ts
+++ b/packages/studio/tests/new-project-import-tab.test.ts
@@ -14,6 +14,7 @@ import {
   npType,
 } from "./harness";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { invalidateModelCache } from "../src/services/ai-models";
 import type { ImportTabCtx } from "../src/new-project/import-tab";
 import type { ImportProgressEvent } from "../src/types";
 
@@ -59,8 +60,10 @@ function inlineError(): string {
 function directCtx(resolveDestination: ImportTabCtx["resolveDestination"]) {
   const counter = { rerenders: 0 };
   const ctx: ImportTabCtx = {
+    aiGateOpen: () => true,
     credsForm: { render: () => "" as never, startEdit: () => {} },
     form: { directory: "site", name: "Site" },
+    managedConnect: { canOffer: () => false, render: () => "" },
     onDone: () => {},
     rerender: () => {
       counter.rerenders += 1;
@@ -130,9 +133,17 @@ function reachParams(url = "https://clone.example/") {
   return promise;
 }
 
+/* The credentials gate probes the AI proxy for backend-held credentials; default it to a plain
+   BYOK-only backend, and let managed/env-keyed tests override. */
+let proxyState: { configured: boolean; managed: boolean } = { configured: false, managed: false };
+(globalThis as Record<string, unknown>).fetch = async () =>
+  Response.json({ models: [], ...proxyState }, { status: 200 });
+
 beforeEach(() => {
   captured = null;
   localStorage.clear();
+  proxyState = { configured: false, managed: false };
+  invalidateModelCache(); // Re-arms the one-shot probe between tests.
 });
 
 afterEach(async () => {
@@ -154,6 +165,20 @@ describe("Import source step", () => {
     expect(document.querySelector("#layer-modal .new-project-creds")).toBeTruthy();
     // Only Cancel in the footer while gated.
     expect(footerButtons()).toHaveLength(1);
+  });
+
+  test("opens the gate for a backend holding its own credentials, with no key stored", async () => {
+    /* Regression: gating on hasOpenAiKey() alone blocked env-keyed dev servers and managed cloud
+       platforms, whose AI already works without anything stored in this browser. */
+    proxyState = { configured: true, managed: false };
+    importPlatform();
+    void openNewProjectModal();
+    switchTab("import");
+    await flush();
+
+    expect(localStorage.getItem("jx.ai.openaiKey")).toBeNull();
+    expect(document.querySelector("#layer-modal .new-project-creds")).toBeNull();
+    expect(footerButtons().map((b) => b.textContent?.trim())).toEqual(["Cancel", "Next"]);
   });
 
   test("shows the URL + crawl options once a key is stored", () => {

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,9 +2,9 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.3.3-draft
+**Version:** 0.3.4-draft
 **Status:** Pending
-**Updated:** 2026-07-29
+**Updated:** 2026-07-31
 **License:** MIT
 
 ---
@@ -86,7 +86,7 @@ The canonical `StudioPlatform` interface is `packages/studio/src/types.ts` — r
 | **Git**                  | `gitStatus`, `gitCommit`, `gitPush`, `gitPull`, `gitDiff`, `gitCheckout`, `gitClone?`, `createPullRequest?`, …                                                                                                                 |
 | **Collab**               | `collab?` (realtime co-editing handle per document)                                                                                                                                                                            |
 | **Data / secrets**       | `dataConnections?`, `dataRows?`, row CRUD, `dataPush?`, `listSecrets?`, `setSecrets?`                                                                                                                                          |
-| **Publish / identity**   | `getUser?`, `getAccountStatus?`, `listRepos?`, `importProject?`, `cfConnection?`, `cfApi?`                                                                                                                                     |
+| **Publish / identity**   | `getUser?`, `getAccountStatus?`, `listRepos?`, `importProject?`, `cfConnection?`, `cfConnect?`, `cfApi?`                                                                                                                       |
 | **Code services / AI**   | `codeService` (§5.3), `resolveClass?`, `aiChatUrl`                                                                                                                                                                             |
 | **Multi-window / shell** | `openProjectInNewWindow?`, `newWindow?`, `setWindowProject?`, `getProjectRoot?`, `getAppInfo?`, backend-persisted settings                                                                                                     |
 
@@ -813,6 +813,7 @@ Ensure desktop app matches dev-mode capabilities:
 
 ## Changelog
 
+- **0.3.4-draft** (2026-07-31) — List the cfConnect? PAL member in the Publish/identity family — it ships in StudioPlatform and backs the hosted Cloudflare OAuth flow, but the table omitted it.
 - **0.3.3-draft** (2026-07-29) — PAL: launcher-only capabilities (updater, windowControls) stay off the StudioPlatform interface; adapter factories infer their return type and assert conformance instead of annotating it away.
 - **0.3.2-draft** (2026-07-29) — The desktop shell routes Studio preview links to the user's default browser via Utils.openExternal (§3.5).
 - **0.3.1-draft** (2026-07-25) — Repo picker gains a repository-access footer: per-installation manage links, install-on-another-account, and Refresh.
@@ -835,4 +836,4 @@ Ensure desktop app matches dev-mode capabilities:
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.3.3-draft_
+_Jx Studio Desktop Architecture Specification v0.3.4-draft_


### PR DESCRIPTION
The 2.0 refactor extracted the BYOK form into ui/ai-credentials-form.ts so the New Project modal could embed it, but left the keyless "Connect Cloudflare" (Workers AI) half behind in ai-panel.ts. The assistant sidebar kept both paths; the New Project Import/Agent tabs — the first and, for a new cloud user, only AI surface — rendered the key form alone. On the cloud SaaS that reads as the Cloudflare enablement feature having been lost.

Those tabs also gated on hasOpenAiKey() rather than proxy state, so they never fired the capability probe (managed mode was never discovered there) and suppressed the Next button outright for users whose Cloudflare account was already brokering working AI. The same predicate locked out env-keyed dev servers (OPENAI_API_KEY), which the sidebar has always honored.

- ui/ai-managed-connect.ts: the CTA as a shared controller — the companion ai-credentials-form.ts always needed. ai-panel consumes it instead of owning a private copy; behavior there is unchanged.
- services/ai-models.ts: owns the one-shot capability probe (shared in-flight fetch, multi-host listeners) and hasAiCredentials() — a local key OR a backend holding its own. invalidateModelCache() now re-arms the probe; it previously cleared the managed/configured flags while keeping the settled promise, so after one BYOK save the Cloudflare option vanished until a full reload.
- new-project-modal.ts / import-tab.ts: both gates use aiGateOpen() and render the Cloudflare option beside the key form, with intro copy that adapts.

Specs & docs: specs/desktop.md §3.1 omitted the cfConnect? PAL member this seam depends on (released 0.3.3 → 0.3.4-draft); docs/studio/ai.md and docs/studio/projects/create.md now document both routes.

Tests: ai-managed-connect.test.ts (offer conditions, connect/abandon/throw, in-flight guard, probe repaint), ai-models.test.ts (probe sharing, failure, re-arm on invalidation, hasAiCredentials), plus managed/configured-proxy regression cases on the Agent and Import gates.