### PR TITLE
fix(compiler): resolve the open issue sweep (#121–#127)

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -16,7 +16,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | ------------------------- | ------------ | ----------- | ---------- |
 | `ai.md`                   | 0.1.4-draft  | Partial     | 2026-08-12 |
 | `collab.md`               | 0.2.2-draft  | Partial     | 2026-08-05 |
-| `compiler.md`             | 0.1.25-draft | Partial     | 2026-07-30 |
+| `compiler.md`             | 0.1.26-draft | Partial     | 2026-08-14 |
 | `desktop.md`              | 0.3.8-draft  | Pending     | 2026-08-13 |
 | `extensions.md`           | 0.3.4-draft  | Partial     | 2026-08-08 |
 | `imports.md`              | 0.1.7-draft  | Partial     | 2026-08-02 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -30,6 +30,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `compiler.md`
 
+- **0.1.26-draft** (2026-08-14) — $switch compiles on dynamic pages (§9.2); branch subtrees hoisted out of $switch and chosen-tagName constructs (§4.8); prerender treats handler-written entries and computeds reading them as runtime-only, and keeps an array any surviving reader still references (§8.1).
 - **0.1.25-draft** (2026-07-30) — Element modules: props.* attribute intake and $props template bindings, one effect registry stopped on disconnect, state.$map published for map handlers; prerender keeps a repeater whose build-time expansion is empty (§4.1, §4.2, §4.4, §4.7, §8.1).
 - **0.1.24-draft** (2026-07-30) — Element modules: $export aliasing, Request auto-fetch on connect with effect teardown, $map bound in map callbacks, tagName-based output naming; prerender leaves runtime-only reads unresolved (§4.1, §4.7, §8.1).
 - **0.1.23-draft** (2026-07-24) — §1 Overview: condition the generated Hono worker on build.adapter (per-page _server.js without one) and scope the static-build failure to active data/auth mounts; §6.3 document compileSiteServer's mounts/connectors parameters and extension mount emission.

--- a/docs/framework/build.md
+++ b/docs/framework/build.md
@@ -100,6 +100,31 @@ Across all three tiers the emitter indents nested children so the generated HTML
 
 Style never ships as JavaScript. During compilation, every static `style` definition — the project-level `style` from `project.json`, the layout's, the page's, and each node's — is extracted into a single `<style>` block in the page `<head>`, with `$media` breakpoint names expanded to real media queries. Components additionally emit a `dist/components/<tag>.css` sidecar, and styles found in component slot content are collected into the page's style block. See [Styling](/docs/framework/concepts/styling) for the authoring model.
 
+## What prerendering will and won't bake
+
+Every page is prerendered: the compiler evaluates `${state.…}` against the build-time scope and
+writes the result into the HTML. That is what makes a page's content visible to crawlers and to
+readers with no JavaScript. But baking a template **replaces** it — the binding is gone, not stale —
+so the compiler bakes only what it can prove will never change:
+
+- **A constant bakes.** `{"tagline": {"type": "string", "default": "Ship JSON"}}` read as
+  `${state.tagline}` becomes text in the HTML, with no JavaScript behind it.
+- **An entry a handler writes to stays bound.** If any handler in the document assigns to
+  `state.saved` — `=`, `+=`, `++`, or an in-place `push`/`splice`/`sort` — every template reading it
+  keeps its binding, even though the entry has a perfectly ordinary build-time value.
+- **A computed over changing state stays bound.** A `$prototype: "Function"` whose body returns is
+  evaluated at build time, so a computed reading a written entry — or reading a `$src` value or a
+  `Request` — is left unresolved too, however many steps removed.
+- **An array a computed still reads stays in client state.** Expanding an array into a list at build
+  time no longer drops it: if a computed or a template still reads `state.rows` at runtime, the array
+  ships with the island. Mark it `timing: "compiler"` to say the data really is build-time only.
+
+:::doc-note
+One case the compiler cannot see: a handler loaded through `$src` lives in a JavaScript file the
+build does not open, so a state entry written **only** from there is still treated as a constant and
+baked. Declare a writer for it in the document if a binding over it goes dead.
+:::
+
 ## Why is my page shipping JavaScript?
 
 Work the static-detection list backwards:

--- a/docs/framework/concepts/lists.md
+++ b/docs/framework/concepts/lists.md
@@ -125,6 +125,27 @@ This works on the map body and on any descendant of it. A nested list shadows th
 }
 ```
 
+## Setting a property on each row
+
+Properties that live on the DOM element rather than in markup — `value`, `checked`, `selected`,
+`disabled` — go directly on the map body, the same as anywhere else. They may interpolate `$map`:
+
+```json
+{
+  "$prototype": "Array",
+  "items": { "$ref": "#/state/rows" },
+  "map": {
+    "tagName": "option",
+    "value": "${$map.item.id}",
+    "textContent": "${$map.item.label}"
+  }
+}
+```
+
+Each `<option>` gets its row's `id` as its value, so a `change` handler reads the key rather than the
+label shown on screen. Put it in `attributes` instead and you get an HTML attribute, which for
+`value` sets only the _default_ — the two diverge as soon as the user interacts.
+
 ## Filtering and sorting
 
 `filter` and `sort` reference [functions](/docs/framework/concepts/functions) declared in `state`. The filter function receives each item and returns true to keep it; the sort function receives two items and returns a number, like a standard comparator:

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -130,7 +130,7 @@ export async function compile(sourcePath: string | JxDocument, opts: CompileOpti
       path: `${tagName}.js`,
       tagName,
     };
-    const styleBlock = compileStyles(raw, raw.$media ?? {});
+    const styleBlock = compileStyles(raw, raw.$media ?? {}, projectStyle);
 
     const html = `<!DOCTYPE html>
 <html lang="en">

