### PR TITLE
fix(lint): exempt the repo-root entrypoints from the type-aware no-unsafe rules

### DIFF
--- a/.oxlintrc.typecheck.json
+++ b/.oxlintrc.typecheck.json
@@ -30,7 +30,24 @@
       // codegen scripts sit outside the tsconfig project (tsc skips them), so
       // tsgolint sees error-types for their imports. The no-unsafe-* family is
       // therefore src-only; promise safety still applies everywhere.
-      "files": ["**/tests/**/*.*", "**/*.test.*", "**/scripts/**/*.*", "**/bin/**/*.*"],
+      //
+      // The repo-root entrypoints are outside it for the same reason and were
+      // simply missed: tsconfig.json sets `allowJs: false` and its `include`
+      // starts at packages/ and extensions/, so a root-level `.js` file is in
+      // no project at all and EVERY expression in it types as `error`. That is
+      // not a latent bug the rule is catching — there is no annotation or
+      // rewrite that fixes it, because the file has no program. `server.js`
+      // proved it: adding `exampleRoutes()` in 7fb3669a turned three ordinary
+      // lines (`new Bun.Glob(...)`, the `const` that takes its result, and a
+      // `.length` on that) into three errors and reddened main.
+      "files": [
+        "**/tests/**/*.*",
+        "**/*.test.*",
+        "**/scripts/**/*.*",
+        "**/bin/**/*.*",
+        "./server.js",
+        "./commitlint.config.js"
+      ],
       "rules": {
         "typescript/no-unsafe-assignment": "off",
         "typescript/no-unsafe-call": "off",


### PR DESCRIPTION
`main` has been red since **7fb3669a**. `bun run lint:typecheck` fails, which fails the whole `checks` job — and because the step sits two-thirds of the way down that job, the **eight steps after it have not run since**: `docs:verify`, `docs:claims`, `docs:status`, `docs:markdown`, `docs:standards`, `docs:spec-release`, `schema:validate-all`, `schema:verify`.

```
server.js:74:10  Unsafe call of a(n) `error` type typed value.
server.js:80:7   Unsafe assignment of an error typed value.
server.js:81:12  Unsafe member access .length on an `error` typed value.
```

## Why it is not a real finding

`tsconfig.json` sets `allowJs: false`, and its `include` starts at `packages/` and `extensions/`. **`server.js` is therefore in no TypeScript project at all**, so tsgolint types *every* expression in it as `error` — and the `no-unsafe-*` family fires on whichever ones happen to reach a call, an assignment, or a member access. 7fb3669a added `exampleRoutes()` and supplied all three in one commit:

```js
return [...new Bun.Glob("**/index.html").scanSync(dist)]   // call
const routes = exampleRoutes();                            // assignment
if (routes.length === 0) {                                 // member access
```

**No annotation or rewrite fixes it, because the file has no program.** I tried the obvious one — replacing `new Bun.Glob(...)` with a named `import { Glob } from "bun"` — and the same three errors survive at the shifted line numbers.

## The fix

`.oxlintrc.typecheck.json` already carries this exact carve-out, and already explains it:

> Package `bin/` codegen scripts sit outside the tsconfig project (tsc skips them), so tsgolint sees error-types for their imports. The `no-unsafe-*` family is therefore src-only; promise safety still applies everywhere.

The repo-root entrypoints are outside the project for precisely that reason and were simply missed by the glob list (`**/tests/**`, `**/*.test.*`, `**/scripts/**`, `**/bin/**` — a root-level file matches none of them). They join it, **anchored to the root** as `./server.js` so a future `packages/*/server.js` is not silently exempted along with it.

Promise safety (`no-floating-promises`, `await-thenable`) still applies to these files, exactly as it does to the existing entries.

## Verification

Confirmed by **negative control**, not by the absence of output: pointing the entry at `./NOT-server.js` brings all three errors straight back, so it is the glob match doing the work and not some incidental change.

All **twenty** steps of the `checks` job pass locally — including the eight that had not run since the breakage. `schema:verify` regenerates 26 projects with no diff; `docs:verify` is clean on a clean tree.

## The alternative, deliberately not taken

The other fix is to bring `server.js` into a project so the rules become meaningful there — convert it to `.ts` **and** extend the tsconfig `include` past `packages/`/`extensions/` to reach the repo root (converting alone changes nothing; root-level `.ts` is not in `include` either). That is a larger and more opinionated change to the project layout than unbreaking CI warrants, so this PR matches the policy the config already documents. Happy to do it that way instead if you'd rather the dev-server entrypoint were type-checked for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
