### PR TITLE
ci: name a runner crash as a crash, and cap a hung test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,12 @@ jobs:
     # A `strategy.matrix` built from an empty include is a workflow ERROR, not a skipped job.
     if: needs.changes.outputs.has_tests == 'true'
     runs-on: ubuntu-latest
+    # The slowest workspace in this matrix is studio at ~6 minutes; every other one is under a
+    # minute. The cap is not a performance budget, it is a liveness one: on 19 Aug the compiler
+    # job — a 40-second job — sat inside `bun test` for over an hour, and with GitHub's 360-minute
+    # default it would have held the `ci` required check pending for six. A hung runner should
+    # report a red X while someone is still looking at the PR.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       # dir = workspace path (packages/* core, extensions/* extensions);
@@ -67,9 +73,20 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
+          status=0
           bun test --isolate --coverage \
             --reporter=junit --reporter-outfile=junit.xml \
-            2>&1 | tee /tmp/test-output.txt
+            2>&1 | tee /tmp/test-output.txt || status=$?
+          # An exit status above 128 is a SIGNAL: the test RUNNER died, and the counts above it
+          # are the files that happened to finish first, not a verdict on the suite. Bun has
+          # trapped this way on main three times since 14 Aug (133 = SIGTRAP, ~10s in, studio,
+          # never with a failing test and never on a diff that touched it) — and the only trace
+          # it leaves is one shell line buried mid-log, so the job reads exactly like a broken
+          # test. Say which it was, here, where the failure is annotated.
+          if [ "$status" -gt 128 ]; then
+            echo "::error::bun test was killed by signal $((status - 128)) (exit $status) in ${{ matrix.package.dir }} — the runner crashed partway through, so no test reported this. Treat the counts above as a partial run, not a result."
+          fi
+          exit "$status"
         working-directory: ${{ matrix.package.dir }}
       - run: bun scripts/check-coverage-manifest.ts ${{ matrix.package.dir }}
       - name: Upload coverage reports to Codecov
@@ -100,7 +117,11 @@ jobs:
           # dashes / header / dashes / rows / dashes.
           awk '/^-+\|/ { n++; print; if (n == 3) exit; next } n >= 1' /tmp/test-output.txt \
             > /tmp/coverage-report/${{ matrix.package.flag }}.txt
-          tests=$(grep -E '^ [0-9]+ (pass|fail)' /tmp/test-output.txt | sed 's/^ *//' | awk '{printf "%s%s", sep, $0; sep=", "}')
+          # `|| true`, because this step runs `if: always()` and a run that DIED has no summary
+          # line to grep: under `bash -e -o pipefail` the empty grep failed the assignment, so a
+          # crashed suite painted a second red X on a diagnostics step and buried the first.
+          tests=$(grep -E '^ [0-9]+ (pass|fail)' /tmp/test-output.txt | sed 's/^ *//' | awk '{printf "%s%s", sep, $0; sep=", "}' || true)
+          tests=${tests:-'no test summary — the run did not finish'}
           all=$(grep '^All files' /tmp/coverage-report/${{ matrix.package.flag }}.txt || echo 'no coverage data')
           {
             echo "### \`${{ matrix.package.flag }}\` coverage"


### PR DESCRIPTION
## What broke on main this week

Three different-looking red X's, three different causes. Two are already fixed on `main`; this PR is about the third and about making it legible.

| Failure | Status |
| --- | --- |
| `checks` → `schema:verify` (missing `scroll-axis-lock` / `scrollAxisLock` in 26 entry documents) | **Already fixed** by #142 (`c06ae09`). Verified green locally: `bun run schema:verify` → *26 projects regenerated, 0 failing*. |
| `Screenshots` lane, 4 red shots (`block-action-bar`, `slash-menu`, `inline-editing`, `media-picker`) | **Already fixed** by `50f4168` + `b945a1d`. The failing nightly ran on `cc77a1fb`, which predates both. |
| `test (packages/studio)` → **exit 133, `Trace/breakpoint trap (core dumped)`** | Upstream Bun crash — not fixed here, but no longer silent. |
| `test (packages/compiler)` hung >1 h inside `bun test` (normally 40 s) | Not fixed here; now bounded to 20 min. |

## The crash

`bun test --isolate` has trapped three times on `main` since 14 Aug:

| Commit | Date | Files completed before the trap |
| --- | --- | --- |
| `b576cbb2` | 14 Aug 17:12 | 44 |
| `9256a797` | 19 Aug 18:40 | 46 |
| `c06ae09` | 19 Aug 20:37 | 46 |

Every one is signal 5 (SIGTRAP) about ten seconds in, with **zero failing tests** and no crash report. It is not the diff: `7587404` and `c06ae09` have a byte-identical `packages/studio` tree, and `7587404` ran 8932 tests across 424 files green forty minutes earlier.

Ruled out locally on the pinned Bun 1.3.13, running CI's command, CI's `| tee` pipeline and CI's own discovery — **8932 tests across 424 files, peak RSS 4.0 GB, no crash**, the same count CI's green run reports:

- **Not the suite.** It passes in full, repeatedly, including in CI's exact file order.
- **Not memory.** Peak is 637 MB at 46 files — the point where CI dies — and 4.0 GB for the whole run, on a 16 GB runner.
- **Not a specific file.** The first 46 files in CI's order, three consecutive runs, no crash.

So it is a Bun-level fault this repo cannot fix, and the decision about what to do (pin bump to 1.3.14 + coverage re-baseline, or a crash-only retry) belongs to a human. What this PR fixes is that the crash was **indistinguishable from a broken test** — the only trace was one shell line mid-log.

## What this changes

- **`Test with coverage`** captures the exit status; any status above 128 is annotated as the signal it was, naming the workspace, and the step still exits with that status.
- **`Extract coverage report`** tolerates a missing summary line. It runs `if: always()`, and under `bash -e -o pipefail` an empty `grep` failed the assignment — so a crashed suite painted a **second** red X on a diagnostics step, on top of the real one.
- **`timeout-minutes: 20`** on the test matrix. Triple the slowest workspace (studio, ~6 min); the compiler hang would otherwise have held the `ci` required check pending for GitHub's 360-minute default.

## Verification

Each shell path simulated under GitHub's own `bash --noprofile --norc -e -o pipefail`:

| Case | Step exit | Annotation |
| --- | --- | --- |
| Runner killed by SIGTRAP | 133 | `bun test was killed by signal 5 (exit 133) in packages/studio — …` |
| Ordinary test failure | 1 | none |
| Success | 0 | none |

The extract step was replayed against real `bun test` output and produces a byte-identical summary; against crashed output it now exits 0 with *"no test summary — the run did not finish"* instead of failing.

No verdict changes: a failing test still fails the way it always did.

## Specs & docs

None. `bun run docs:sync` reports no association for a workflow-only change, and this alters no product behaviour, spec contract, or documented interface.