### PR TITLE
ci: run a check only where it can fail

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,0 +1,30 @@
+name: Set up Bun
+description: Install the pinned Bun and the workspace dependencies.
+
+# `actions/checkout` deliberately is NOT here. A local `uses: ./…` action requires the repository
+# to already be on disk, so the checkout has to stay in the calling job — and it varies anyway
+# (the gate and the spec-release check need history; the matrix jobs do not).
+#
+# There is also no `actions/cache` here on purpose. `bun install --frozen-lockfile` is 3-7s in
+# these jobs and a cache restore plus save is comparable, so it would buy nothing. (deploy-site.yml
+# caches because it runs a non-frozen install alongside heavy image encoding — a different job.)
+
+inputs:
+  install:
+    description: Run `bun install --frozen-lockfile`. Set false for jobs that only need Bun itself.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        # THE pin, in one place. Coverage instrumentation shifts between Bun versions and would
+        # silently move the per-file coverageThreshold ratchet, so bumping this means
+        # re-baselining every packages/*/bunfig.toml in the same PR (CLAUDE.md, Testing &
+        # Coverage Policy). It used to be copied across five workflows.
+        bun-version: 1.3.13
+    - if: inputs.install == 'true'
+      run: bun install --frozen-lockfile
+      shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily" # or weekly/monthly
+      # Weekly, grouped. Daily-and-ungrouped produced bursts of three and four PRs on a single
+      # day, each one firing the entire test matrix for a one-line version bump. Action versions
+      # are not a freshness-critical dependency; a week's latency costs nothing.
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -14,6 +14,12 @@ on:
       - main
   pull_request:
 
+# Same rule as test.yml: supersede a PR's in-flight run, never main's (the Codecov bundle
+# baseline is per-commit).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   bundle-analysis:
     # Fork PRs get a read-only token with no OIDC, so the upload can't run.

--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -13,6 +13,29 @@ on:
     branches:
       - main
   pull_request:
+    # The DEPENDENCY closure of the three bundles below — a bundle of X is rebuilt when X or
+    # anything X imports changes, which is the opposite direction from which test suites must be
+    # rerun. A `paths:` filter at this level costs nothing (no gate job to provision), and this is
+    # the whole reason a PR bumping an action version no longer gets told its bundle grew 16.2MB.
+    #
+    # GENERATED, and guarded: scripts/ci/bundle-paths.test.ts asserts this list is exactly what
+    # `dependencyClosure` produces for compiler, runtime and studio. Add a dependency to any of
+    # them and forget this file, and that test goes red naming both sides.
+    paths:
+      - "packages/ai/**"
+      - "packages/collab/**"
+      - "packages/compiler/**"
+      - "packages/create/**"
+      - "packages/formulas/**"
+      - "packages/markup/**"
+      - "packages/protocol/**"
+      - "packages/runtime/**"
+      - "packages/schema/**"
+      - "packages/starters/**"
+      - "packages/studio/**"
+      # The lockfile moves what any of them actually bundles.
+      - "bun.lock"
+      - ".github/workflows/bundle-analysis.yml"
 
 # Same rule as test.yml: supersede a PR's in-flight run, never main's (the Codecov bundle
 # baseline is per-commit).

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -33,14 +33,19 @@ name: Screenshots
 on:
   pull_request:
     paths:
-      # The surfaces a picture is OF.
+      # The surfaces a picture is OF. `packages/starters/**` was too wide: a starters README
+      # cannot move a pixel, and the only starter inputs a shot opens are the project roots.
       - "packages/studio/src/**"
-      - "packages/starters/**"
+      - "packages/starters/sites/**"
+      - "packages/starters/registry.json"
       # The pipeline itself, and the lock's own definition.
       - "scripts/screenshots/**"
       - "scripts/check-image-lock.ts"
       - "scripts/lib/png.ts"
-      - ".github/workflows/screenshots.yml"
+      # NOT this file. It listed itself, so a dependabot bump of an action version — a diff that
+      # cannot change a picture — booted the container, re-captured all 61 shots, and pushed the
+      # result onto the bot's branch. That is how PR #131, titled "bump actions/upload-artifact
+      # from 4 to 7", merged 26 re-captured PNGs. Editing the *steps* has `workflow_dispatch`.
       # Someone hand-editing bytes: the lane is the fastest way to say so out loud.
       - "docs/images/**"
   schedule:
@@ -70,6 +75,11 @@ concurrency:
 jobs:
   capture:
     runs-on: ubuntu-latest
+    # Belt-and-braces with the `paths:` list above. This lane's failure mode is a bot commit on
+    # your branch, and a bot branch is precisely where that is never wanted: an automated
+    # dependency bump has no picture to review, and the re-capture lands as unreviewable bytes in
+    # a PR nobody opened for that purpose.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     # A PINNED container, Chromium AND fontconfig. The fontset is not optional: the Spectrum UI
     # Stack resolves differently on NixOS and on Ubuntu, so a hash lock over bytes rendered with an
     # Unknown font set is a lock nobody can reproduce — which is why every lock entry records the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,41 +17,52 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Which of the jobs below this diff can actually fail. See scripts/ci/affected.ts for the rules