--- a/packages/compiler/src/shared.ts
+++ b/packages/compiler/src/shared.ts
@@ -425,6 +425,62 @@ export function createCompileContext(
 }
 
 /**
+ * `state.x = …`, `state.x += …`, `state.x++` — every form a string handler body can use to write a
+ * state entry. `===`/`!==`/`<=`/`>=` are excluded by the `(?!=)` guard and by the operator set.
+ */
+const STATE_ASSIGNMENT_RE =
+  /\bstate\.([A-Za-z_$][\w$]*)\s*(?:\+\+|--|(?:\*\*|\|\||&&|\?\?|<<|>>>|>>|[-+*/%&|^])?=(?!=))/g;
+
+/** `state.list.push(…)` and friends mutate in place without ever assigning to the entry. */
+const STATE_MUTATING_METHOD_RE =
+  /\bstate\.([A-Za-z_$][\w$]*)\s*\.\s*(?:push|pop|shift|unshift|splice|sort|reverse|fill|copyWithin)\s*\(/g;
+
+/**
+ * Collect every state key a handler writes to, across all the forms a body can take: a string body,
+ * a structured body (spec §20), and an `$expression` node with a mutating operator.
+ *
+ * Used to keep prerender from baking a binding over an entry that changes after hydration. A plain
+ * `{ "type": "string" }` entry holds a perfectly ordinary build-time value, so nothing else
+ * distinguishes it from a constant — but if a handler assigns to it, interpolating it at build time
+ * replaces the template in the emitted output and the element is dead for the life of the page.
+ *
+ * @param {unknown} node
+ * @param {Set<string>} into
+ */
+function collectAssignedStateKeys(node: unknown, into: Set<string>) {
+  if (typeof node === "string") {
+    for (const m of node.matchAll(STATE_ASSIGNMENT_RE)) {
+      into.add(m[1] as string);
+    }
+    for (const m of node.matchAll(STATE_MUTATING_METHOD_RE)) {
+      into.add(m[1] as string);
+    }
+    return;
+  }
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const entry of node) {
+      collectAssignedStateKeys(entry, into);
+    }
+    return;
+  }
+  const rec = node as Record<string, unknown>;
+  // A mutating expression names its destination as `target: { $ref: "#/state/x" }`.
+  const op = rec.operator;
+  if (typeof op === "string" && isMutating(op)) {
+    const target = rec.target as { $ref?: string } | undefined;
+    if (target && typeof target.$ref === "string" && target.$ref.startsWith("#/state/")) {
+      into.add(target.$ref.slice("#/state/".length).split("/")[0] as string);
+    }
+  }
+  for (const value of Object.values(rec)) {
+    collectAssignedStateKeys(value, into);
+  }
+}
+
+/**
  * @param {Record<string, JxStateDefinition>} [defs]
  * @param {Record<string, unknown> | null} [parentScope]
  * @returns {Record<string, unknown>}
@@ -447,6 +503,26 @@ export function buildInitialScope(
     writable: true,
   });
 
+  // Pass 0: every entry some handler in this document writes to is mutable, so prerender must not
+  // Bake a binding over it. Narrow on purpose — an entry nothing ever writes stays bakeable, so
+  // Prerendered content is preserved for SEO. A `$src` handler's assignments live in a JS file this
+  // Builder cannot open, so a write that only happens there is still missed (issue #125).
+  const assigned = new Set<string>();
+  for (const def of Object.values(defs)) {
+    if (def && typeof def === "object" && (isFunctionDef(def) || isExpressionDef(def))) {
+      collectAssignedStateKeys(
+        (def as { body?: unknown; $expression?: unknown }).body ??
+          (def as { $expression?: unknown }).$expression,
+        assigned,
+      );
+    }
+  }
+  for (const key of assigned) {
+    if (key in defs) {
+      runtimeOnly.add(key);
+    }
+  }
+
   for (const [key, def] of Object.entries(defs)) {
     if (typeof def !== "object" || def === null || Array.isArray(def)) {
       setOwnScopeValue(scope, key, cloneValue(def));
@@ -465,6 +541,10 @@ export function buildInitialScope(
   // Template-string entries are deferred to a third pass: whether one is resolvable depends on the
   // Runtime-only marks the loop below adds, and key order must not decide the answer.
   const templateDefs: [string, string][] = [];
+  // Computed (`bodyReturnsValue`) entries are deferred for the same reason. A computed is stored in
+  // The scope as its already-evaluated *result*, so a template reading it sees an ordinary string
+  // And prerender bakes it — destroying the binding rather than merely staling it (issue #124).
+  const computedBodies: [string, string][] = [];
 
   for (const [key, def] of Object.entries(defs)) {
     if (typeof def === "string" && isTemplateString(def)) {
@@ -523,6 +603,7 @@ export function buildInitialScope(
           fn(...params.map((name) => (name === "state" ? state : event)));
         if (bodyReturnsValue(body)) {
           defineLazyScopeValue(scope, key, () => invoke(scope));
+          computedBodies.push([key, body]);
         } else {
           setOwnScopeValue(scope, key, invoke);
         }
@@ -547,13 +628,23 @@ export function buildInitialScope(
     }
   }
 
-  for (const [key, template] of templateDefs) {
-    // A state entry that interpolates a runtime-only key cannot resolve until hydration either, so
-    // It is runtime-only in turn. Without this, prerender would bake the failed evaluation (`null`)
-    // Into every template that reads *this* entry, one step removed from the original.
-    if (readsRuntimeOnlyState(template, scope)) {
-      runtimeOnly.add(key);
+  // A state entry that reads a runtime-only key cannot resolve until hydration either, so it is
+  // Runtime-only in turn. Without this, prerender would bake the failed evaluation (`null`) into
+  // Every template that reads *this* entry, one step removed from the original. Iterated to a
+  // Fixpoint because marking one entry can qualify another, in either direction, and declaration
+  // Order must not decide the answer.
+  let marked = true;
+  while (marked) {
+    marked = false;
+    for (const [key, source] of [...computedBodies, ...templateDefs]) {
+      if (!runtimeOnly.has(key) && readsRuntimeOnlyState(source, scope)) {
+        runtimeOnly.add(key);
+        marked = true;
+      }
     }
+  }
+
+  for (const [key, template] of templateDefs) {
     defineLazyScopeValue(scope, key, () => evaluateStaticTemplate(template, scope));
   }
 
@@ -669,7 +760,15 @@ function readsRuntimeOnlyState(str: string, scope: Record<string, unknown>) {
     if (runtimeOnly instanceof Set && runtimeOnly.has(key)) {
       return true;
     }
-    if (typeof scope[key] === "function") {
+    // Reading the key can run a computed's getter, which is free to throw on partial build-time
+    // Data. A throw says nothing about whether the entry is runtime-only, so it is not a mark.
+    let value: unknown;
+    try {
+      value = scope[key];
+    } catch {
+      continue;
+    }
+    if (typeof value === "function") {
       return true;
     }
   }

--- a/packages/compiler/src/site/site-build.ts
+++ b/packages/compiler/src/site/site-build.ts
@@ -761,6 +761,12 @@ async function compilePage(
   // Also strip resolved content arrays (from ContentCollection) that have been
   // Baked into unrolled map templates.
   if (layoutDoc.state) {
+    // An array is only strippable if nothing that survives the build still reads it. A map
+    // Expansion is one consumer, not the only one: the same array is routinely also read by a
+    // Computed at runtime, and dropping it there left `state.rows` undefined in the browser while
+    // The build reported success (issue #122). `timing: "compiler"` is excluded from this rescue —
+    // That is the author declaring the entry build-time-only, so it is stripped as before.
+    const strippable = new Set<string>();
     for (const [key, def] of Object.entries(layoutDoc.state)) {
       if (key === "$site" || key === "$page") {
         continue;
@@ -773,8 +779,27 @@ async function compilePage(
       ) {
         delete layoutDoc.state[key];
       } else if (Array.isArray(def)) {
-        delete layoutDoc.state[key];
+        strippable.add(key);
       }
+    }
+    // Iterated to a fixpoint: rescuing one array can reveal a read of another from its own def.
+    let rescued = true;
+    while (rescued) {
+      rescued = false;
+      const surviving = { ...layoutDoc.state } as Record<string, unknown>;
+      for (const key of strippable) {
+        delete surviving[key];
+      }
+      const haystack = JSON.stringify({ children: layoutDoc.children, state: surviving });
+      for (const key of strippable) {
+        if (referencesStateKey(haystack, key)) {
+          strippable.delete(key);
+          rescued = true;
+        }
+      }
+    }
+    for (const key of strippable) {
+      delete layoutDoc.state[key];
     }
   }
 
@@ -1227,6 +1252,19 @@ function resolveDocTemplates(node: JxElement | string, scope: Record<string, unk
       i += 1;
     }
   }
+}
+
+/**
+ * Whether a serialized document fragment still reads a given state key — as a `${state.key}`
+ * template, a bare `state.key` inside a handler or computed body, or a `#/state/key` $ref.
+ *
+ * @param {string} haystack - JSON-serialized document fragment
+ * @param {string} key
+ * @returns {boolean}
+ */
+function referencesStateKey(haystack: string, key: string): boolean {
+  const escaped = key.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  return new RegExp(String.raw`\bstate\.${escaped}\b|#/state/${escaped}(?=["/])`).test(haystack);
 }
 
 /**

--- a/packages/compiler/src/targets/compile-client.ts
+++ b/packages/compiler/src/targets/compile-client.ts
@@ -340,12 +340,12 @@ function buildClientNode(
     raw?.$media ?? context.media,
   );
 
-  /* REFUSED, LOUDLY. This target has no branch construct — it also drops `$switch` on the floor
-     today, compiling a switch node to `<div><div></div></div>` with no binding at all. Emitting a
-     silently wrong element here would be a second instance of the class the tagName pattern was
-     added to end, so a dynamic page that needs a chosen tag is told to put the element in a
-     component (which compiles through `compile-element`, where the construct is implemented)
-     rather than shipping markup that is quietly missing a branch. */
+  /* REFUSED, LOUDLY. A chosen tag has no implementation in this target: the element's identity is
+     fixed in the prerendered markup, so there is nothing here to re-choose at hydration the way the
+     `$switch` binding below re-chooses a subtree. Emitting a silently wrong element would be an
+     instance of the class the tagName pattern was added to end, so a dynamic page that needs a
+     chosen tag is told to put the element in a component (which compiles through `compile-element`,
+     where the construct is implemented) rather than shipping markup with the wrong tag. */
   if (isTagExpression(def.tagName)) {
     throw new Error(
       "A tag chosen at creation is not supported on a dynamic page yet (candidates: " +
@@ -499,6 +499,33 @@ function buildClientNode(
   // Inner content
   let inner = "";
   const source = raw ?? def;
+  if (source.$switch) {
+    // ─── $switch → lit-html render binding ───
+    // Without this branch the node fell through to the generic element path, which emitted a
+    // Container and then looked for `children` to recurse into — `cases` is not `children`, so the
+    // Subtree was never visited and the page shipped with the content missing, no error (#127).
+    // The container is emitted empty for the same reason the mapped-array branch below is: lit's
+    // `render` appends into the container rather than replacing its existing children, so any
+    // Prerendered branch would survive alongside the rendered one.
+    counter.needsLit = true;
+    const swKey = `_sw${counter.sw}`;
+    counter.sw += 1;
+    const discriminant = isRefObject(source.$switch)
+      ? `state.${refToBindingKey((source.$switch as { $ref: string }).$ref)}`
+      : `\`${String(source.$switch)}\``;
+    const cases = (source.cases ?? {}) as Record<string, JxMutableNode>;
+    const caseEntries = Object.entries(cases)
+      // An external `$ref` case cannot be fetched at compile time, exactly as in the static target.
+      .filter(([, caseDef]) => caseDef && !isRefObject(caseDef))
+      .map(
+        ([key, caseDef]) =>
+          `${JSON.stringify(key)}: html\`${emitChildLit(caseDef, nextContext.preformatted)}\``,
+      );
+    bindings.set(swKey, `() => ({${caseEntries.join(", ")}})[String(${discriminant})] ?? html\`\``);
+    bindAttrs.push(`:render="${swKey}"`);
+    const bindAttrStrSwitch = ` ${bindAttrs.join(" ")}`;
+    return `<${tag}${staticAttrs} data-bind${bindAttrStrSwitch}></${tag}>`;
+  }
   if (source.textContent !== undefined && !needsBind) {
     const value = resolveStaticValue(source.textContent, nextContext.scope);
     inner = value == null ? "" : escapeHtml(String(value));

--- a/packages/compiler/src/targets/compile-element.ts
+++ b/packages/compiler/src/targets/compile-element.ts
@@ -556,12 +556,19 @@ export function emitElementModule(
     }
   }
 
+  // Subtrees a branching construct would otherwise repeat are lifted into `const _cN = html`…``
+  // Declarations emitted inside `template()`, above the `return` — inside it, so they are rebuilt
+  // Per render and read the same `s` the template does.
+  const hoistScope = createHoistScope();
+  const templateBody = emitLitChildren(doc.children, doc.style, "      ", false, false, hoistScope);
+
   lines.push(
     // Template method
     "  template() {",
     "    const s = this.state;",
+    ...hoistScope.decls,
     "    return html`",
-    emitLitChildren(doc.children, doc.style, "      "),
+    templateBody,
     "    `;",
     "  }",
     "",
@@ -690,6 +697,46 @@ export function emitElementModule(
 }
 
 /**
+ * Declarations that must be emitted _beside_ a lit template rather than inside it.
+ *
+ * `emitLitNode` writes one template string, so a construct with N branches recursed once per branch
+ * and wrote the whole subtree N times into the bundle — the authored document contains it once. A
+ * scope collects `const _cN = html`…`;` declarations for subtrees that would otherwise repeat, and
+ * the branches reference those instead.
+ *
+ * One scope per template body: `template()` has its own, and each map callback gets a fresh one
+ * because its declarations close over that callback's `item`/`index`.
+ */
+interface HoistScope {
+  decls: string[];
+  byText: Map<string, string>;
+}
+
+function createHoistScope(): HoistScope {
+  return { byText: new Map(), decls: [] };
+}
+
+/**
+ * Hoist an emitted subtree into a `const` and return the `${_cN}` expression referencing it.
+ * Identical subtrees collapse onto a single declaration.
+ *
+ * @param {HoistScope} scope
+ * @param {string} text
+ * @returns {string}
+ */
+function hoistSubtree(scope: HoistScope, text: string): string {
+  const existing = scope.byText.get(text);
+  if (existing) {
+    return existing;
+  }
+  const name = `_c${scope.decls.length}`;
+  scope.decls.push(`    const ${name} = html\`\n${text}\n    \`;`);
+  const ref = `\${${name}}`;
+  scope.byText.set(text, ref);
+  return ref;
+}
+
+/**
  * Convert Jx children to lit-html template content.
  *
  * @param {JxMutableNode["children"]} children
@@ -704,6 +751,7 @@ function emitLitChildren(
   indent: string,
   preformatted = false,
   inMap = false,
+  scope: HoistScope | null = null,
 ) {
   if (!children) {
     return "";
@@ -723,7 +771,7 @@ function emitLitChildren(
     .map((child: JxMutableNode | string) =>
       isMappedArray(child)
         ? emitMappedArray(child, indent)
-        : emitLitNode(child, preformatted ? "" : indent, preformatted, inMap),
+        : emitLitNode(child, preformatted ? "" : indent, preformatted, inMap, scope),
     )
     .join(preformatted ? "" : "\n");
 }
@@ -739,6 +787,9 @@ function emitLitNode(
   indent: string,
   preformatted = false,
   inMap = false,
+  scope: HoistScope | null = null,
+  /** Pre-emitted inner content, so a branching construct can share one subtree across branches. */
+  innerOverride: string | null = null,
 ): string {
   // String children are text nodes
   if (typeof def === "string") {
@@ -760,11 +811,8 @@ function emitLitNode(
      HTML-injection primitive with an unbounded template cache, deliberately avoided in this repo.
 
      The candidates are literal `TagName`s by schema, so this terminates and every branch is a legal
-     element. The subtree is emitted once per candidate in the BUNDLE; it is written once in the
-     DOCUMENT, which is the thing that was wrong. Hoisting the shared subtree into a preamble const
-     would fix the bundle too, and would shrink every existing `$switch` while it was at it —
-     tracked separately, because it is a refactor of this function's return shape rather than part
-     of this feature. */
+     element. The subtree is written once in the DOCUMENT, and — since the hoist scope below lifts it
+     into a single `const` the branches share — once in the BUNDLE too. */
   if (isTagExpression(def.tagName)) {
     const expression = def.tagName.$expression;
     // The same two shapes `$switch` accepts: a pointer, or an expression node.
@@ -781,9 +829,21 @@ function emitLitNode(
             [false, expression.initial],
           ]
         : [...Object.entries(expression.cases), ["__default__", expression.default]];
+    // The inner content is identical across candidates — only the tag differs — so it is emitted
+    // Once and every branch references it. Skipped when the candidates disagree about being
+    // Preformatted, because `white-space` decides how the subtree itself is indented.
+    const candidateTags = branches.map(([, candidate]) => String(candidate));
+    const sharedPre = candidateTags.map((t) => preformatted || PREFORMATTED_TAGS.has(t));
+    let innerRef: string | null = null;
+    if (scope && sharedPre.every((p) => p === sharedPre[0])) {
+      const sharedInner = emitNodeInner(def, `${indent}  `, sharedPre[0] === true, inMap, scope);
+      if (sharedInner.trim() !== "") {
+        innerRef = hoistSubtree(scope, sharedInner);
+      }
+    }
     const rendered: [string | boolean | undefined, string][] = branches.map(([key, candidate]) => {
       const asLiteral = { ...def, tagName: candidate as string };
-      return [key, emitLitNode(asLiteral, `${indent}  `, preformatted, inMap)];
+      return [key, emitLitNode(asLiteral, `${indent}  `, preformatted, inMap, scope, innerRef)];
     });
     if (expression.operator === "?:") {
       const [, yes] = rendered[0]!;
@@ -855,6 +915,12 @@ ${no}
       parts.push(`.${key}="\${${refToExpr((val as JxMutableNode).$ref as string)}}"`);
     } else if (typeof val === "string" && val.includes("${")) {
       parts.push(`.${key}="${toLitExpr(val)}"`);
+    } else {
+      // A literal IDL value (`value: "a"`, `checked: true`) is still a property the author asked
+      // For. Without this branch it was dropped outright — including every `${…}` a build-time map
+      // Expansion had already resolved to a constant, which is how an unrolled `<option>` lost its
+      // Value and fell back to using its own label as its key.
+      parts.push(`.${key}="\${${JSON.stringify(val)}}"`);
     }
   }
 
@@ -914,34 +980,70 @@ ${no}
     return `${indent}<${tag}${attrsStr}\n${indent}>`;
   }
 
-  let inner = "";
-  if (def.$switch) {
-    const switchRef = isRef(def.$switch) ? def.$switch.$ref : (def.$switch as string);
-    const switchExpr = refToExpr(switchRef);
-    const cases = (def.cases ?? {}) as Record<string, JxMutableNode>;
-    const caseEntries: string[] = [];
-    for (const [key, caseDef] of Object.entries(cases)) {
-      if (!caseDef || isRef(caseDef)) {
-        continue;
-      }
-      const renderedCase = emitLitNode(caseDef, `${indent}  `, false, inMap);
-      caseEntries.push(`  ${JSON.stringify(key)}: html\`\n${renderedCase}\n  \``);
-    }
-    inner = `\${{\n${caseEntries.join(",\n")}\n}[${switchExpr}]}`;
-  } else if (def.textContent !== undefined) {
-    inner = toLitTextContent(def.textContent);
-  } else if (def.innerHTML !== undefined) {
-    inner = def.innerHTML;
-  } else if (def.children) {
-    inner = inPre
-      ? emitLitChildren(def.children, def.style, "", true, inMap)
-      : `\n${emitLitChildren(def.children, def.style, `${indent}  `, false, inMap)}\n${indent}`;
-  }
+  const inner = innerOverride ?? emitNodeInner(def, indent, inPre, inMap, scope);
 
   // Inside a <pre>, the newline before `>` would land in the element's own text.
   return inPre
     ? `<${tag}${attrsStr}>${inner}</${tag}>`
     : `${indent}<${tag}${attrsStr}\n${indent}>${inner}</${tag}>`;
+}
+
+/**
+ * Emit an element's inner content — the `$switch` lookup, text, raw HTML, or children.
+ *
+ * Split out of `emitLitNode` so a chosen `tagName` can emit it once and share it across candidates
+ * instead of recursing into the same subtree per branch.
+ *
+ * @param {JxMutableNode} def
+ * @param {string} indent
+ * @param {boolean} inPre
+ * @param {boolean} inMap
+ * @param {HoistScope | null} scope
+ * @returns {string}
+ */
+function emitNodeInner(
+  def: JxMutableNode,
+  indent: string,
+  inPre: boolean,
+  inMap: boolean,
+  scope: HoistScope | null,
+): string {
+  if (def.$switch) {
+    const switchRef = isRef(def.$switch) ? def.$switch.$ref : (def.$switch as string);
+    const switchExpr = refToExpr(switchRef);
+    const cases = (def.cases ?? {}) as Record<string, JxMutableNode>;
+    const rendered: [string, string][] = [];
+    for (const [key, caseDef] of Object.entries(cases)) {
+      if (!caseDef || isRef(caseDef)) {
+        continue;
+      }
+      rendered.push([key, emitLitNode(caseDef, `${indent}  `, false, inMap, scope)]);
+    }
+    // Cases that emit byte-identical subtrees share one hoisted `const` rather than repeating it
+    // Once per case — the authored document names the subtree once (#126).
+    const repeated = new Set(
+      rendered
+        .map(([, text]) => text)
+        .filter((text, i, all) => all.indexOf(text) !== i && text.trim() !== ""),
+    );
+    const caseEntries = rendered.map(([key, text]) => {
+      const body = scope && repeated.has(text) ? hoistSubtree(scope, text) : text;
+      return `  ${JSON.stringify(key)}: html\`\n${body}\n  \``;
+    });
+    return `\${{\n${caseEntries.join(",\n")}\n}[${switchExpr}]}`;
+  }
+  if (def.textContent !== undefined) {
+    return toLitTextContent(def.textContent);
+  }
+  if (def.innerHTML !== undefined) {
+    return def.innerHTML;
+  }
+  if (def.children) {
+    return inPre
+      ? emitLitChildren(def.children, def.style, "", true, inMap, scope)
+      : `\n${emitLitChildren(def.children, def.style, `${indent}  `, false, inMap, scope)}\n${indent}`;
+  }
+  return "";
 }
 
 /**
@@ -981,6 +1083,36 @@ function emitMappedArray(arrayDef: JxMappedArray, indent: string) {
     parts.push(`class="${toLitExpr(String(mapDef.className))}"`);
   }
 
+  // IDL properties (`value`, `checked`, `selected`, …) go straight on the element, exactly as they
+  // Do outside a map (emitLitNode above). Without this loop the map body silently dropped them, so
+  // An `<option value="${$map.item.v}">` emitted no value at all and every option fell back to its
+  // Own label — a change handler then received a display string instead of the key.
+  for (const [key, val] of Object.entries(mapDef)) {
+    if (
+      RESERVED_KEYS.has(key) ||
+      key.startsWith("$") ||
+      key.startsWith("on") ||
+      key === "tagName" ||
+      key === "id" ||
+      key === "className" ||
+      key === "style" ||
+      key === "children" ||
+      key === "textContent" ||
+      key === "innerHTML" ||
+      key === "attributes"
+    ) {
+      continue;
+    }
+
+    if (val && typeof val === "object" && (val as JxMutableNode).$ref) {
+      parts.push(`.${key}="\${${mapRefToExpr((val as JxMutableNode).$ref as string)}}"`);
+    } else if (typeof val === "string" && val.includes("${")) {
+      parts.push(`.${key}="${toLitExpr(val)}"`);
+    } else {
+      parts.push(`.${key}="\${${JSON.stringify(val)}}"`);
+    }
+  }
+
   if (mapDef.$props) {
     for (const [key, val] of Object.entries(mapDef.$props)) {
       if (isRef(val)) {
@@ -1018,11 +1150,14 @@ function emitMappedArray(arrayDef: JxMappedArray, indent: string) {
 
   const attrsStr = parts.length > 0 ? `\n${indent}    ${parts.join(`\n${indent}    `)}` : "";
 
+  // The map body gets its own hoist scope: a subtree lifted out of a branch here closes over this
+  // Callback's `item`/`index`, so its declaration belongs inside the callback, not in `template()`.
+  const mapScope = createHoistScope();
   let inner = "";
   if (mapDef.textContent !== undefined) {
     inner = toLitTextContent(mapDef.textContent);
   } else if (mapDef.children) {
-    inner = `\n${emitLitChildren(mapDef.children, null, `${indent}      `, false, true)}\n${indent}    `;
+    inner = `\n${emitLitChildren(mapDef.children, null, `${indent}      `, false, true, mapScope)}\n${indent}    `;
   }
 
   const body = `html\`\n${indent}  <${tag}${attrsStr}\n${indent}  >${inner}</${tag}>\n${indent}\``;
@@ -1035,8 +1170,11 @@ function emitMappedArray(arrayDef: JxMappedArray, indent: string) {
   // `$map["item"]` — and nests correctly, since an inner map shadows the outer binding exactly as
   // The interpreter's child scope does. Emitted only when referenced, so output is otherwise
   // Unchanged.
-  const callback = body.includes("$map")
-    ? `(item, index) => { const $map = { item, index }; return ${body}; }`
+  const prelude =
+    (body.includes("$map") ? `const $map = { item, index }; ` : "") +
+    mapScope.decls.map((d) => `${d.trim()} `).join("");
+  const callback = prelude
+    ? `(item, index) => { ${prelude}return ${body}; }`
     : `(item, index) => ${body}`;
 
   return `${indent}\${${itemsExpr}.map(${callback})}`;

--- a/packages/compiler/tests/branch-subtree-hoisting.test.ts
+++ b/packages/compiler/tests/branch-subtree-hoisting.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Branch-subtree-hoisting.test.ts — shared subtrees are hoisted out of branching constructs (#126).
+ *
+ * `emitLitNode` returns one template string, so a construct with N branches recursed once per
+ * branch and wrote the whole subtree N times into the bundle — the authored document contains it
+ * once. The output was always correct, which is why this sat unnoticed since `$switch` was
+ * implemented: it is invisible except in bundle size.
+ *
+ * The assertions are on the COUNT, not on the output still rendering: the duplicating emitter
+ * passed every render-level assertion, which is why the issue was measured rather than noticed. The
+ * last block executes the emitted module in a DOM, because hoisting moves a subtree into a `const`
+ * inside `template()` and that is a change to lit semantics, not just to bytes.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Window } from "happy-dom";
+import { emitElementModule } from "../src/targets/compile-element";
+import type { JxDocument } from "@jxsuite/schema/types";
+
+const emit = (doc: unknown, name = "XProbe") => emitElementModule(doc as JxDocument, name, []);
+
+/** Two children, so the shared subtree is big enough for duplication to matter. */
+const SUBTREE = [
+  { className: "label", tagName: "span", textContent: "${state.label}" },
+  { tagName: "p", textContent: "Body copy." },
+];
+
+const chosenTag = (candidates: [string, string]) => ({
+  children: [
+    {
+      children: SUBTREE,
+      tagName: {
+        $expression: {
+          initial: candidates[1],
+          operator: "?:",
+          target: { $ref: "#/state/on" },
+          value: candidates[0],
+        },
+      },
+    },
+  ],
+  state: { label: { default: "L", type: "string" }, on: { default: false, type: "boolean" } },
+  tagName: "x-tag",
+});
+
+const switchDoc = {
+  children: [
+    {
+      $switch: { $ref: "#/state/mode" },
+      cases: {
+        a: { children: SUBTREE, tagName: "div" },
+        b: { children: SUBTREE, tagName: "div" },
+        c: { children: SUBTREE, tagName: "div" },
+      },
+      tagName: "div",
+    },
+  ],
+  state: { label: { default: "L", type: "string" }, mode: { default: "a", type: "string" } },
+  tagName: "x-switch",
+};
+
+describe("a chosen tagName", () => {
+  test("writes the shared subtree once, not once per candidate", () => {
+    const out = emit(chosenTag(["a", "div"]));
+
+    expect(out.split("<span").length - 1).toBe(1);
+    expect(out.split("${_c0}").length - 1).toBe(2);
+  });
+
+  test("declares the const inside template(), above the return", () => {
+    // It has to be rebuilt per render and read the same `s` the template does — a module-scope
+    // Const would capture one render's values forever.
+    const out = emit(chosenTag(["a", "div"]));
+
+    expect(out.indexOf("const s = this.state")).toBeLessThan(out.indexOf("const _c0"));
+    expect(out.indexOf("const _c0")).toBeLessThan(out.indexOf("return html`"));
+  });
+
+  test("keeps both branches' tags", () => {
+    const out = emit(chosenTag(["a", "div"]));
+
+    expect(out).toContain("<a");
+    expect(out).toContain("<div");
+  });
+
+  test("does not hoist when the candidates disagree about being preformatted", () => {
+    // `white-space` decides how the subtree itself is indented, so `pre` and `div` cannot share one
+    // Emitted copy.
+    const out = emit(chosenTag(["pre", "div"]));
+
+    expect(out).not.toContain("const _c0");
+    expect(out.split("<span").length - 1).toBe(2);
+  });
+});
+
+describe("$switch", () => {
+  test("collapses byte-identical cases onto one const", () => {
+    const out = emit(switchDoc);
+
+    expect(out.split("<span").length - 1).toBe(1);
+    expect(out.split("${_c0}").length - 1).toBe(3);
+  });
+
+  test("leaves distinct cases inline", () => {
+    // Hoisting a case that appears once would add the `const` wrapper and save nothing.
+    const out = emit({
+      ...switchDoc,
+      children: [
+        {
+          ...switchDoc.children[0],
+          cases: {
+            a: { tagName: "p", textContent: "ONE" },
+            b: { tagName: "p", textContent: "TWO" },
+          },
+        },
+      ],
+    });
+
+    expect(out).not.toContain("const _c0");
+    expect(out).toContain("ONE");
+    expect(out).toContain("TWO");
+  });
+});
+
+describe("inside a map callback", () => {
+  test("declares the const in the callback, not in template()", () => {
+    // A subtree hoisted out of a branch in a map body closes over that callback's item/index, so
+    // Lifting it to template() scope would emit a reference to an undefined binding.
+    const out = emit({
+      children: [
+        {
+          $prototype: "Array",
+          items: { $ref: "#/state/rows" },
+          map: {
+            children: [
+              {
+                $switch: { $ref: "#/state/mode" },
+                cases: {
+                  a: { tagName: "b", textContent: "${$map.item.name}" },
+                  b: { tagName: "b", textContent: "${$map.item.name}" },
+                },
+                tagName: "div",
+              },
+            ],
+            tagName: "li",
+          },
+        },
+      ],
+      state: { mode: { default: "a", type: "string" }, rows: { default: [], type: "array" } },
+      tagName: "x-map",
+    });
+
+    const callbackStart = out.indexOf("(item, index) =>");
+    expect(callbackStart).toBeGreaterThan(-1);
+    expect(out.indexOf("const _c0")).toBeGreaterThan(callbackStart);
+  });
+});
+
+// ── The hoisted module actually renders ──────────────────────────────────────
+
+const TMP = resolve(import.meta.dir, "__test-hoist-render__");
+let win: Window;
+let host: Element;
+
+beforeAll(async () => {
+  rmSync(TMP, { force: true, recursive: true });
+  mkdirSync(TMP, { recursive: true });
+  writeFileSync(resolve(TMP, "el.js"), emit(chosenTag(["a", "div"]), "XHoist"), "utf8");
+
+  win = new Window({ url: "https://example.test" });
+  const globals = globalThis as Record<string, unknown>;
+  const source = win as unknown as Record<string, unknown>;
+  for (const key of [
+    "window",
+    "document",
+    "HTMLElement",
+    "customElements",
+    "Node",
+    "Element",
+    "Event",
+    "CustomEvent",
+  ]) {
+    globals[key] = source[key];
+  }
+
+  await import(resolve(TMP, "el.js"));
+  win.document.body.innerHTML = "<x-tag></x-tag>";
+  host = win.document.querySelector("x-tag") as unknown as Element;
+  await new Promise((r) => {
+    setTimeout(r, 20);
+  });
+});
+
+afterAll(() => {
+  rmSync(TMP, { force: true, recursive: true });
+});
+
+describe("hoisted branch — runtime behaviour", () => {
+  test("renders the shared subtree through the hoisted const", () => {
+    expect(host.querySelector("span")?.textContent).toBe("L");
+    expect(host.querySelector("p")?.textContent).toBe("Body copy.");
+  });
+
+  test("renders the branch the discriminant selects", () => {
+    // `on` defaults to false → the `initial` candidate.
+    expect(host.querySelector("div")).toBeTruthy();
+    expect(host.querySelector("a")).toBeNull();
+  });
+
+  test("the shared subtree stays reactive after a state change", () => {
+    // The const is rebuilt per render, so the binding inside it must still track `label`.
+    (host as unknown as { state: Record<string, unknown> }).state.label = "CHANGED";
+    expect(host.querySelector("span")?.textContent).toBe("CHANGED");
+  });
+
+  test("switching the discriminant swaps the tag and keeps the subtree", () => {
+    (host as unknown as { state: Record<string, unknown> }).state.on = true;
+    expect(host.querySelector("a")).toBeTruthy();
+    expect(host.querySelector("a")?.querySelector("span")?.textContent).toBe("CHANGED");
+  });
+});

--- a/packages/compiler/tests/client-switch.test.ts
+++ b/packages/compiler/tests/client-switch.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Client-switch.test.ts — `$switch` on a dynamic page (issue #127).
+ *
+ * `buildClientNode` had no `$switch` branch at all, so the node fell through to the generic element
+ * path: a container was emitted and then `children` was looked for to recurse into. `cases` is not
+ * `children`, so the subtree was never visited and the page compiled to `<div><div></div></div>`
+ * with no binding — no error, no warning, content missing. The same node through the element target
+ * emitted both branches correctly, so this was one construct with two implementations and one of
+ * them missing.
+ *
+ * Every assertion here is on branch CONTENT: the tests that existed passed against a target that
+ * emitted neither branch, which is why this went unnoticed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { compileClient } from "../src/targets/compile-client";
+import type { JxDocument } from "@jxsuite/schema/types";
+
+const DOC = {
+  children: [
+    {
+      $switch: { $ref: "#/state/mode" },
+      cases: {
+        a: { tagName: "p", textContent: "AAA-BRANCH" },
+        b: { tagName: "p", textContent: "BBB-BRANCH" },
+      },
+    },
+  ],
+  state: { mode: "a" },
+  tagName: "div",
+};
+
+const compile = (doc: unknown = DOC) =>
+  compileClient(doc as JxDocument, { modulePath: "app.js", title: "t" });
+
+const moduleOf = (r: { files: { content: string }[] }) => r.files[0]?.content ?? "";
+
+describe("compileClient — $switch", () => {
+  test("emits every branch's content", () => {
+    const js = moduleOf(compile());
+
+    expect(js).toContain("AAA-BRANCH");
+    expect(js).toContain("BBB-BRANCH");
+  });
+
+  test("binds the container rather than emitting an empty div", () => {
+    const { html } = compile();
+
+    expect(html).toContain("data-bind");
+    expect(html).toMatch(/:render="_sw0"/);
+  });
+
+  test("keys the lookup on the discriminant", () => {
+    expect(moduleOf(compile())).toContain("[String(state.mode)]");
+  });
+
+  test("falls back to an empty template for an unmatched key", () => {
+    // A discriminant with no matching case renders nothing rather than throwing on `undefined`.
+    expect(moduleOf(compile())).toContain("?? html``");
+  });
+
+  test("accepts a template-string discriminant", () => {
+    const js = moduleOf(
+      compile({ ...DOC, children: [{ ...DOC.children[0], $switch: "${state.mode}" }] }),
+    );
+
+    expect(js).toContain("[String(`${state.mode}`)]");
+  });
+
+  test("skips an external $ref case it cannot fetch at compile time", () => {
+    const js = moduleOf(
+      compile({
+        ...DOC,
+        children: [
+          {
+            ...DOC.children[0],
+            cases: { a: { tagName: "p", textContent: "AAA-BRANCH" }, b: { $ref: "./other.json" } },
+          },
+        ],
+      }),
+    );
+
+    expect(js).toContain("AAA-BRANCH");
+    expect(js).not.toContain("other.json");
+  });
+
+  test("imports lit-html, which the binding needs", () => {
+    expect(moduleOf(compile())).toContain("lit-html");
+  });
+});

--- a/packages/compiler/tests/compile-element.test.ts
+++ b/packages/compiler/tests/compile-element.test.ts
@@ -76,10 +76,16 @@ describe("compileElement", () => {
       expect(content).toContain("<a");
       expect(content).toContain("</a>");
       expect(content).toContain("<div");
-      // In both branches of the bundle the SUBTREE appears; it is written once in the DOCUMENT, which
-      // The thing that was wrong. Hoisting it into a preamble const would shrink the bundle here
-      // And in every existing `$switch` — a refactor of this emitter's return shape, tracked apart.
-      expect(content.split("<span").length - 1).toBe(2);
+      // The subtree is written once in the DOCUMENT and now once in the BUNDLE too: it is hoisted
+      // Into a `const` inside `template()` that both branches reference. Asserted as a COUNT — the
+      // Duplicating emitter passed every other assertion in this test.
+      expect(content.split("<span").length - 1).toBe(1);
+      expect(content).toMatch(/const _c0 = html`/);
+      // Declared inside template(), above the return, so it is rebuilt per render and reads `s`.
+      expect(content.indexOf("const _c0")).toBeGreaterThan(content.indexOf("const s = this.state"));
+      expect(content.indexOf("const _c0")).toBeLessThan(content.indexOf("return html`"));
+      // Both branches reference it rather than repeating the subtree.
+      expect(content.split("${_c0}").length - 1).toBe(2);
       expect(content).not.toContain("[object Object]");
     });
 

--- a/packages/compiler/tests/compiler.test.ts
+++ b/packages/compiler/tests/compiler.test.ts
@@ -753,3 +753,57 @@ describe("escapeHtml — via compile output", () => {
     expect(html).toContain("it&#39;s fine");
   });
 });
+
+// ─── Project style reaches every route (issue #123) ──────────────────────────
+
+/**
+ * `project.json#/style` declares site-wide tokens and typography. The static and client routes
+ * threaded it into `compileStyles`; the custom-element route built its own <head> inline and
+ * dropped it, so a project whose pages are JSON documents under a component layout emitted no
+ * `:root` rule at all. Every `var(--x)` in the project then resolved to nothing and the page
+ * rendered unstyled — while passing lint, `jx validate`, the build, and a DOM-level check.
+ */
+describe("compile — project style", () => {
+  const STYLE = { "--probe-token": "#ff0000", fontFamily: "ProbeFont, sans-serif" };
+
+  test("emits :root custom properties on the custom-element route", async () => {
+    const result = await compile(
+      { children: [{ tagName: "slot" }], state: { n: 0 }, tagName: "probe-base" },
+      { projectStyle: STYLE, title: "probe" },
+    );
+
+    expect(result.html).toContain(":root { --probe-token: #ff0000 }");
+  });
+
+  test("emits direct properties on body on the custom-element route", async () => {
+    const result = await compile(
+      { children: [{ tagName: "slot" }], state: { n: 0 }, tagName: "probe-base" },
+      { projectStyle: STYLE, title: "probe" },
+    );
+
+    expect(result.html).toContain("body { font-family: ProbeFont, sans-serif }");
+  });
+
+  test("still emits the element's own rules alongside the project's", async () => {
+    const result = await compile(
+      {
+        children: [{ style: { color: "var(--probe-token)" }, tagName: "span" }],
+        state: { n: 0 },
+        tagName: "probe-base",
+      },
+      { projectStyle: STYLE, title: "probe" },
+    );
+
+    expect(result.html).toContain("--probe-token");
+    expect(result.html).toContain("var(--probe-token)");
+  });
+
+  test("emits no project rules when the project declares no style", async () => {
+    const result = await compile(
+      { children: [{ tagName: "slot" }], state: { n: 0 }, tagName: "probe-base" },
+      { title: "probe" },
+    );
+
+    expect(result.html).not.toContain(":root {");
+  });
+});

--- a/packages/compiler/tests/element-idl-props.test.ts
+++ b/packages/compiler/tests/element-idl-props.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Element-idl-props.test.ts — IDL properties survive to the emitted element (issue #121).
+ *
+ * `value`, `checked` and friends go directly on the element rather than into `attributes`. The
+ * emitter only had branches for a `$ref` and for a string containing `${…}`, with no `else` — so a
+ * literal IDL value was dropped outright, and so was every `${…}` that a build-time map expansion
+ * had already resolved to a constant. Nothing warned: `jx validate` passed, the build reported no
+ * errors, and the page rendered. It just never responded correctly to input.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { emitElementModule } from "../src/targets/compile-element";
+import type { JxDocument } from "@jxsuite/schema/types";
+
+const emit = (doc: unknown) => emitElementModule(doc as JxDocument, "XProbe", []);
+
+describe("emitLitNode — IDL properties", () => {
+  test("emits a literal string property", () => {
+    const out = emit({
+      children: [{ tagName: "option", textContent: "Alpha", value: "a" }],
+      tagName: "x-probe",
+    });
+
+    expect(out).toContain('.value="${"a"}"');
+  });
+
+  test("emits a literal boolean property", () => {
+    const out = emit({ children: [{ checked: true, tagName: "input" }], tagName: "x-probe" });
+
+    expect(out).toContain('.checked="${true}"');
+  });
+
+  test("still emits a bound property", () => {
+    const out = emit({
+      children: [{ tagName: "input", value: "${state.sel}" }],
+      state: { sel: { default: "a", type: "string" } },
+      tagName: "x-probe",
+    });
+
+    expect(out).toContain('.value="${s.sel}"');
+  });
+
+  test("does not emit reserved or structural keys as properties", () => {
+    const out = emit({
+      children: [{ attributes: { id: "x" }, tagName: "p", textContent: "hi" }],
+      tagName: "x-probe",
+    });
+
+    expect(out).not.toContain(".textContent=");
+    expect(out).not.toContain(".tagName=");
+    expect(out).not.toContain(".attributes=");
+  });
+});
+
+describe("emitMappedArray — IDL properties inside a map", () => {
+  const mapDoc = {
+    children: [
+      {
+        $prototype: "Array",
+        items: { $ref: "#/state/rows" },
+        map: { tagName: "option", textContent: "${$map.item.label}", value: "${$map.item.v}" },
+      },
+    ],
+    state: { rows: { default: [], type: "array" } },
+    tagName: "x-probe",
+  };
+
+  test("emits a $map-interpolating property on the map body", () => {
+    // Authored per the IDL rule, this reached the output as no `value` at all, so each <option>
+    // Fell back to its own label and a change handler received a display string, not the key.
+    expect(emit(mapDoc)).toContain('.value="${$map.item.v}"');
+  });
+
+  test("emits a $ref property on the map body", () => {
+    const out = emit({
+      ...mapDoc,
+      children: [
+        {
+          ...mapDoc.children[0],
+          map: { tagName: "option", value: { $ref: "$map/item" } },
+        },
+      ],
+    });
+
+    // `$map/item` resolves to the callback's own `item` parameter.
+    expect(out).toContain('.value="${item}"');
+  });
+
+  test("emits a literal property on the map body", () => {
+    const out = emit({
+      ...mapDoc,
+      children: [{ ...mapDoc.children[0], map: { disabled: true, tagName: "option" } }],
+    });
+
+    expect(out).toContain('.disabled="${true}"');
+  });
+});

--- a/packages/compiler/tests/prerender-runtime-state.test.ts
+++ b/packages/compiler/tests/prerender-runtime-state.test.ts
@@ -214,3 +214,108 @@ describe("emitRequestFetch", () => {
     }
   });
 });
+
+// ── Mutable state is not bakeable (issues #124, #125) ────────────────────────
+
+/**
+ * The widest tier of the #112 family. A `$prototype: "Function"` whose body returns is stored in
+ * the build scope as its already-evaluated _result_, and a plain `{ "type": "string" }` entry holds
+ * an ordinary build-time value — so nothing distinguished either from a constant. Baking a template
+ * over one replaces it in the emitted output, and the element is dead for the life of the page.
+ */
+describe("buildInitialScope — entries a handler writes to", () => {
+  const withHandler = (body: string, extra: Record<string, unknown> = {}) =>
+    scopeOf({
+      count: { default: 0, type: "number" },
+      list: { default: [], type: "array" },
+      saved: { default: "", type: "string" },
+      touch: { $prototype: "Function", body, parameters: ["state"] },
+      ...extra,
+    });
+
+  test("refuses a plain entry a handler assigns to", () => {
+    const scope = withHandler("state.saved = 'saved';");
+
+    // The build-time value is "", so a baked result would be indistinguishable from an empty
+    // Element — which is exactly why this shipped unnoticed.
+    expect(evaluateStaticTemplate("${state.saved}", scope)).toBeNull();
+  });
+
+  test.each([
+    ["compound assignment", "state.count += 1;"],
+    ["increment", "state.count++;"],
+    ["decrement", "state.count--;"],
+  ])("refuses an entry written by %s", (_label, body) => {
+    expect(evaluateStaticTemplate("${state.count}", withHandler(body))).toBeNull();
+  });
+
+  test("refuses an array a handler mutates in place", () => {
+    // `push` never assigns to the entry, so an assignment-only scan would miss it.
+    expect(
+      evaluateStaticTemplate("${state.list.length}", withHandler("state.list.push(1);")),
+    ).toBeNull();
+  });
+
+  test("still bakes an entry nothing ever writes to", () => {
+    // Narrow on purpose: prerendered content has to survive for SEO.
+    const scope = scopeOf({
+      tagline: { default: "Static marketing copy", type: "string" },
+      touch: { $prototype: "Function", body: "state.other = 1;", parameters: ["state"] },
+    });
+
+    expect(evaluateStaticTemplate("${state.tagline}", scope)).toBe("Static marketing copy");
+  });
+
+  test("does not mistake a comparison for a write", () => {
+    const scope = withHandler(
+      "if (state.saved === 'x' && state.count >= 2 && state.list != null) return 1;",
+    );
+
+    expect(evaluateStaticTemplate("${state.saved}", scope)).toBe("");
+  });
+
+  test("refuses an entry a mutating $expression targets", () => {
+    const scope = scopeOf({
+      hits: { default: 0, type: "number" },
+      bump: { $expression: { operator: "+=", target: { $ref: "#/state/hits" }, value: 1 } },
+    });
+
+    expect(evaluateStaticTemplate("${state.hits}", scope)).toBeNull();
+  });
+
+  test("refuses a computed that reads a written entry, in either declaration order", () => {
+    // Issue #124: the computed is stored as its result, so `readsRuntimeOnlyState` saw a plain
+    // String. The mark has to propagate transitively, and key order must not decide the answer.
+    const label = { $prototype: "Function", body: "return state.saved + '!';" };
+    const writer = { $prototype: "Function", body: "state.saved = 'x';", parameters: ["state"] };
+    const base = { saved: { default: "", type: "string" } };
+
+    for (const defs of [
+      { ...base, label, writer },
+      { ...base, writer, label },
+    ]) {
+      expect(evaluateStaticTemplate("${state.label}", scopeOf(defs))).toBeNull();
+    }
+  });
+
+  test("still bakes a computed over constants only", () => {
+    const scope = scopeOf({
+      price: 10,
+      total: { $prototype: "Function", body: "return state.price * 2;" },
+    });
+
+    expect(evaluateStaticTemplate("${state.total}", scope)).toBe(20);
+  });
+
+  test("survives a computed whose getter throws on partial build-time data", () => {
+    // Reading a key to classify it can run a computed's getter, which is free to throw before the
+    // Data it needs exists. A throw says nothing about whether the entry is runtime-only, so it
+    // Must not take the build down with it.
+    const scope = scopeOf({
+      boom: { $prototype: "Function", body: "return state.missing.deep.value;" },
+      label: { $prototype: "Function", body: "return state.boom + '!';" },
+    });
+
+    expect(() => evaluateStaticTemplate("${state.label}", scope)).not.toThrow();
+  });
+});

--- a/packages/compiler/tests/site-build-state-retention.test.ts
+++ b/packages/compiler/tests/site-build-state-retention.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Site-build-state-retention.test.ts — array state survives to the client when something reads it
+ * at runtime (issue #122).
+ *
+ * An `Array` map expands its items at build time, after which the build stripped the array from
+ * state. But a map expansion is one consumer, not the only one: the same array is routinely also
+ * read by a computed at runtime. Stripping it left `state.rows` undefined in the browser, so the
+ * computed fell through to its guard — silently, and shape-dependently, since the same computed
+ * behaved correctly if the array was also referenced somewhere the compiler treated as a runtime
+ * read.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { buildSite } from "../src/site/site-build";
+
+const TMP = resolve(import.meta.dir, "__test-state-retention__");
+
+/** @param {string} path @param {unknown} obj */
+function writeJSON(path: string, obj: unknown) {
+  mkdirSync(resolve(TMP, ...path.split("/").slice(0, -1)), { recursive: true });
+  writeFileSync(resolve(TMP, path), JSON.stringify(obj, null, 2), "utf8");
+}
+
+const ROWS = [
+  { label: "Alpha", v: "a" },
+  { label: "Beta", v: "b" },
+];
+
+/** The array is expanded into <option>s AND read by `picked` at runtime. */
+const OPTION_MAP = {
+  $prototype: "Array",
+  items: { $ref: "#/state/rows" },
+  map: { tagName: "option", textContent: "${$map.item.label}", value: "${$map.item.v}" },
+};
+
+beforeAll(async () => {
+  rmSync(TMP, { force: true, recursive: true });
+
+  writeJSON("project.json", {
+    build: { outDir: "./dist" },
+    defaults: { lang: "en", layout: "./layouts/base.json" },
+    name: "probe",
+  });
+  writeJSON("layouts/base.json", { children: [{ tagName: "slot" }], tagName: "probe-base" });
+
+  writeJSON("pages/index.json", {
+    children: [
+      { children: [OPTION_MAP], tagName: "select" },
+      { attributes: { id: "out" }, tagName: "p", textContent: "${state.picked}" },
+    ],
+    state: {
+      // Read only by the build-time map — nothing survives to read it, so it may be stripped.
+      decor: ["x", "y"],
+      picked: {
+        $prototype: "Function",
+        body: "var l = state.rows; return (l && l.length) ? l[0].label : 'NO-ROWS';",
+      },
+      rows: ROWS,
+      sel: { default: "a", type: "string" },
+    },
+    title: "probe",
+  });
+
+  // Its own layout, so its island cannot collide with the index page's `probe-base.js`.
+  writeJSON("layouts/decor.json", { children: [{ tagName: "slot" }], tagName: "decor-base" });
+  writeJSON("pages/decor.json", {
+    children: [
+      {
+        children: [
+          { $prototype: "Array", items: { $ref: "#/state/only" }, map: { tagName: "li" } },
+        ],
+        tagName: "ul",
+      },
+    ],
+    layout: "./layouts/decor.json",
+    state: { only: ["x", "y"] },
+    title: "decor",
+  });
+
+  await buildSite(TMP);
+});
+
+afterAll(() => {
+  rmSync(TMP, { force: true, recursive: true });
+});
+
+const islandOf = (name: string) => readFileSync(resolve(TMP, "dist", name), "utf8");
+
+describe("buildSite — array state read at runtime", () => {
+  test("keeps an array a computed still reads in client state", () => {
+    const js = islandOf("probe-base.js");
+
+    // `reactive({...})` is the island's client state; `rows` was absent from it entirely.
+    expect(js).toMatch(/rows:\s*\[/);
+  });
+
+  test("the computed reading it survives as a binding", () => {
+    expect(islandOf("probe-base.js")).toContain("state.rows");
+  });
+
+  test("still expands the map at build time", () => {
+    // The rescue must not turn the static expansion back into a runtime one.
+    const js = islandOf("probe-base.js");
+
+    expect(js).toContain("Alpha");
+    expect(js).toContain("Beta");
+  });
+
+  test("still strips an array nothing reads at runtime", () => {
+    // `decor` is consumed by nothing that survives the build, so keeping it would ship dead data —
+    // And would flip the page to dynamic on the strength of data no longer referenced.
+    expect(islandOf("probe-base.js")).not.toContain("decor");
+  });
+
+  test("a page whose only array was expanded away stays fully static", () => {
+    // Nothing reads `only` after the map expands it, so the page keeps zero JS.
+    const html = readFileSync(resolve(TMP, "dist", "decor", "index.html"), "utf8");
+
+    expect(html).toContain("<li>");
+    expect(html).not.toContain("decor-base.js");
+    expect(existsSync(resolve(TMP, "dist", "decor-base.js"))).toBe(false);
+  });
+});

--- a/packages/schema/schema.json
+++ b/packages/schema/schema.json
@@ -7738,6 +7738,26 @@
             }
           ]
         },
+        "animation-delay-end": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "animation-delay-start": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "animation-direction": {
           "oneOf": [
             {
@@ -7879,6 +7899,26 @@
           ]
         },
         "animationDelay": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "animationDelayEnd": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "animationDelayStart": {
           "oneOf": [
             {
               "type": "string"

--- a/specs/compiler.md
+++ b/specs/compiler.md
@@ -2,9 +2,9 @@
 
 ## Static HTML Compiler, Custom Element Emitter, and Island Detector
 
-**Version:** 0.1.25-draft
+**Version:** 0.1.26-draft
 **Status:** Partial
-**Updated:** 2026-07-30
+**Updated:** 2026-08-14
 **License:** MIT
 
 ---
@@ -281,10 +281,25 @@ invoking, so bodies can read `state.$map.index`/`state.$map.item` per spec.md
 
 ### 4.8 `$switch` Compilation
 
+A `$switch` compiles to a case-keyed lookup over lit templates, matched on the discriminant's string
+form (spec.md §14.1) with an empty template as the fallback:
+
 ```js
-${s.currentRoute === 'home' ? html`<div>Home page</div>` : ''}
-${s.currentRoute === 'about' ? html`<div>About page</div>` : ''}
+${{
+  "home": html`<div>Home page</div>`,
+  "about": html`<div>About page</div>`,
+}[String(s.currentRoute)]}
 ```
+
+**A shared subtree is hoisted, not repeated.** A branching construct — `$switch`, or a `tagName`
+chosen at creation (spec.md §8.6) — writes one template per branch, so a subtree the authored
+document names once was emitted once per branch into the bundle. Any subtree that would repeat is
+lifted into a `const _cN = html`…`` declared inside `template()`, above the `return`, and the
+branches reference it. The declaration is inside the method, not at module scope, so it is rebuilt
+per render and reads the same state alias the template does. A map body gets its own declarations
+inside its callback, because they close over that callback's `item`/`index`. Branches that emit
+distinct subtrees are left inline, and a chosen `tagName` whose candidates disagree about being
+preformatted is not hoisted, since `white-space` decides how the subtree itself is indented.
 
 > **Status: Implemented.** `compile-element.js` produces complete lit-html custom element modules.
 
@@ -603,6 +618,35 @@ such a template is emitted unresolved for the client to populate. A read that
 _calls_ the entry is unaffected: invoking a build-time callable, such as a named
 formula (spec.md §19.4c), still evaluates during prerender.
 
+**An entry a handler writes to is runtime-only.** A plain `{ "type": "string" }` entry holds a
+perfectly ordinary build-time value, so nothing else distinguishes it from a constant — but if any
+handler in the document assigns to it, baking `${state.x}` replaces the template and the element is
+dead for the life of the page, not merely stale. Before the main pass the scope builder scans every
+handler body in the document for writes to `state.x` — assignment (`=`, `+=`, `++`, …) and in-place
+array mutation (`push`, `splice`, `sort`, …) alike — and marks each target runtime-only. A mutating
+`$expression` contributes its `target` pointer the same way. The scan is narrow on purpose: an entry
+nothing ever writes stays bakeable, so prerendered content survives for SEO.
+
+**The mark is transitive, and order-independent.** A `$prototype: "Function"` whose body returns is
+stored in the build scope as its already-evaluated _result_, so a template reading it sees an
+ordinary value and would bake it. A computed that reads a runtime-only entry is therefore
+runtime-only in turn, as is a template entry that reads one. The marks are propagated to a fixpoint
+after the main pass, so declaration order does not decide the answer, and a computed over constants
+alone still bakes.
+
+> **Known limitation.** A `$src` handler's assignments live in a JS file the scope builder does not
+> open, so an entry written only from there is still baked. Declaring the same entry's writer in the
+> document, or reading the entry through a `Request`/`$src` value, restores the mark.
+
+**An array is only stripped when nothing still reads it.** A build-time repeater expansion consumes
+its `items`, after which the array would be dead weight in client state. But a map expansion is one
+consumer, not the only one: the same array is routinely also read by a computed at runtime. An array
+state entry is therefore dropped only when no surviving state definition and no surviving node in
+the document still references it — as `${state.x}`, as a bare `state.x` in a handler or computed
+body, or as a `#/state/x` pointer — iterated to a fixpoint, since rescuing one array can reveal a
+read of another. An entry the author marked `timing: "compiler"` is exempt and is always stripped:
+that declaration is the author saying the data is build-time only.
+
 ### 8.2 CSS Extraction
 
 All static `style` definitions are extracted into a single `<style>` block in `<head>`.
@@ -622,6 +666,24 @@ For dynamic documents that are not custom elements, the compiler emits:
 - `effect()` bindings for reactive properties
 
 > **Status: Implemented.** `compile-client.js` handles dynamic page compilation.
+
+### 9.2 `$switch` on a Dynamic Page
+
+A `$switch` node compiles to a render binding on its container element, mirroring the mapped-array
+binding in the same target: the container carries `data-bind :render="_swN"`, and the module holds a
+case-keyed lookup over lit templates matched on `String(discriminant)`, with an empty template as
+the fallback. The discriminant may be a `#/state/…` pointer or a template string. An external `$ref`
+case cannot be fetched at compile time and is skipped, exactly as in the static renderer.
+
+The container is emitted **empty**, with the matched case supplied at hydration. lit's `render`
+inserts into a container rather than replacing its existing children, so a prerendered branch would
+survive alongside the rendered one — the same reason the mapped-array binding prerenders nothing.
+
+> **Status: Implemented.** Previously `buildClientNode` had no `$switch` branch at all: the node
+> fell through to the generic element path, which emitted a container and then looked for `children`
+> to recurse into. `cases` is not `children`, so the subtree was never visited and the page compiled
+> to an empty `<div>` with the content missing and no error — while the same node through the
+> element target (§4.8) emitted every branch correctly.
 
 ---
 
@@ -731,6 +793,7 @@ The site build bundles Function-def `$src` modules for the browser
 
 ## Changelog
 
+- **0.1.26-draft** (2026-08-14) — $switch compiles on dynamic pages (§9.2); branch subtrees hoisted out of $switch and chosen-tagName constructs (§4.8); prerender treats handler-written entries and computeds reading them as runtime-only, and keeps an array any surviving reader still references (§8.1).
 - **0.1.25-draft** (2026-07-30) — Element modules: props.* attribute intake and $props template bindings, one effect registry stopped on disconnect, state.$map published for map handlers; prerender keeps a repeater whose build-time expansion is empty (§4.1, §4.2, §4.4, §4.7, §8.1).
 - **0.1.24-draft** (2026-07-30) — Element modules: $export aliasing, Request auto-fetch on connect with effect teardown, $map bound in map callbacks, tagName-based output naming; prerender leaves runtime-only reads unresolved (§4.1, §4.7, §8.1).
 - **0.1.23-draft** (2026-07-24) — §1 Overview: condition the generated Hono worker on build.adapter (per-page _server.js without one) and scope the static-build failure to active data/auth mounts; §6.3 document compileSiteServer's mounts/connectors parameters and extension mount emission.
@@ -760,4 +823,4 @@ The site build bundles Function-def `$src` modules for the browser
 
 ---
 
-_`@jxsuite/compiler` Specification v0.1.25-draft_
+_`@jxsuite/compiler` Specification v0.1.26-draft_


### PR DESCRIPTION
Closes all seven open issues. Five are the dogfooding sweep (#121–#125), which share one repro project; two are the compiler pair filed alongside #120 (#126, #127).

Every symptom reproduced on `main` before anything was changed, and the end-to-end repro from the issues now matches its own expectation table in a real DOM — including the row the issues could not check, that the page finally responds to input:

| Read | Before | After |
| --- | --- | --- |
| `[...document.querySelectorAll('option')].map(o=>o.value)` | `["Alpha","Beta"]` | `["a","b"]` |
| `#out` textContent | baked dead | `"Alpha"` |
| `--probe-token` in the emitted CSS | absent | `#ff0000` |
| `#out` after `state.sel = "b"` | never moved | `"Beta"` |

## One commit per issue

| Commit | Issue | What was wrong |
| --- | --- | --- |
| `chore(schema)` | — | Pre-existing red gate on `main`, see below |
| `fix(compiler): emit project style…` | #123 | The custom-element route built its `<head>` inline and never passed `projectStyle` |
| `fix(compiler): keep prerender from baking…` | #124, #125 | A written entry and a computed reading one were indistinguishable from constants |
| `fix(compiler): keep array state…` | #122 | A map expansion was treated as the array's only consumer |
| `feat(compiler): compile $switch…` | #127 | `buildClientNode` had no `$switch` branch at all |
| `fix(compiler): emit IDL properties…` | #121, #126 | No `else` for a literal IDL value; branches duplicated their subtree |
| `docs(compiler)` | — | specs 0.1.25-draft → 0.1.26-draft, plus the two user-facing pages |

## Two findings worth flagging

**#121 was wider than reported.** The missing `else` dropped *any* literal IDL value, not just one inside a map — `{ "tagName": "input", "value": "hello" }` lost its value anywhere in a document. `emitMappedArray` was separately missing the property loop outright, so both paths needed fixing.

**#123 reproduced through a second door.** The repro builds through the site pipeline, which does pass `projectStyle` into `compile()`; it was Route 2 that dropped it. Worth knowing because the `jx` bin runs a prebuilt `dist/` bundle — my first probe silently tested stale output, and every measurement here is from `src/`.

## Where I departed from the issues

- **#125** suggests treating every plain typed value in a document declaring any `$src` entry as mutable. I implemented the precise in-document scan and left that heuristic out: it contradicts the issue's own stated principle that constants should still bake for SEO, and it would silently strip prerendered content from every page with a sidecar. The gap is stated as a known limitation in specs/compiler.md §8.1 and in the build docs, so an author hitting it can diagnose it.
- **#126** proposes changing `emitLitNode` to return `{ text, preamble[] }`. I threaded a hoist scope instead — same hoisting, same de-risking of "emit beside the template", across 8 call sites rather than rewriting the return shape at all of them. Happy to convert it if you want the signature change on its own merits.

## The extra commit

`schema:verify` is red on `main`: the dep bump in 42df7f16 taught the generator two new CSS properties and `packages/schema/schema.json` was never regenerated. The first commit is that regeneration with no hand edits — unrelated to these issues, but this PR could not go green without it.

## Verification

- 1059 compiler tests pass (up from 1014); all 20 workspaces green
- Every new test was confirmed to **fail** against the unfixed code — 7 of 8 prerender tests, 5 of 7 IDL tests, both project-style tests, the array-retention test
- `#126` is asserted as a **count**, per the issue: the duplicating emitter passed every other assertion. A DOM render test covers the lit semantics hoisting changes — reactivity through the hoisted const, and the tag swap
- Measured: `$switch` 3 copies → 1 (2331 → 2041 bytes), chosen `tagName` 2 → 1 (2110 → 2011)
- `lint`, `typecheck`, `docs:check`, `docs:verify`, `docs:spec-release`, `docs:claims`, `check-shot-contract`, `schema:verify`, coverage manifest — all clean
- Coverage held; worst-file unchanged, so no threshold ratchet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
