### PR TITLE
test: CI scope probe — docs-only diff (do not merge)

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -33,3 +33,5 @@ The visual editor only runs as the desktop app above — there's no way to insta
 ## Next
 
 Ready to build something? Continue to **[Your first project](/docs/start/first-project)**.
+
+<!-- CI scope probe: docs-only diff. Delete this branch. -->


### PR DESCRIPTION
Verification for #133, step 5. Based on **and targeting** `ci/targeted-checks`, so GitHub evaluates the gated workflow — an earlier attempt branched from `main` and got main's ungated one.

Entire diff: one comment line in `docs/start/install.md`.

**Expected:** `changes`, `checks` and `ci` only. Zero test matrix jobs, no `lens-mutants`, no `coverage-comment`, no Bundle Analysis, no Screenshots. On `main` today this same diff runs 18 test jobs + 3 bundle jobs.

Delete once observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)