+  # and for why only three things here are gated at all.
+  #
+  # This workflow must NEVER grow an `on:`-level `paths:` filter. A path-filtered workflow that
+  # does not trigger leaves a required status check pending forever; the `ci` job at the bottom is
+  # the one stable name to protect, and it can only report if the workflow always runs.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.affected.outputs.test_matrix }}
+      has_tests: ${{ steps.affected.outputs.has_tests }}
+      all_workspaces: ${{ steps.affected.outputs.all_workspaces }}
+      lens_mutants: ${{ steps.affected.outputs.gate_lens_mutants }}
+      mode: ${{ steps.affected.outputs.mode }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The gate diffs against the merge base. `blob:none` keeps history and trees local —
+          # so merge-base and --name-only run offline — while deferring file content nobody here
+          # reads. A full clone of this 551 MB pack is 28s; this is ~4s.
+          fetch-depth: 0
+          filter: blob:none
+      - uses: ./.github/actions/setup-bun
+      # The gate proves itself before it gates. This also gives scripts/*.test.ts its only home in
+      # CI: scripts/ is not a coverage workspace and the matrix below only runs `bun test` with
+      # cwd INSIDE a workspace, so these five files previously ran nowhere.
+      - run: bun test --isolate scripts
+      - id: affected
+        env:
+          BASE_REF: ${{ github.base_ref || github.event.repository.default_branch }}
+        run: bun scripts/ci/affected.ts
+
   test:
+    needs: changes
+    # A `strategy.matrix` built from an empty include is a workflow ERROR, not a skipped job.
+    if: needs.changes.outputs.has_tests == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # dir = workspace path (packages/* core, extensions/* extensions);
+      # flag = codecov flag / artifact name (flags cannot contain "/").
       matrix:
-        # dir = workspace path (packages/* core, extensions/* extensions);
-        # flag = codecov flag / artifact name (flags cannot contain "/").
-        package:
-          - { dir: packages/ai, flag: ai }
-          - { dir: extensions/auth, flag: auth }
-          - { dir: packages/collab, flag: collab }
-          - { dir: packages/compiler, flag: compiler }
-          - { dir: extensions/connector, flag: connector }
-          - { dir: packages/create, flag: create }
-          - { dir: packages/desktop, flag: desktop }
-          - { dir: packages/formulas, flag: formulas }
-          - { dir: packages/import, flag: import }
-          - { dir: packages/markup, flag: markup }
-          - { dir: extensions/parser, flag: parser }
-          - { dir: packages/protocol, flag: protocol }
-          - { dir: packages/runtime, flag: runtime }
-          - { dir: packages/schema, flag: schema }
-          - { dir: extensions/search, flag: search }
-          - { dir: packages/server, flag: server }
-          - { dir: packages/starters, flag: starters }
-          - { dir: packages/studio, flag: studio }
+        package: ${{ fromJSON(needs.changes.outputs.test_matrix).include }}
     steps:
       - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
-        with:
-          # Pinned: coverage instrumentation shifts between Bun versions and
-          # would silently move the coverageThreshold ratchet. Bump this
-          # together with re-baselining packages/*/bunfig.toml thresholds.
-          bun-version: 1.3.13
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-bun
       - name: Test with coverage
         shell: bash
         run: |
@@ -114,11 +125,13 @@ jobs:
 
   coverage-comment:
     # Sticky PR comment with all packages' coverage tables. Skipped for fork
-    # PRs, where GITHUB_TOKEN is read-only.
+    # PRs, where GITHUB_TOKEN is read-only, and for a diff that reaches no
+    # workspace at all — a docs PR does not need an all-empty coverage table.
     if: >-
       always() && github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    needs: test
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.changes.outputs.has_tests == 'true'
+    needs: [changes, test]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -130,15 +143,32 @@ jobs:
           merge-multiple: true
       - name: Build comment body
         shell: bash
+        env:
+          # Every workspace, not just the ones that ran. A table that silently shrinks to the
+          # affected packages reads as coverage having vanished; each skipped row says why
+          # instead. Codecov's own flags carry forward (codecov.yml) for the same reason.
+          ALL_WORKSPACES: ${{ needs.changes.outputs.all_workspaces }}
         run: |
+          # jq, not bun: this job never installs Bun, it only downloads artifacts.
+          mapfile -t all < <(echo "$ALL_WORKSPACES" | jq -r '.[]')
+          ran=0
+          for pkg in "${all[@]}"; do
+            [ -f "coverage-reports/$pkg.txt" ] && ran=$((ran + 1))
+          done
           {
             echo "<!-- coverage-report -->"
             echo "## Test coverage"
             echo ""
+            echo "$ran of ${#all[@]} workspaces ran; the rest are unreachable from this diff."
+            echo ""
             echo "| Package | % Funcs | % Lines |"
             echo "|---|---|---|"
-            for f in coverage-reports/*.txt; do
-              pkg=$(basename "$f" .txt)
+            for pkg in "${all[@]}"; do
+              f="coverage-reports/$pkg.txt"
+              if [ ! -f "$f" ]; then
+                echo "| $pkg | — | not affected |"
+                continue
+              fi
               row=$(grep '^All files' "$f" || true)
               funcs=$(echo "$row" | awk -F'|' '{gsub(/ /,"",$2); print $2}')
               lines=$(echo "$row" | awk -F'|' '{gsub(/ /,"",$3); print $3}')
@@ -177,6 +207,11 @@ jobs:
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
 
+  # Deliberately UNGATED, and deliberately one job. Measured on green run 31489926926, every
+  # check below is 0-4s and all of them together are 22s, while a fresh job costs ~15s just to
+  # provision — so splitting these by concern, or gating them, would cost more time than it saves.
+  # The two expensive things that used to live here have moved: the 28s full clone is now blobless,
+  # and the 87s mutation gate is its own job below.
   checks:
     runs-on: ubuntu-latest
     steps:
@@ -190,10 +225,7 @@ jobs:
           # `git merge-base` and `git diff --name-only` still run offline — and defers
           # only file CONTENT, of which the gate reads a handful of changed spec .md.
           filter: blob:none
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.13
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-bun
       - run: bun run lint
       # Core packages must never depend on extension packages — see
       # specs/extensions.md §2 and scripts/check-dep-rules.ts.
@@ -253,8 +285,10 @@ jobs:
       - run: bun run schema:verify
 
   # Its own job because it is 87 of the 159 seconds `checks` used to take, and everything else
-  # in there is 0-4s. Running it alongside rather than after halves that job's wall clock; a
-  # later commit gates it on studio, which is the only tree it can be affected by.
+  # in there is 0-4s. It is gated on studio's OWN tree — not on studio merely being retested —
+  # because the mutation targets are files under packages/studio/src and the assertions are
+  # studio's own test files. Gating on the test set would fire this on most PRs in the repo,
+  # since studio sits downstream of nearly everything. See scripts/ci/affected.ts.
   #
   # The derived pane's lens/companion discriminators (§18.4), each mutated in turn against the
   # ONE test file expected to notice. Two review rounds of that workstream each fixed the
@@ -263,11 +297,34 @@ jobs:
   # inversion the whole 8000-test suite passed. A surviving mutant is red here, in the PR that
   # removed the assertion, naming the behaviour that is now unprotected.
   lens-mutants:
+    needs: changes
+    if: needs.changes.outputs.lens_mutants == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.13
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-bun
       - run: bun --cwd packages/studio scripts/check-lens-mutants.ts
+
+  # The ONE stable name to make a required status check on `main`. It lives in a workflow with no
+  # `paths:` filter, so it always runs and always reports — a required check on a path-filtered
+  # workflow hangs pending forever instead.
+  #
+  # It tests for failure/cancelled rather than requiring success, because `skipped` is the POINT
+  # of this design: a job the diff cannot reach must leave this green.
+  ci:
+    if: always()
+    needs: [changes, test, checks, lens-mutants, coverage-comment]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+          MODE: ${{ needs.changes.outputs.mode }}
+        run: |
+          echo "scope: $MODE — job results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "::error::a required job reported '$result'"
+              exit 1
+            fi
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,14 @@ on:
       - main
   pull_request:
 
+# A PR branch that gets three pushes in a minute used to leave three full ~22-job fan-outs
+# racing each other; only the last one's answer was ever read. On main, never cancel:
+# release-please and the Codecov per-flag baselines need every main commit to produce a
+# complete report.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -177,6 +185,11 @@ jobs:
           # The spec release gate diffs against the merge base with main; a shallow
           # clone has no merge base and the gate would silently pass.
           fetch-depth: 0
+          # …but a full clone of a 551 MB pack costs 28s, which was the single largest
+          # step in this job. `blob:none` keeps all commits and all trees local — so
+          # `git merge-base` and `git diff --name-only` still run offline — and defers
+          # only file CONTENT, of which the gate reads a handful of changed spec .md.
+          filter: blob:none
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
@@ -204,13 +217,6 @@ jobs:
       # module-level `let active` is well-typed — so the guard is a ratcheting allow-list.
       - run: bun --cwd packages/studio scripts/check-pane-singletons.ts
       - run: bun --cwd packages/studio scripts/check-icons.ts
-      # The derived pane's lens/companion discriminators (§18.4), each mutated in turn against the
-      # ONE test file expected to notice. Two review rounds of that workstream each fixed the
-      # defects they named and left as many behind, because a green suite says nothing about
-      # whether it could tell right from wrong — a measurement found seven discriminators whose
-      # inversion the whole 8000-test suite passed. A surviving mutant is red here, in the PR that
-      # removed the assertion, naming the behaviour that is now unprotected.
-      - run: bun --cwd packages/studio scripts/check-lens-mutants.ts
       - run: bun run typecheck
       # packages/desktop is EXCLUDED from the root tsconfig (electrobun ships raw .ts in its dist,
       # which the root's two strictest flags reject 165 times) so it needs its own pass — without
@@ -245,3 +251,23 @@ jobs:
       # core, and one starter whose entry document was composed against a published @jxsuite/schema
       # left in a stray node_modules, so it was NARROWER than its own content required.
       - run: bun run schema:verify
+
+  # Its own job because it is 87 of the 159 seconds `checks` used to take, and everything else
+  # in there is 0-4s. Running it alongside rather than after halves that job's wall clock; a
+  # later commit gates it on studio, which is the only tree it can be affected by.
+  #
+  # The derived pane's lens/companion discriminators (§18.4), each mutated in turn against the
+  # ONE test file expected to notice. Two review rounds of that workstream each fixed the
+  # defects they named and left as many behind, because a green suite says nothing about
+  # whether it could tell right from wrong — a measurement found seven discriminators whose
+  # inversion the whole 8000-test suite passed. A surviving mutant is red here, in the PR that
+  # removed the assertion, naming the behaviour that is now unprotected.
+  lens-mutants:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+      - run: bun install --frozen-lockfile
+      - run: bun --cwd packages/studio scripts/check-lens-mutants.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,13 @@ Every workspace must keep full unit-test coverage — `packages/*` core packages
 
 1.  **Per-file coverage thresholds** live in each workspace's own `bunfig.toml` — `packages/<pkg>/bunfig.toml` and `extensions/<ext>/bunfig.toml` (`coverageThreshold = { lines = X, functions = Y }`). Bun enforces these **per file**, not as an aggregate — no single source file may fall below the bar. Keys must be plural (`lines`/`functions`); singular keys are silently ignored by Bun.
 2.  **Manifest check** — `bun scripts/check-coverage-manifest.ts <workspace-dir>` (e.g. `packages/schema`, `extensions/auth`) fails if any `src/**/*.ts` file never appears in `coverage/lcov.info` (Bun only counts files imported during the run, so a brand-new untested file is otherwise invisible to thresholds). Type-only files are allowlisted inside the script.
-3.  **CI** — `.github/workflows/test.yml` runs the per-workspace matrix (see the matrix list in that file — it interleaves `packages/*` and `extensions/*` entries): `bun test --isolate --coverage` (cwd = the workspace, so its bunfig applies) plus the manifest check, and a separate lint-and-typecheck job. The Bun version is pinned there; bump it together with re-baselining thresholds.
+3.  **CI** — `.github/workflows/test.yml` runs the per-workspace matrix: `bun test --isolate --coverage` (cwd = the workspace, so its bunfig applies) plus the manifest check, alongside an ungated `checks` job (lint, both typechecks, the studio guards, the docs and schema gates) and a gated `lens-mutants` job. The Bun version is pinned once in `.github/actions/setup-bun`; bump it together with re-baselining thresholds.
+
+    The matrix is **derived**, not listed: the `changes` job runs `scripts/ci/affected.ts`, which reads the workspace graph via `scripts/lib/workspaces.ts` and emits the workspaces a diff can reach. Consequences for agents:
+    - **Adding a workspace needs no CI edit** — but it must ship a `bunfig.toml` with a `coverageThreshold`, or `affected.ts` fails the run by name.
+    - **A suite that reads a file outside its own workspace needs an entry in `EXTRA_EDGES`**, with the test file that proves it. Those anchors are `existsSync`-checked before any other job starts, so moving a cited test reds CI immediately.
+    - Push to `main` and `workflow_dispatch` are never gated; only pull requests are.
+    - `scripts/**` has no coverage workspace, so its tests run via `bun test --isolate scripts` inside the `checks` job. Put new script tests where that finds them.
 
 Conventions:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Every workspace must keep full unit-test coverage — `packages/*` core packages
     - **Adding a workspace needs no CI edit** — but it must ship a `bunfig.toml` with a `coverageThreshold`, or `affected.ts` fails the run by name.
     - **A suite that reads a file outside its own workspace needs an entry in `EXTRA_EDGES`**, with the test file that proves it. Those anchors are `existsSync`-checked before any other job starts, so moving a cited test reds CI immediately.
     - Push to `main` and `workflow_dispatch` are never gated; only pull requests are.
-    - `scripts/**` has no coverage workspace, so its tests run via `bun test --isolate scripts` inside the `checks` job. Put new script tests where that finds them.
+    - `scripts/**` has no coverage workspace, so its tests run via `bun test --isolate scripts` inside the `changes` job — the gate proves itself before it gates anything. Put new script tests where that finds them.
 
 Conventions:
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+# Coverage is uploaded per workspace under a flag (see the `flags:` key on the codecov steps in
+# .github/workflows/test.yml). Once the test matrix is gated on what a PR actually changed, a
+# workspace the diff cannot reach uploads nothing for that commit — and without carryforward
+# Codecov reads "no upload" as "no coverage" and reports an invented drop against a package the
+# PR never touched.
+#
+# `carryforward` makes a flag with no upload on this commit reuse its last known measurement.
+# Push to main stays ungated precisely so every flag keeps a complete, current baseline for that
+# to carry from.
+flag_management:
+  default_rules:
+    carryforward: true

--- a/docs/extending/contributing/monorepo.md
+++ b/docs/extending/contributing/monorepo.md
@@ -25,3 +25,27 @@ The Jx monorepo ([github.com/jxsuite/jx](https://github.com/jxsuite/jx)) is a Bu
 ## Testing policy
 
 Every package keeps full unit-test coverage, enforced per file by each package's `bunfig.toml` thresholds plus a manifest check that fails CI when a source file is never imported by any test. New source files ship with tests in the same PR.
+
+## What CI runs, and when
+
+A pull request runs the checks its diff can actually fail. The test matrix is **derived** from the workspace dependency graph rather than listed by hand, so adding a package cannot leave it untested.
+
+To see what your working diff would trigger, before pushing:
+
+```bash
+git diff --name-only origin/main... | bun scripts/ci/affected.ts --stdin
+```
+
+Three rules decide the scope:
+
+- **A changed package retests its dependents.** Every `@jxsuite/*` package resolves to its `src/` and CI never builds first, so a change to `schema` is observable in every suite downstream of it.
+- **Some suites read files outside their own workspace.** Those edges cannot be seen in a `package.json`, so they are declared in `scripts/ci/affected.ts` — each one naming the test file that proves it. Such an edge retests only that one suite, not everything downstream of it.
+- **An unrecognised path runs everything.** A new top-level directory costs one full run until someone classifies it, which is the safe direction to be wrong in.
+
+Pushes to `main`, the nightly cron, and manual dispatch are never gated: they always run the full matrix. That is the safety net if a rule above has gone stale, and it keeps each package's coverage baseline current.
+
+`lint`, both typechecks and all the docs and schema gates run **unconditionally**, in one `checks` job. Each is a few seconds and a fresh CI job costs longer than that to start, so gating them would cost time rather than save it.
+
+:::doc-note
+`ci` is the aggregate job. It passes when every other job either succeeded or was skipped, and fails if any failed or was cancelled — so a job your diff never reached leaves the run green.
+:::

--- a/scripts/ci/affected.test.ts
+++ b/scripts/ci/affected.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Golden tests for the CI gate, pinned against the REAL on-disk workspace graph.
+ *
+ * That is deliberate. A fixture graph would let a package rename pass here and then silently
+ * un-gate a suite in CI; pinning to the real graph means renaming a package changes these
+ * expectations and reds this file — which is the red X the design is built around.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readWorkspaces } from "../lib/workspaces.ts";
+import { anchorProblems, decide } from "./affected.ts";
+import type { ExtraEdge } from "./affected.ts";
+
+const workspaces = await readWorkspaces();
+
+/** Flags of the workspaces whose test job would run for this diff. */
+function flagsFor(...changed: string[]): string[] {
+  const byDir = new Map(workspaces.map((w) => [w.dir, w.flag]));
+  return decide(changed, workspaces)
+    .testDirs.map((d) => byDir.get(d)!)
+    .toSorted();
+}
+
+describe("the whole matrix", () => {
+  test("a schema change reaches every workspace that depends on it", () => {
+    const flags = flagsFor("packages/schema/src/schema.ts");
+    // Everything except `ai`, which depends on nothing and is depended on only by studio.
+    expect(flags).not.toContain("ai");
+    expect(flags).toContain("studio");
+    expect(flags).toContain("server");
+    expect(flags).toContain("parser");
+    expect(flags.length).toBe(workspaces.length - 1);
+  });
+
+  test("a root manifest change runs everything", () => {
+    const d = decide(["package.json"], workspaces);
+    expect(d.mode).toBe("all");
+    expect(d.testDirs.length).toBe(workspaces.length);
+    expect(d.bundles).toEqual(["compiler", "runtime", "studio"]);
+  });
+
+  test("the gate's own source runs everything, so a PR editing it is not graded by it", () => {
+    expect(decide(["scripts/ci/affected.ts"], workspaces).mode).toBe("all");
+    expect(decide(["scripts/lib/workspaces.ts"], workspaces).mode).toBe("all");
+    expect(decide([".github/workflows/test.yml"], workspaces).mode).toBe("all");
+  });
+
+  test("an unclassified path fails OPEN rather than narrowing the run", () => {
+    const d = decide(["some-new-toplevel-dir/thing.ts"], workspaces);
+    expect(d.mode).toBe("all");
+    expect(d.reason).toContain("matches no rule");
+  });
+});
+
+describe("nothing at all", () => {
+  test("a docs-only diff runs no test job", () => {
+    const d = decide(["docs/start/install.md"], workspaces);
+    expect(d.testDirs).toEqual([]);
+    expect(d.lensMutants).toBe(false);
+    expect(d.bundles).toEqual([]);
+  });
+
+  test("a workflow-only diff runs no test job — the dependabot shape", () => {
+    // A PR whose entire content is `actions/upload-artifact@4 -> @7` used to run 18 test jobs,
+    // The full checks chain, three bundle builds and a Chromium screenshot capture.
+    const d = decide([".github/workflows/publish.yml", ".github/dependabot.yml"], workspaces);
+    expect(d.testDirs).toEqual([]);
+    expect(d.bundles).toEqual([]);
+  });
+
+  test("an empty diff runs nothing", () => {
+    expect(decide([], workspaces).testDirs).toEqual([]);
+  });
+});
+
+describe("edges package.json cannot see", () => {
+  test("a screenshot script retests studio ONLY — not studio's dependents", () => {
+    // Studio's suite imports scripts/lib/png.ts. Desktop depends on studio, but desktop's tests
+    // Do not read png.ts, so pulling desktop in would be over-running.
+    expect(flagsFor("scripts/lib/png.ts")).toEqual(["studio"]);
+    expect(flagsFor("scripts/screenshots/manifest.json")).toEqual(["studio"]);
+    expect(flagsFor("scripts/check-shot-contract.ts")).toEqual(["studio"]);
+  });
+
+  test("a committed site config retests studio", () => {
+    expect(flagsFor("sites/jxsuite.com/project.json")).toEqual(["studio"]);
+    expect(flagsFor("sites/test-blank/pages/index.json")).toEqual(["studio"]);
+  });
+
+  test("a site page that is not a project config retests nothing", () => {
+    expect(flagsFor("sites/jxsuite.com/pages/index.md")).toEqual([]);
+  });
+
+  test("examples retests the compiler, whose CLI suite compiles it as a fixture", () => {
+    expect(flagsFor("examples/components/todo-app.json")).toEqual(["compiler"]);
+  });
+
+  test("an extension's source retests schema — the inverted edge", () => {
+    // Nothing depends on @jxsuite/search, so without the edge this would be `search` alone and
+    // Schema's class-drift test, which walks every extension's src, would not have run.
+    expect(flagsFor("extensions/search/src/index.ts")).toEqual(["schema", "search"]);
+  });
+
+  test("the inverted edge adds schema WITHOUT dragging in schema's sixteen dependents", () => {
+    const flags = flagsFor("extensions/search/src/index.ts");
+    expect(flags).not.toContain("studio");
+    expect(flags).not.toContain("server");
+    expect(flags.length).toBe(2);
+  });
+
+  test("an extension change still expands its own real dependents", () => {
+    const flags = flagsFor("extensions/parser/src/index.ts");
+    expect(flags).toContain("parser");
+    expect(flags).toContain("schema"); // The inverted edge.
+    expect(flags).toContain("compiler"); // A genuine devDependency.
+    expect(flags).toContain("desktop"); // A genuine runtime dependency.
+  });
+});
+
+describe("lens-mutants", () => {
+  test("runs when studio is in the test set", () => {
+    expect(decide(["packages/studio/src/canvas/pane.ts"], workspaces).lensMutants).toBe(true);
+    expect(decide(["scripts/lib/png.ts"], workspaces).lensMutants).toBe(true);
+  });
+
+  test("does not run for a package studio merely depends on", () => {
+    // Studio IS retested for a markup change — markup is a real dependency — but the mutation
+    // Targets are studio's own source, and a markup edit cannot make one of those mutants
+    // Survive. Gating on the test set instead would fire this 87s job on most PRs in the repo.
+    expect(flagsFor("packages/markup/src/index.ts")).toContain("studio");
+    expect(decide(["packages/markup/src/index.ts"], workspaces).lensMutants).toBe(false);
+  });
+
+  test("does not run when studio is untouched", () => {
+    expect(decide(["docs/x.md"], workspaces).lensMutants).toBe(false);
+    expect(decide(["packages/server/src/server.ts"], workspaces).lensMutants).toBe(false);
+  });
+});
+
+describe("bundles use the DEPENDENCY closure, not the dependent closure", () => {
+  test("a studio change rebuilds only studio's bundle", () => {
+    expect(decide(["packages/studio/src/studio.ts"], workspaces).bundles).toEqual(["studio"]);
+  });
+
+  test("a schema change rebuilds all three, because all three bundle it", () => {
+    expect(decide(["packages/schema/src/schema.ts"], workspaces).bundles).toEqual([
+      "compiler",
+      "runtime",
+      "studio",
+    ]);
+  });
+
+  test("a runtime change rebuilds runtime, compiler and studio but not the reverse", () => {
+    const { bundles } = decide(["packages/runtime/src/runtime.ts"], workspaces);
+    expect(bundles).toContain("runtime");
+    expect(bundles).toContain("compiler");
+    expect(bundles).toContain("studio");
+  });
+
+  test("a server change rebuilds nothing — no bundle imports the server", () => {
+    expect(decide(["packages/server/src/server.ts"], workspaces).bundles).toEqual([]);
+  });
+
+  test("a suite-only edge does not rebuild a bundle", () => {
+    // Studio's tests read png.ts; studio's BUNDLE does not.
+    expect(decide(["scripts/lib/png.ts"], workspaces).bundles).toEqual([]);
+  });
+});
+
+describe("the rename ratchet", () => {
+  test("the repository as committed has no anchor problems", () => {
+    expect(anchorProblems(workspaces)).toEqual([]);
+  });
+
+  test("an edge whose evidence file has moved fails, naming the file and the edge", () => {
+    const moved: ExtraEdge[] = [
+      {
+        patterns: ["scripts/whatever.ts"],
+        seeds: ["packages/studio"],
+        evidence: ["packages/studio/tests/this-test-was-renamed.test.ts"],
+        why: "irrelevant",
+      },
+    ];
+    const problems = anchorProblems(workspaces, moved);
+    expect(problems.length).toBe(1);
+    expect(problems[0]).toContain("this-test-was-renamed.test.ts");
+    expect(problems[0]).toContain("packages/studio");
+  });
+
+  test("an edge seeding a workspace that no longer exists fails", () => {
+    const gone: ExtraEdge[] = [
+      {
+        patterns: ["x/**"],
+        seeds: ["packages/renamed-away"],
+        evidence: ["package.json"],
+        why: "irrelevant",
+      },
+    ];
+    expect(anchorProblems(workspaces, gone)[0]).toContain("packages/renamed-away");
+  });
+
+  test("a bundle naming a package that is not a workspace fails", () => {
+    const problems = anchorProblems(workspaces, [], ["compiler", "not-a-package"]);
+    expect(problems.length).toBe(1);
+    expect(problems[0]).toContain("not-a-package");
+  });
+});
+
+describe("combinations", () => {
+  test("a mixed diff unions its parts", () => {
+    const flags = flagsFor("docs/x.md", "packages/markup/src/index.ts", "examples/foo.json");
+    expect(flags).toContain("markup");
+    expect(flags).toContain("compiler");
+    expect(flags).toContain("import"); // Depends on markup.
+  });
+
+  test("one global path in a mixed diff still runs everything", () => {
+    expect(decide(["docs/x.md", "bun.lock"], workspaces).mode).toBe("all");
+  });
+});

--- a/scripts/ci/affected.ts
+++ b/scripts/ci/affected.ts
@@ -1,0 +1,443 @@
+/**
+ * Decides which CI jobs a pull request can actually fail, and emits that decision as GitHub Actions
+ * job outputs. Consumed by the `changes` job in .github/workflows/test.yml.
+ *
+ * The rule this implements: a check runs when its inputs changed, and not otherwise. The rule it
+ * does NOT implement: gating everything. Measured on green run 31489926926, lint is 1s, both
+ * typechecks are 5s, and all four docs gates together are 3s — while a fresh job costs ~15s to
+ * provision. Gating those would make CI slower. Only three things here are worth a gate: the
+ * per-workspace test matrix (0.3-5.3 min each), `check-lens-mutants` (87s), and the bundle builds
+ * (20s each). Everything else stays unconditional in the `checks` job.
+ *
+ * Correctness before economy. Three properties matter more than any minute saved:
+ *
+ * 1. The matrix is DERIVED from disk. The hand-maintained 18-entry list it replaces had no guard at
+ *    all: add a package, forget to list it, and it is never tested.
+ * 2. `package.json` is not the whole graph. Several suites reach across workspaces at the filesystem
+ *    level and are invisible to a dependency reader — see EXTRA_EDGES, where each one carries the
+ *    test file that proves it, asserted to exist on startup.
+ * 3. Unknown paths FAIL OPEN. A changed file matching no rule turns everything on rather than quietly
+ *    narrowing the run. New top-level directories therefore cost a full run, once, until someone
+ *    classifies them — which is the right direction to be wrong in.
+ *
+ * In CI it derives the diff from the merge base with the base branch. To see what a working diff
+ * would trigger, pipe one in:
+ *
+ *     git diff --name-only origin/main... | bun scripts/ci/affected.ts --stdin
+ */
+
+import { existsSync } from "node:fs";
+import { dependencyClosure, dependentClosure, readWorkspaces } from "../lib/workspaces.ts";
+import type { Workspace } from "../lib/workspaces.ts";
+
+/**
+ * A change to any of these invalidates every assumption below, so everything runs. The gate's own
+ * inputs are in here on purpose: a PR that edits the gate must not be graded by it.
+ */
+const GLOBAL = [
+  "package.json",
+  "bun.lock",
+  "bunfig.toml",
+  "tsconfig.json",
+  "types.d.ts",
+  ".oxlintrc.json",
+  ".oxlintrc.typecheck.json",
+  ".oxlintignore",
+  "flake.nix",
+  "flake.lock",
+  "bun.nix",
+  ".github/workflows/test.yml",
+  ".github/actions/**",
+  "scripts/ci/**",
+  "scripts/lib/workspaces.ts",
+];
+
+/**
+ * Dependency edges that exist in the filesystem but not in any `package.json`. Each declares the
+ * test file that justifies it; those files are asserted to exist at startup, so deleting one reds
+ * this script — the FIRST job in the graph — instead of silently un-gating a suite.
+ */
+export interface ExtraEdge {
+  /** Changed-path globs that trigger this edge. */
+  patterns: string[];
+  /** Workspace dirs to add to the test set (their dependents come along automatically). */
+  seeds: string[];
+  /** Files proving the edge is real. Asserted to exist. */
+  evidence: string[];
+  why: string;
+}
+
+const EXTRA_EDGES: ExtraEdge[] = [
+  {
+    patterns: [
+      "scripts/check-image-lock.ts",
+      "scripts/check-shot-contract.ts",
+      "scripts/check-command-levels.ts",
+      "scripts/check-chrome-budget.ts",
+      "scripts/lib/png.ts",
+      "scripts/screenshots/**",
+    ],
+    seeds: ["packages/studio"],
+    evidence: [
+      "packages/studio/tests/image-lock.test.ts",
+      "packages/studio/tests/shot-contract-diff-gaps.test.ts",
+      "packages/studio/tests/commands-ci-checks.test.ts",
+      "packages/studio/tests/automation-commands.test.ts",
+    ],
+    why: "Studio's suite imports these CI scripts directly and spawns two more of them, and reads the screenshot manifest and its contract fixtures.",
+  },
+  {
+    patterns: ["sites/*/project.json", "sites/test-blank/**"],
+    seeds: ["packages/studio"],
+    evidence: [
+      "packages/studio/tests/project-config.test.ts",
+      "packages/studio/tests/harness/load-fixture.ts",
+    ],
+    why: "project-config globs every committed sites/*/project.json as its only real-formatting fixture; the DOM harness loads sites/test-blank as its site.",
+  },
+  {
+    patterns: ["examples/**"],
+    seeds: ["packages/compiler"],
+    evidence: [
+      "packages/compiler/tests/cli.test.ts",
+      "packages/compiler/tests/compile-element.test.ts",
+    ],
+    why: "The CLI suite compiles examples/ as its fixture site, and compile-element loads components out of examples/components.",
+  },
+  {
+    patterns: ["extensions/*/src/**", "extensions/*/schemas/**"],
+    seeds: ["packages/schema"],
+    evidence: [
+      "packages/schema/tests/validate-project.test.ts",
+      "packages/schema/tests/class-schema-drift.test.ts",
+    ],
+    why: "An INVERTED edge: extensions depend on schema, yet schema's tests read parser's committed fragment and walk every extension's src for class definitions.",
+  },
+];
+
+/**
+ * Paths that are understood to affect no test workspace. Anything matching neither these, nor a
+ * workspace prefix, nor an extra edge, nor GLOBAL, turns everything on (see FAIL OPEN above).
+ */
+const NO_TESTS = [
+  "docs/**",
+  "specs/**",
+  "scripts/docs/**",
+  "sites/**",
+  ".github/**",
+  ".husky/**",
+  ".claude/**",
+  "branding/**",
+  "*.md",
+  "LICENSE",
+  "codecov.yml",
+  ".gitattributes",
+  ".gitignore",
+  ".oxfmtrc.json",
+  ".pre-commit-config.yaml",
+  "commitlint.config.js",
+  "release-please-config.json",
+  ".release-please-manifest.json",
+];
+
+/** Bundles built by bundle-analysis.yml, keyed by the workspace whose bundle it is. */
+const BUNDLES = ["compiler", "runtime", "studio"];
+
+function matches(path: string, patterns: string[]): boolean {
+  return patterns.some((p) => new Bun.Glob(p).match(path));
+}
+
+/** The workspace a path lives in, if any. */
+function owningWorkspace(path: string, workspaces: Workspace[]): string | undefined {
+  return workspaces.find((w) => path === w.dir || path.startsWith(`${w.dir}/`))?.dir;
+}
+
+/**
+ * Every anchor this script's correctness depends on. A rename that moves one of these reds the gate
+ * by name rather than degrading it to a narrower run nobody notices.
+ */
+export function anchorProblems(
+  workspaces: Workspace[],
+  edges: ExtraEdge[] = EXTRA_EDGES,
+  bundles: string[] = BUNDLES,
+): string[] {
+  const problems: string[] = [];
+
+  for (const edge of edges) {
+    for (const file of edge.evidence) {
+      if (!existsSync(file)) {
+        problems.push(
+          `EXTRA_EDGES evidence is gone: ${file}\n` +
+            `  That file is why ${edge.seeds.join(", ")} is retested for ${edge.patterns[0]}.\n` +
+            `  If the edge is genuinely gone, delete it from scripts/ci/affected.ts. If the test\n` +
+            `  simply moved, point the evidence at its new path.`,
+        );
+      }
+    }
+    for (const seed of edge.seeds) {
+      if (!workspaces.some((w) => w.dir === seed)) {
+        problems.push(`EXTRA_EDGES seeds a workspace that does not exist: ${seed}`);
+      }
+    }
+  }
+
+  // Every workspace the matrix will emit must carry a coverage threshold — CLAUDE.md's per-file
+  // Ratchet is enforced by each workspace's own bunfig, and a workspace without one is silently
+  // Exempt from the policy.
+  for (const w of workspaces) {
+    const bunfig = `${w.dir}/bunfig.toml`;
+    if (!existsSync(bunfig)) {
+      problems.push(
+        `${w.dir} has no bunfig.toml, so it has no coverageThreshold and the per-file coverage\n` +
+          `  ratchet does not apply to it. See CLAUDE.md, Testing & Coverage Policy.`,
+      );
+    }
+  }
+
+  for (const bundle of bundles) {
+    if (!workspaces.some((w) => w.flag === bundle)) {
+      problems.push(
+        `BUNDLES names '${bundle}', which is not a workspace. bundle-analysis.yml builds it, so\n` +
+          `  either the package was renamed or the workflow's matrix is stale.`,
+      );
+    }
+  }
+
+  return problems;
+}
+
+function assertAnchors(workspaces: Workspace[]): void {
+  const problems = anchorProblems(workspaces);
+  if (problems.length > 0) {
+    console.error(`affected.ts: ${problems.length} anchor(s) failed:\n\n${problems.join("\n\n")}`);
+    process.exit(1);
+  }
+}
+
+interface Decision {
+  mode: "all" | "affected";
+  reason: string;
+  testDirs: string[];
+  lensMutants: boolean;
+  bundles: string[];
+}
+
+export function decide(changed: string[], workspaces: Workspace[]): Decision {
+  const all = (reason: string): Decision => ({
+    mode: "all",
+    reason,
+    testDirs: workspaces.map((w) => w.dir),
+    lensMutants: true,
+    bundles: [...BUNDLES],
+  });
+
+  if (changed.length === 0) {
+    return {
+      mode: "affected",
+      reason: "no files changed",
+      testDirs: [],
+      lensMutants: false,
+      bundles: [],
+    };
+  }
+
+  // Two different things, deliberately kept apart.
+  //
+  // `changedWorkspaces` are packages whose own source moved. Their DEPENDENTS must be retested
+  // Too, because every package resolves its @jxsuite deps straight to `src/` and CI never builds
+  // First — a schema edit is observable in all seventeen suites downstream of it.
+  //
+  // `edgeTargets` are suites that read a file outside their own workspace. Only THAT suite is
+  // Affected; nothing downstream of it is. Expanding these was the first version's bug: it made
+  // Any extension source change retest all seventeen workspaces, because `class-schema-drift`
+  // Reads `extensions/*/src` and schema has sixteen dependents. Schema's TEST is affected;
+  // Schema's OUTPUT is not.
+  const changedWorkspaces = new Set<string>();
+  const edgeTargets = new Set<string>();
+  const reasons: string[] = [];
+
+  for (const path of changed) {
+    if (matches(path, GLOBAL)) {
+      return all(`${path} invalidates every assumption`);
+    }
+
+    const edge = EXTRA_EDGES.find((e) => matches(path, e.patterns));
+    if (edge) {
+      for (const seed of edge.seeds) {
+        if (!edgeTargets.has(seed)) {
+          edgeTargets.add(seed);
+          reasons.push(`${path} -> ${seed}`);
+        }
+      }
+      // Fall through: a path can be BOTH a workspace's own source and an edge trigger
+      // (`extensions/parser/src/**` changes parser and is read by schema's tests).
+    }
+
+    const owner = owningWorkspace(path, workspaces);
+    if (owner) {
+      changedWorkspaces.add(owner);
+      continue;
+    }
+
+    if (edge || matches(path, NO_TESTS)) {
+      continue;
+    }
+
+    // FAIL OPEN. A path nobody classified is a path whose blast radius nobody knows.
+    return all(`${path} matches no rule in affected.ts — running everything`);
+  }
+
+  const testDirs = [
+    ...dependentClosure(workspaces, changedWorkspaces).union(edgeTargets),
+  ].toSorted();
+
+  // A bundle rebuilds when the thing it bundles changes — the DEPENDENCY closure, the opposite
+  // Direction from which suites must be retested. Only real source changes count: an edge target
+  // Means someone's test reads a file, not that the bundle's input moved.
+  const bundles = BUNDLES.filter((flag) => {
+    const w = workspaces.find((x) => x.flag === flag)!;
+    const inputs = dependencyClosure(workspaces, [w.dir]);
+    return [...changedWorkspaces].some((s) => inputs.has(s));
+  });
+
+  return {
+    mode: "affected",
+    reason:
+      reasons.length > 0 ? reasons.join("; ") : `${changedWorkspaces.size} workspace(s) changed`,
+    testDirs,
+    // Studio's OWN tree, not merely "studio is being retested". The mutation targets are files
+    // Under packages/studio/src and the assertions are studio's own test files, so a change to
+    // Something studio merely depends on — markup, schema — cannot make a mutant survive that
+    // Would not have survived before. Gating on the test set instead would fire this 87s job on
+    // Most PRs in the repo, since studio sits downstream of nearly everything.
+    lensMutants: changedWorkspaces.has("packages/studio") || edgeTargets.has("packages/studio"),
+    bundles,
+  };
+}
+
+async function changedFiles(): Promise<string[]> {
+  if (Bun.argv.includes("--stdin")) {
+    const text = await Bun.stdin.text();
+    return text
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+  }
+
+  const baseRef = process.env.BASE_REF || "main";
+  const base = `origin/${baseRef}`;
+  const mergeBase = Bun.spawnSync(["git", "merge-base", base, "HEAD"]);
+  if (mergeBase.exitCode !== 0) {
+    console.error(`affected.ts: no merge base with ${base}; running everything`);
+    return [];
+  }
+  const diff = Bun.spawnSync([
+    "git",
+    "diff",
+    "--name-only",
+    mergeBase.stdout.toString().trim(),
+    "HEAD",
+  ]);
+  if (diff.exitCode !== 0) {
+    console.error("affected.ts: git diff failed; running everything");
+    return [];
+  }
+  return diff.stdout
+    .toString()
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+async function main(): Promise<void> {
+  const workspaces = await readWorkspaces();
+  assertAnchors(workspaces);
+
+  const event = process.env.GITHUB_EVENT_NAME ?? "";
+  let decision: Decision;
+
+  if (event && event !== "pull_request") {
+    // Push to main, the nightly cron, and manual dispatch all run everything. This is the
+    // Safety net for a gate mapping that has gone stale, and it is what keeps every Codecov
+    // Flag's baseline on main complete for `carryforward` to carry from (codecov.yml).
+    decision = {
+      mode: "all",
+      reason: `${event} is never gated`,
+      testDirs: workspaces.map((w) => w.dir),
+      lensMutants: true,
+      bundles: [...BUNDLES],
+    };
+  } else {
+    const changed = await changedFiles();
+    decision =
+      changed.length === 0 && event
+        ? {
+            mode: "all",
+            reason: "could not determine the diff",
+            testDirs: workspaces.map((w) => w.dir),
+            lensMutants: true,
+            bundles: [...BUNDLES],
+          }
+        : decide(changed, workspaces);
+  }
+
+  const byDir = new Map(workspaces.map((w) => [w.dir, w]));
+  const include = decision.testDirs.map((dir) => ({ dir, flag: byDir.get(dir)!.flag }));
+
+  const outputs: Record<string, string> = {
+    mode: decision.mode,
+    reason: decision.reason,
+    test_matrix: JSON.stringify({ include }),
+    has_tests: String(include.length > 0),
+    all_workspaces: JSON.stringify(workspaces.map((w) => w.flag)),
+    gate_lens_mutants: String(decision.lensMutants),
+    gate_bundle: JSON.stringify(decision.bundles),
+    has_bundle: String(decision.bundles.length > 0),
+  };
+
+  const outFile = process.env.GITHUB_OUTPUT;
+  if (outFile) {
+    await Bun.write(
+      outFile,
+      `${
+        ((await Bun.file(outFile).exists()) ? await Bun.file(outFile).text() : "") +
+        Object.entries(outputs)
+          .map(([k, v]) => `${k}=${v}`)
+          .join("\n")
+      }\n`,
+    );
+  } else {
+    for (const [k, v] of Object.entries(outputs)) {
+      console.log(`${k}=${v}`);
+    }
+  }
+
+  // A skipped job is only trustworthy if it says why it was skipped.
+  const ran = new Set(decision.testDirs);
+  const table = [
+    `### CI scope — \`${decision.mode}\``,
+    "",
+    decision.reason,
+    "",
+    "| workspace | tests |",
+    "|---|---|",
+    ...workspaces.map((w) => `| \`${w.flag}\` | ${ran.has(w.dir) ? "ran" : "not affected"} |`),
+    "",
+    `lens-mutants: ${decision.lensMutants ? "ran" : "not affected"} · ` +
+      `bundles: ${decision.bundles.length > 0 ? decision.bundles.join(", ") : "none"}`,
+  ].join("\n");
+
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (summary) {
+    await Bun.write(
+      summary,
+      `${((await Bun.file(summary).exists()) ? await Bun.file(summary).text() : "") + table}\n`,
+    );
+  } else {
+    console.error(`\n${table}`);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/ci/bundle-paths.test.ts
+++ b/scripts/ci/bundle-paths.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `bundle-analysis.yml` gates itself with a hand-written `paths:` list, because a workflow-level
+ * filter costs nothing while a gate job would cost ~15s to provision — but a hand-written list of
+ * package directories is exactly the thing that goes stale the moment someone adds a dependency.
+ *
+ * So it is checked against the graph. Give `@jxsuite/studio` a new dependency and forget this file,
+ * and the list no longer matches the closure: red, naming both sides.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { dependencyClosure, readWorkspaces } from "../lib/workspaces.ts";
+
+const WORKFLOW = ".github/workflows/bundle-analysis.yml";
+
+/** Paths in the filter that are not workspace globs, and so are not derivable from the graph. */
+const NON_WORKSPACE = ["bun.lock", ".github/workflows/bundle-analysis.yml"];
+
+interface Workflow {
+  on: { pull_request: { paths: string[] } };
+  jobs: { "bundle-analysis": { strategy: { matrix: { package: string[] } } } };
+}
+
+const workflow = Bun.YAML.parse(await Bun.file(WORKFLOW).text()) as Workflow;
+const workspaces = await readWorkspaces();
+
+describe("bundle-analysis.yml paths", () => {
+  const bundles = workflow.jobs["bundle-analysis"].strategy.matrix.package;
+
+  test("every bundle in the matrix is a real workspace", () => {
+    for (const bundle of bundles) {
+      expect(workspaces.some((w) => w.flag === bundle)).toBe(true);
+    }
+  });
+
+  test("the paths filter is exactly the dependency closure of the bundles it builds", () => {
+    const expected = new Set<string>();
+    for (const bundle of bundles) {
+      const w = workspaces.find((x) => x.flag === bundle)!;
+      for (const dir of dependencyClosure(workspaces, [w.dir])) {
+        expected.add(`${dir}/**`);
+      }
+    }
+
+    const committed = workflow.on.pull_request.paths.filter((p) => !NON_WORKSPACE.includes(p));
+
+    // Named both ways round, so the failure says which side to fix.
+    const missing = [...expected].filter((p) => !committed.includes(p)).toSorted();
+    const extra = committed.filter((p) => !expected.has(p)).toSorted();
+    expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+  });
+
+  test("the lockfile and the workflow itself stay in the filter", () => {
+    for (const path of NON_WORKSPACE) {
+      expect(workflow.on.pull_request.paths).toContain(path);
+    }
+  });
+});

--- a/scripts/lib/workspaces.test.ts
+++ b/scripts/lib/workspaces.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { dependencyClosure, dependentClosure, readWorkspaces } from "./workspaces.ts";
+import type { Workspace } from "./workspaces.ts";
+
+/** A hand-built graph, so the closure tests do not move when the real repo does. */
+function fixture(): Workspace[] {
+  const w = (dir: string, deps: string[] = [], devDeps: string[] = []): Workspace => ({
+    dir,
+    name: `@jxsuite/${dir.split("/")[1]}`,
+    flag: dir.split("/")[1]!,
+    publishable: true,
+    deps,
+    devDeps,
+  });
+  return [
+    w("packages/base"),
+    w("packages/mid", ["@jxsuite/base"]),
+    w("packages/leaf", ["@jxsuite/mid"]),
+    w("packages/sibling", ["@jxsuite/base"]),
+    // Depends on nothing shipped, but its TESTS use mid.
+    w("extensions/tester", [], ["@jxsuite/mid"]),
+  ];
+}
+
+describe("readWorkspaces", () => {
+  test("reads every packages/* and extensions/* member of the real repo", async () => {
+    const ws = await readWorkspaces();
+    const flags = ws.map((x) => x.flag);
+    expect(flags).toContain("schema");
+    expect(flags).toContain("studio");
+    expect(flags).toContain("parser");
+    // Every workspace directory in the repo is a workspace here; if this drifts, the CI matrix
+    // Silently loses a package (the exact failure the derived matrix exists to prevent).
+    expect(ws.length).toBeGreaterThanOrEqual(18);
+  });
+
+  test("is sorted by dir, so callers need not sort", async () => {
+    const ws = await readWorkspaces();
+    expect(ws.map((x) => x.dir)).toEqual(ws.map((x) => x.dir).toSorted());
+  });
+
+  test("separates runtime deps from dev deps", async () => {
+    const ws = await readWorkspaces();
+    const compiler = ws.find((x) => x.flag === "compiler")!;
+    expect(compiler.deps).toContain("@jxsuite/schema");
+    // Compiler dev-depends on parser, an EXTENSION. specs/extensions.md §2 forbids that as a
+    // Runtime dep, so if this ever appears in `deps` the dep-rules gate is broken too.
+    expect(compiler.devDeps).toContain("@jxsuite/parser");
+    expect(compiler.deps).not.toContain("@jxsuite/parser");
+  });
+
+  test("marks desktop unpublishable and schema publishable", async () => {
+    const ws = await readWorkspaces();
+    expect(ws.find((x) => x.flag === "desktop")!.publishable).toBe(false);
+    expect(ws.find((x) => x.flag === "schema")!.publishable).toBe(true);
+  });
+
+  test("returns nothing for a root with no workspace directories", async () => {
+    expect(await readWorkspaces("/nonexistent-root")).toEqual([]);
+  });
+});
+
+describe("dependentClosure", () => {
+  const ws = fixture();
+
+  test("includes the seed itself", () => {
+    expect([...dependentClosure(ws, ["packages/leaf"])]).toEqual(["packages/leaf"]);
+  });
+
+  test("walks transitively upward", () => {
+    expect([...dependentClosure(ws, ["packages/base"])].toSorted()).toEqual([
+      "extensions/tester",
+      "packages/base",
+      "packages/leaf",
+      "packages/mid",
+      "packages/sibling",
+    ]);
+  });
+
+  test("counts a devDependency, because tests import them", () => {
+    expect([...dependentClosure(ws, ["packages/mid"], "all")]).toContain("extensions/tester");
+  });
+
+  test("ignores devDependencies when asked for the runtime graph only", () => {
+    expect([...dependentClosure(ws, ["packages/mid"], "runtime")]).not.toContain(
+      "extensions/tester",
+    );
+  });
+
+  test("ignores a dependency name that is not a workspace", () => {
+    const external = [{ ...ws[0]!, deps: ["@jxsuite/published-elsewhere"] }] satisfies Workspace[];
+    expect([...dependentClosure(external, ["packages/base"])]).toEqual(["packages/base"]);
+  });
+
+  test("terminates on a cycle", () => {
+    const cyclic: Workspace[] = [
+      { ...ws[0]!, deps: ["@jxsuite/mid"] },
+      { ...ws[1]!, deps: ["@jxsuite/base"] },
+    ];
+    expect([...dependentClosure(cyclic, ["packages/base"])].toSorted()).toEqual([
+      "packages/base",
+      "packages/mid",
+    ]);
+  });
+});
+
+describe("dependencyClosure", () => {
+  const ws = fixture();
+
+  test("walks downward, the opposite direction from dependentClosure", () => {
+    expect([...dependencyClosure(ws, ["packages/leaf"])].toSorted()).toEqual([
+      "packages/base",
+      "packages/leaf",
+      "packages/mid",
+    ]);
+  });
+
+  test("a root package pulls in nothing", () => {
+    expect([...dependencyClosure(ws, ["packages/base"])]).toEqual(["packages/base"]);
+  });
+
+  test("defaults to runtime edges, because a bundle ships runtime deps only", () => {
+    expect([...dependencyClosure(ws, ["extensions/tester"])]).toEqual(["extensions/tester"]);
+    expect([...dependencyClosure(ws, ["extensions/tester"], "all")].toSorted()).toEqual([
+      "extensions/tester",
+      "packages/base",
+      "packages/mid",
+    ]);
+  });
+});

--- a/scripts/lib/workspaces.ts
+++ b/scripts/lib/workspaces.ts
@@ -1,0 +1,163 @@
+/**
+ * The one reader of the `@jxsuite` workspace dependency graph.
+ *
+ * Three scripts had grown their own copy of "readdir packages/ and extensions/, parse each
+ * package.json, keep the `@jxsuite/*` deps": `publish-order.ts`, `check-dep-rules.ts`, and (would
+ * have been) `ci/affected.ts`. They disagree in ways that matter — publish-order counts runtime
+ * deps only, dep-rules counts runtime deps and scans source, and the CI gate needs devDependencies
+ * too. Divergence between them is silent by construction, since each is right about its own
+ * question and wrong about the others', so the graph is read once here and each caller selects the
+ * edge set its question actually needs.
+ *
+ * `deps` is the PUBLISH graph: dependencies, peerDependencies, optionalDependencies. `devDeps` is
+ * what makes the difference for TESTING: a package's tests import its devDependencies, so
+ * `compiler` (dev: connector, parser), `server` (dev: auth, connector, parser) and
+ * `formulas`/`parser` (dev: runtime) must be retested when those change, even though none of it
+ * ships.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+export const WORKSPACE_ROOTS = ["packages", "extensions"];
+
+export interface Workspace {
+  /** Full repo-relative path, e.g. "packages/server". */
+  dir: string;
+  /** The npm name, e.g. "@jxsuite/server". */
+  name: string;
+  /** Codecov flag / artifact name. Flags cannot contain "/", so this is the basename. */
+  flag: string;
+  /** True when the package is published to npm (not private, declares publishConfig). */
+  publishable: boolean;
+  /** Runtime dependency names: dependencies, peerDependencies, optionalDependencies. */
+  deps: string[];
+  /** Dev dependency names. Tests import these; the publish graph does not. */
+  devDeps: string[];
+}
+
+function jxOnly(...records: (Record<string, string> | undefined)[]): string[] {
+  const names = new Set<string>();
+  for (const record of records) {
+    for (const name of Object.keys(record ?? {})) {
+      if (name.startsWith("@jxsuite/")) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names];
+}
+
+/**
+ * Every workspace under `packages/` and `extensions/`, sorted by dir so callers are deterministic
+ * without each having to remember to sort.
+ */
+export async function readWorkspaces(root = "."): Promise<Workspace[]> {
+  const found: Workspace[] = [];
+  for (const group of WORKSPACE_ROOTS) {
+    const groupDir = join(root, group);
+    if (!existsSync(groupDir)) {
+      continue;
+    }
+    for (const entry of readdirSync(groupDir)) {
+      const file = Bun.file(join(groupDir, entry, "package.json"));
+      if (!(await file.exists())) {
+        continue;
+      }
+      const j = await file.json();
+      found.push({
+        dir: `${group}/${entry}`,
+        name: j.name,
+        flag: entry,
+        publishable: j.private !== true && j.publishConfig != null,
+        deps: jxOnly(j.dependencies, j.peerDependencies, j.optionalDependencies),
+        devDeps: jxOnly(j.devDependencies),
+      });
+    }
+  }
+  return found.toSorted((a, b) => a.dir.localeCompare(b.dir));
+}
+
+/**
+ * Reverse-edge closure: given some workspaces, every workspace whose tests could observe a change
+ * in them. `edges` picks which dependency kinds count — the CI gate passes "all", a publish-order
+ * question would pass "runtime".
+ *
+ * Returns dirs, including the seeds themselves.
+ */
+export function dependentClosure(
+  workspaces: Workspace[],
+  seedDirs: Iterable<string>,
+  edges: "runtime" | "all" = "all",
+): Set<string> {
+  const byName = new Map(workspaces.map((w) => [w.name, w]));
+  /** Package name -> dirs of the workspaces that depend on it. */
+  const dependents = new Map<string, string[]>();
+  for (const w of workspaces) {
+    const names = edges === "all" ? [...w.deps, ...w.devDeps] : w.deps;
+    for (const dep of names) {
+      if (!byName.has(dep)) {
+        continue; // A name with no workspace: published-only, not part of this graph.
+      }
+      const list = dependents.get(dep) ?? [];
+      list.push(w.dir);
+      dependents.set(dep, list);
+    }
+  }
+
+  const byDir = new Map(workspaces.map((w) => [w.dir, w]));
+  const reached = new Set<string>();
+  const queue = [...seedDirs];
+  while (queue.length > 0) {
+    const dir = queue.shift()!;
+    if (reached.has(dir)) {
+      continue;
+    }
+    reached.add(dir);
+    const w = byDir.get(dir);
+    if (!w) {
+      continue;
+    }
+    for (const next of dependents.get(w.name) ?? []) {
+      if (!reached.has(next)) {
+        queue.push(next);
+      }
+    }
+  }
+  return reached;
+}
+
+/**
+ * Forward closure: a workspace plus everything it imports. This is the direction a BUNDLE cares
+ * about — a bundle of studio must be rebuilt when studio or anything studio pulls in changes, which
+ * is the exact opposite of which suites must be retested.
+ */
+export function dependencyClosure(
+  workspaces: Workspace[],
+  seedDirs: Iterable<string>,
+  edges: "runtime" | "all" = "runtime",
+): Set<string> {
+  const byName = new Map(workspaces.map((w) => [w.name, w]));
+  const byDir = new Map(workspaces.map((w) => [w.dir, w]));
+  const reached = new Set<string>();
+  const queue = [...seedDirs];
+  while (queue.length > 0) {
+    const dir = queue.shift()!;
+    if (reached.has(dir)) {
+      continue;
+    }
+    reached.add(dir);
+    const w = byDir.get(dir);
+    if (!w) {
+      continue;
+    }
+    const names = edges === "all" ? [...w.deps, ...w.devDeps] : w.deps;
+    for (const name of names) {
+      const dep = byName.get(name);
+      if (dep && !reached.has(dep.dir)) {
+        queue.push(dep.dir);
+      }
+    }
+  }
+  return reached;
+}

--- a/scripts/publish-order.ts
+++ b/scripts/publish-order.ts
@@ -18,45 +18,13 @@
 //
 // Usage: PATHS_RELEASED='["packages/server","extensions/parser"]' bun scripts/publish-order.ts
 
-import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+// The graph itself is read by scripts/lib/workspaces.ts, which is also what the CI gate uses.
+// Publishing asks a narrower question than testing does — only RUNTIME deps decide the order in
+// Which npm must receive packages, since devDependencies never ship — so this file reads `deps`
+// And ignores `devDeps`.
+import { readWorkspaces } from "./lib/workspaces.ts";
 
-const WORKSPACE_ROOTS = ["packages", "extensions"];
-
-interface Pkg {
-  dir: string; // Full repo-relative path, e.g. "packages/server"
-  name: string;
-  publishable: boolean;
-  deps: string[]; // @jxsuite/* runtime dependency package names (deduped)
-}
-
-const pkgs: Pkg[] = [];
-for (const root of WORKSPACE_ROOTS) {
-  if (!existsSync(root)) {
-    continue;
-  }
-  for (const entry of readdirSync(root)) {
-    const file = Bun.file(join(root, entry, "package.json"));
-    if (!(await file.exists())) {
-      continue;
-    }
-    const j = await file.json();
-    const deps = new Set(
-      [
-        ...Object.keys(j.dependencies ?? {}),
-        ...Object.keys(j.peerDependencies ?? {}),
-        ...Object.keys(j.optionalDependencies ?? {}),
-      ].filter((d) => d.startsWith("@jxsuite/")),
-    );
-    pkgs.push({
-      dir: `${root}/${entry}`,
-      name: j.name,
-      publishable: j.private !== true && j.publishConfig != null,
-      deps: [...deps],
-    });
-  }
-}
-
+const pkgs = await readWorkspaces();
 const byName = new Map(pkgs.map((p) => [p.name, p]));
 const publishable = pkgs.filter((p) => p.publishable);
 const pubNames = new Set(publishable.map((p) => p.name));


### PR DESCRIPTION
Every PR currently spawns the entire suite regardless of what it touched: 18 test matrix jobs + `checks` + `coverage-comment` from `test.yml`, 3 more from `bundle-analysis.yml`, neither with a concurrency group. Last 7 days: **55 Test runs, 55 Bundle Analysis, 52 Screenshots.**

The prompting case had a specific root cause. `screenshots.yml` listed **itself** in its own `paths:`, so a dependabot action bump booted the Puppeteer container, re-captured 61 shots and pushed the result onto the bot's branch — which is how #131, titled *"bump actions/upload-artifact from 4 to 7"*, merged 26 re-captured PNGs and drew a "+16.2MB bundle" comment from Codecov.

## Where the time actually goes

Measured on green run 31489926926. This table is why the PR is shaped the way it is:

| step | time |
|---|---|
| `actions/checkout` (`fetch-depth: 0`) | **28s** |
| `bun install --frozen-lockfile` | 7s |
| **`check-lens-mutants`** | **87s** |
| `schema:validate-all` | 17s |
| lint, dep-rules, command-levels, chrome-budget, shot-contract, pane-singletons, icons, typecheck ×2, lint:typecheck, docs:verify, docs:claims, docs:status, docs:spec-release, schema:verify | **22s combined** |

A fresh job costs ~15s to provision. So `checks` is **not** split by concern and those checks are **not** gated — doing so would cost time. Two things changed instead: the full clone became blobless (28s → ~4s) and the 87s mutation gate became its own gated job.

## What is gated

Only three things: the per-workspace test matrix, `check-lens-mutants`, and the bundle builds.

The matrix is **derived** from the workspace graph rather than hand-listed. That is a correctness win independent of any minute saved — the 18-entry list it replaces had no guard, so adding a package and forgetting to list it meant it was simply never tested.

## package.json is not the whole graph

Several suites reach across workspaces at the filesystem level. Each edge is declared with the test file that proves it:

- studio's suite imports `scripts/check-image-lock`, `check-shot-contract` and `lib/png`, spawns `check-command-levels` and `check-chrome-budget`, and reads the screenshot manifest and contract fixtures
- studio's `project-config` globs every committed `sites/*/project.json`; its DOM harness loads `sites/test-blank`
- compiler's CLI suite compiles `examples/` as its fixture site
- schema's tests read parser's committed fragment and walk every extension's `src` — an **inverted** edge

That last one is why an extra edge is terminal. Seeding schema *and expanding its dependents* made any extension source change retest all 17 workspaces: schema's TEST is affected, schema's OUTPUT is not.

## Four ways a rename fails loudly

1. **Anchors** — every edge's cited test file is `existsSync`-checked before any other job starts.
2. **Derived-matrix assertion** — every workspace must carry a `bunfig.toml` coverage threshold.
3. **Golden tests** pinned to the real on-disk graph, so a rename moves the expectations.
4. **Unclassified paths fail OPEN** — `mode=all`, never a narrower run.

Plus `bundle-paths.test.ts`, which asserts `bundle-analysis.yml`'s committed `paths:` list equals the computed dependency closure, reporting `missing`/`extra`. Verified by deleting a line and watching it name the line.

## Also in here

- **concurrency groups** on both big workflows, `cancel-in-progress` on PRs only — never on main, where release-please and the Codecov baselines need every commit complete.
- **dependabot** batches github-actions weekly instead of one PR per action daily.
- **codecov.yml** with `carryforward: true`, landed before any gating so a skipped workspace never reports an invented drop.
- **`bun test --isolate scripts`** — `scripts/` has no coverage workspace and the matrix only runs `bun test` with cwd *inside* a workspace, so five existing test files ran in **no CI lane at all**. Now 149 tests across 9 files.
- **`.github/actions/setup-bun`** holds the `1.3.13` pin previously copied across five workflows.

## Behaviour

| event | scope |
|---|---|
| `pull_request` | gated; `ci` always reports |
| push to `main` | **ungated** — the stale-mapping safety net, and what keeps Codecov's per-flag baseline complete |
| `workflow_dispatch` / cron | ungated |

`ci` is the one stable name to make a required status check later. It tests for failure/cancelled rather than requiring success, because `skipped` is the point.

This PR touches `.github/actions/**`, so it correctly grades **itself** as `mode=all` and runs the full matrix.

## Verification

- `bun test --isolate scripts` — 149 pass
- `actionlint` clean on `test.yml` and `bundle-analysis.yml`
- `publish-order.ts` moved onto the shared graph reader and emits a **byte-identical** ordering for all 17 publishable packages
- `docs:verify`, `docs:claims`, `docs:status`, `lint`, `typecheck`, `check-dep-rules` all green locally

**Pre-existing and not touched here:** `lint:typecheck` fails on `packages/studio/tests/ai-panel.test.ts:712` (`no-floating-promises`) on `main` too, which is why Test is currently red there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)