### PR TITLE
build: stop a workspace resolving a dependency its own manifest rules…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,9 @@
 bunx nano-staged
+# Self-healing (never blocks): a workspace resolving a dependency its own manifest rules out.
+# Left behind by installs from before the hoisted-linker switch, and by any install that
+# rebuilds the isolated layout — Studio runs `bun install` in starter roots. Removing the
+# entry is instant and needs no reinstall; resolution falls through to the root copy.
+bun scripts/check-workspace-links.ts --fix || true
 # Advisory (never blocks): staged source files whose docs/specs aren't in the commit
 bun scripts/docs/check-doc-sync.ts --staged || true
 # Advisory (never blocks): a staged spec whose body changed but wasn't released.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,32 @@ schema narrower than the starter's own content for six weeks.
   their generators. `schema:validate-all` answers a different question (documents against schemas)
   and cannot see a stale schema.
 
+### The other half: a workspace shadowing the root install
+
+Same shape, different cause, different guard — `scripts/check-workspace-links.ts`, run as
+`bun run links:check` (report) or `bun run links:clean` (remove).
+
+Bun's `isolated` linker points every workspace's `node_modules` at a store under
+`node_modules/.bun/`. This repo links **hoisted** (`bunfig.toml`, oven-sh/bun#23615), which writes
+real directories into the ROOT `node_modules/` and touches a workspace's own only for a conflict it
+cannot hoist. A leftover from the isolated era is therefore in no later install's plan, so nothing
+rewrites or removes it — and resolution walks UP from the importing file, so the leftover answers
+first. `packages/schema` was resolving `@webref/css` 8.5.8 against a declared `^8.7.1`, which made
+`schema:verify` fail locally with a diff nobody authored; `packages/studio` was two majors behind on
+`@atlaskit/pragmatic-drag-and-drop`, under the drag-and-drop tests.
+
+- **The manifest decides what may be deleted, not the file type.** A nested copy that satisfies the
+  workspace's declared range is the answer that workspace asked for — `packages/import` pins
+  `puppeteer-core: ^24.9.0` while the root holds 25.7.0, and its own copy must survive. Only a copy
+  the declared range _rules out_ is stale. A leftover nothing declares is judged by where it points:
+  a symlink into the isolated store, under a hoisted linker, belongs to an abandoned layout.
+- **Removing one is a single `rm` of the entry, never the tree**, and needs no reinstall —
+  resolution falls through to the root copy immediately.
+- It runs itself: `postinstall` (where the staleness appears) and a non-blocking `pre-commit` step.
+  Both use `--fix`; the check takes ~20ms.
+- **CI never sees this** — it installs clean — so there is no CI lane, and a green PR is no evidence
+  your tree is right. That is what makes it worth automating locally.
+
 ## Specs & User-Documentation Policy
 
 Specs (`/specs`, §-numbered) are the source of truth; user docs (`/docs`, published at jxsuite.com/docs) must track shipped behavior. Every plan for a behavior-changing task MUST include a "Specs & docs" step, and the change set must land code, spec edits, and docs-page updates together.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:fix": "oxlint --fix .",
     "lint:typecheck": "oxlint --type-aware -c .oxlintrc.typecheck.json .",
     "pack": "bun run --workspaces bun pm pack",
-    "postinstall": "node -e \"if(!process.env.CI)require('child_process').execSync('bun2nix -o bun.nix',{stdio:'ignore'})\" || true",
+    "postinstall": "bun scripts/check-workspace-links.ts --fix; node -e \"if(!process.env.CI)require('child_process').execSync('bun2nix -o bun.nix',{stdio:'ignore'})\" || true",
     "prepare": "husky",
     "screenshots": "bun scripts/screenshots/run.ts",
     "screenshots:thumbnails": "bun scripts/screenshots/thumbnails.ts",
@@ -59,6 +59,8 @@
     "typecheck": "tsc",
     "upgrade": "bunx npm-check-updates -u && bun install && bun run --workspaces --if-present upgrade",
     "schema:clean-roots": "bun scripts/check-shadowed-core.ts --fix",
+    "links:check": "bun scripts/check-workspace-links.ts",
+    "links:clean": "bun scripts/check-workspace-links.ts --fix",
     "schema:generate-all": "bun run schema:clean-roots && bun scripts/generate-schemas.ts",
     "schema:validate-all": "bun scripts/validate-schemas.ts"
   },

--- a/scripts/check-workspace-links.test.ts
+++ b/scripts/check-workspace-links.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The workspace-link gate (`scripts/check-workspace-links.ts`).
+ *
+ * Everything runs against fixture trees rather than this repo's own `node_modules`: asserting "the
+ * monorepo has N stale links" would go red the moment someone installs, and the live-tree assertion
+ * is `bun run links:check` anyway. What these pin down is the one judgement that decides whether a
+ * delete is a fix or a breakage — a nested copy exists either because an install could not hoist it
+ * (keep) or because an install layout this repo abandoned left it behind (remove).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  findStaleLinks,
+  isDeadStoreLink,
+  removeStaleLink,
+  staleLinksIn,
+  workspacesWithLinks,
+} from "./check-workspace-links";
+
+/** Write a package manifest at `dir`. */
+function manifest(dir: string, body: Record<string, unknown>): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "package.json"), JSON.stringify(body), "utf8");
+}
+
+/** A repo root with a bunfig selecting `linker`, and the given root-level installs. */
+function repo(linker: "hoisted" | "isolated", rootDeps: Record<string, string> = {}): string {
+  const root = mkdtempSync(join(tmpdir(), "jx-links-"));
+  writeFileSync(join(root, "bunfig.toml"), `[install]\nlinker = "${linker}"\n`, "utf8");
+  for (const [name, version] of Object.entries(rootDeps)) {
+    manifest(join(root, "node_modules", ...name.split("/")), { name, version });
+  }
+  return root;
+}
+
+/** A workspace declaring `deps`, with `installed` materialised under its own `node_modules`. */
+function workspace(
+  root: string,
+  name: string,
+  deps: Record<string, string>,
+  installed: Record<string, string> = {},
+): string {
+  const dir = join(root, "packages", name);
+  manifest(dir, { dependencies: deps, name: `@jxsuite/${name}`, version: "1.0.0" });
+  for (const [dep, version] of Object.entries(installed)) {
+    manifest(join(dir, "node_modules", ...dep.split("/")), { name: dep, version });
+  }
+  return dir;
+}
+
+describe("staleLinksIn — the manifest decides", () => {
+  /*
+   * The defect this exists for: `packages/schema` answered `@webref/css` with 8.5.8 against a
+   * declared `^8.7.1`, so the schema generator dropped every CSS property added since — silently,
+   * because a build against the wrong code still succeeds.
+   */
+  test("a nested copy the declared range rules out is stale", () => {
+    const root = repo("hoisted", { "@webref/css": "8.7.1" });
+    try {
+      const ws = workspace(root, "schema", { "@webref/css": "^8.7.1" }, { "@webref/css": "8.5.8" });
+
+      const stale = staleLinksIn(ws, root);
+
+      expect(stale).toHaveLength(1);
+      expect(stale[0]).toMatchObject({
+        declared: "^8.7.1",
+        reason: "unsatisfied",
+        root: "8.7.1",
+        specifier: "@webref/css",
+        version: "8.5.8",
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  /*
+   * The case a blunter rule would delete. `packages/import` pins puppeteer-core to a major the root
+   * has moved past, so its own copy is the ONLY correct answer — "differs from the root" is not
+   * evidence of staleness.
+   */
+  test("a nested copy that satisfies the declared range survives, root or no root", () => {
+    const root = repo("hoisted", { "puppeteer-core": "25.7.0" });
+    try {
+      const ws = workspace(
+        root,
+        "import",
+        { "puppeteer-core": "^24.9.0" },
+        { "puppeteer-core": "24.9.1" },
+      );
+
+      expect(staleLinksIn(ws, root)).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  // A workspace link resolves back into this repo, so it is right by construction.
+  test("a workspace: range is never judged", () => {
+    const root = repo("hoisted");
+    try {
+      const ws = workspace(
+        root,
+        "compiler",
+        { "@jxsuite/schema": "workspace:^" },
+        { "@jxsuite/schema": "0.0.1" },
+      );
+
+      expect(staleLinksIn(ws, root)).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  // A half-written install has no version to judge; deleting on that guess would be the worse bug.
+  test("an unreadable manifest is left alone rather than guessed at", () => {
+    const root = repo("hoisted", { "some-dep": "2.0.0" });
+    try {
+      const ws = workspace(root, "server", { "some-dep": "^2.0.0" });
+      mkdirSync(join(ws, "node_modules", "some-dep"), { recursive: true });
+
+      expect(staleLinksIn(ws, root)).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("a workspace with no node_modules of its own has nothing to report", () => {
+    const root = repo("hoisted");
+    try {
+      expect(staleLinksIn(workspace(root, "markup", { dep: "^1.0.0" }), root)).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("the dead-store rule — leftovers nothing declares", () => {
+  /** Link `specifier` in `ws` at a store entry under `root`. */
+  function storeLink(root: string, ws: string, specifier: string, version: string): string {
+    const store = join(root, "node_modules", ".bun", `${specifier}@${version}`, "node_modules");
+    manifest(join(store, specifier), { name: specifier, version });
+    const link = join(ws, "node_modules", specifier);
+    mkdirSync(join(ws, "node_modules"), { recursive: true });
+    symlinkSync(join(store, specifier), link);
+    return link;
+  }
+
+  /*
+   * A transitive leftover has no declared range to judge, so it is judged by the layout it belongs
+   * to: the isolated linker's store, which a hoisted repo no longer writes to or reads from.
+   */
+  test("a symlink into the isolated store is stale when the repo links hoisted", () => {
+    const root = repo("hoisted", { glob: "13.0.6" });
+    try {
+      const ws = workspace(root, "compiler", {});
+      const link = storeLink(root, ws, "glob", "10.0.0");
+
+      expect(isDeadStoreLink(link, root)).toBe(true);
+      expect(staleLinksIn(ws, root)).toMatchObject([
+        { reason: "dead-store-link", version: "10.0.0" },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  // Switching back must make the rule stop firing, not delete the layout the switch just asked for.
+  test("the same link is left alone when the repo links isolated", () => {
+    const root = repo("isolated", { glob: "13.0.6" });
+    try {
+      const ws = workspace(root, "compiler", {});
+      const link = storeLink(root, ws, "glob", "10.0.0");
+
+      expect(isDeadStoreLink(link, root)).toBe(false);
+      expect(staleLinksIn(ws, root)).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("a real directory nothing declares is not a store leftover", () => {
+    const root = repo("hoisted", { glob: "13.0.6" });
+    try {
+      const ws = workspace(root, "compiler", {}, { glob: "10.0.0" });
+
+      expect(staleLinksIn(ws, root)).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("removeStaleLink", () => {
+  /*
+   * The entry, never the tree. A workspace's `node_modules` may also hold the copy that IS the
+   * right answer, and resolution falls through to the root the moment the stale one is gone — so
+   * no reinstall is needed, and no correct copy is taken with it.
+   */
+  test("removes the entry, keeps its neighbours, and tidies an emptied scope", () => {
+    const root = repo("hoisted", { "@webref/css": "8.7.1" });
+    try {
+      const ws = workspace(
+        root,
+        "schema",
+        { "@webref/css": "^8.7.1", "@webref/idl": "^3.0.0", keeper: "^1.0.0" },
+        { "@webref/css": "8.5.8", "@webref/idl": "3.1.0", keeper: "1.0.2" },
+      );
+      const [stale] = staleLinksIn(ws, root);
+
+      removeStaleLink(stale!);
+
+      expect(existsSync(join(ws, "node_modules", "@webref", "css"))).toBe(false);
+      // Its neighbour in the same scope satisfies its range, so the scope directory stays.
+      expect(existsSync(join(ws, "node_modules", "@webref", "idl"))).toBe(true);
+      expect(existsSync(join(ws, "node_modules", "keeper"))).toBe(true);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("a scope left empty is removed with its last entry", () => {
+    const root = repo("hoisted", { "@webref/css": "8.7.1" });
+    try {
+      const ws = workspace(root, "schema", { "@webref/css": "^8.7.1" }, { "@webref/css": "8.5.8" });
+      const [stale] = staleLinksIn(ws, root);
+
+      removeStaleLink(stale!);
+
+      expect(existsSync(join(ws, "node_modules", "@webref"))).toBe(false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("an unscoped entry leaves no scope directory to tidy", () => {
+    const root = repo("hoisted", { lodash: "4.17.21" });
+    try {
+      const ws = workspace(root, "server", { lodash: "^4.17.21" }, { lodash: "3.10.1" });
+      const [stale] = staleLinksIn(ws, root);
+
+      removeStaleLink(stale!);
+
+      expect(existsSync(join(ws, "node_modules", "lodash"))).toBe(false);
+      expect(existsSync(join(ws, "node_modules"))).toBe(true);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("walking the repo", () => {
+  test("finds only workspaces that have a node_modules of their own", () => {
+    const root = repo("hoisted", { dep: "2.0.0" });
+    try {
+      const withLinks = workspace(root, "schema", { dep: "^2.0.0" }, { dep: "1.0.0" });
+      workspace(root, "markup", { dep: "^2.0.0" });
+      mkdirSync(join(root, "extensions"), { recursive: true });
+
+      expect(workspacesWithLinks(root)).toEqual([withLinks]);
+      expect(findStaleLinks(workspacesWithLinks(root), root)).toHaveLength(1);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("a repo with neither workspace parent reports nothing", () => {
+    const root = mkdtempSync(join(tmpdir(), "jx-links-bare-"));
+    try {
+      expect(workspacesWithLinks(root)).toEqual([]);
+      expect(findStaleLinks([], root)).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/scripts/check-workspace-links.ts
+++ b/scripts/check-workspace-links.ts
@@ -1,0 +1,318 @@
+/**
+ * Check-workspace-links.ts — no workspace may resolve a dependency to a version its own manifest
+ * rules out.
+ *
+ * The sibling of {@link ../scripts/check-shadowed-core.ts}. That one guards PROJECT roots against a
+ * stale first-party copy; this one guards WORKSPACE roots (`packages/*`, `extensions/*`) against a
+ * stale copy of anything, because the two hazards have different causes and only overlap by
+ * accident.
+ *
+ * **Where the stale copies come from.** Bun's `isolated` linker builds a content-addressed store at
+ * `node_modules/.bun/<pkg>@<version>/` and points a symlink at it from every workspace that depends
+ * on the package. This repo switched to `linker = "hoisted"` (bunfig.toml, and see
+ * oven-sh/bun#23615 for why), and a hoisted install writes real directories into the ROOT
+ * `node_modules/` — reaching into a workspace's own `node_modules/` only when a genuine version
+ * conflict cannot be hoisted.
+ *
+ * So a symlink left over from an isolated install is not something a later install rewrites. It is
+ * not in the install's plan at all, so nothing removes it, and Node resolution walks UP from the
+ * importing file — which means the leftover answers first and the correct root copy is never
+ * reached. That is silent: the build succeeds, against the wrong code.
+ *
+ * It cost real time to find. `packages/schema` resolved `@webref/css` to 8.5.8 against a declared
+ * `^8.7.1`, so `bun run schema:generate` dropped every CSS property added since — and
+ * `schema:verify` failed locally with a diff nobody had authored, on a machine where every other
+ * check was green. `packages/studio` was resolving `@atlaskit/pragmatic-drag-and-drop` 1.8.1
+ * against `^3.0.0`: two majors, under the drag-and-drop tests.
+ *
+ * **What may be deleted, and what may not.** A nested copy is legitimate exactly when it exists to
+ * satisfy a conflict the root cannot: `packages/import` declares `puppeteer-core: ^24.9.0` while
+ * the root holds 25.7.0, so its own 24.x copy is the only correct answer and must survive. The rule
+ * that separates them is the manifest, not the file type:
+ *
+ * - **Stale** — the nested version does not satisfy the range this workspace declares.
+ * - **Legitimate** — it does satisfy it (whether or not the root also would).
+ *
+ * A leftover with no declared range is judged by where it points instead: a symlink into the
+ * isolated store, under a hoisted linker, belongs to an install layout this repo no longer
+ * produces.
+ *
+ * Removing one is a single `rm` of the entry, not of the tree: resolution then falls through to the
+ * root copy, and no reinstall is needed.
+ *
+ * Usage: bun scripts/check-workspace-links.ts # report and exit 1 if any stale link exists bun
+ * scripts/check-workspace-links.ts --fix # remove them, then exit 0
+ */
+
+import { existsSync, lstatSync, readdirSync, readFileSync, readlinkSync, rmSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+
+/** Directories holding workspace members, relative to the repo root. */
+export const WORKSPACE_PARENTS = ["packages", "extensions"];
+
+/** Bun's isolated-linker store, relative to a repo root. */
+const ISOLATED_STORE = join("node_modules", ".bun");
+
+/** One dependency a workspace resolves to a version its own manifest rules out. */
+export interface StaleLink {
+  /** Absolute path to the offending entry under the workspace's `node_modules`. */
+  path: string;
+  /** `@webref/css` — the specifier it answers for. */
+  specifier: string;
+  /** The version it answers with, or `"unknown"` when the manifest will not parse. */
+  version: string;
+  /** The range the workspace declares, or `null` when it declares none (a transitive leftover). */
+  declared: string | null;
+  /** The version the root would answer with, or `null` when the root has no copy. */
+  root: string | null;
+  /** Why this entry is stale, for the report. */
+  reason: "unsatisfied" | "dead-store-link";
+  /** Absolute path to the workspace that holds it. */
+  workspace: string;
+}
+
+/**
+ * Every workspace directory that has a `node_modules` of its own.
+ *
+ * @param {string} [repoRoot] - Absolute repo root; defaults to this script's
+ * @returns {string[]} Absolute paths, sorted
+ */
+export function workspacesWithLinks(repoRoot: string = REPO_ROOT): string[] {
+  const found: string[] = [];
+  for (const parent of WORKSPACE_PARENTS) {
+    const dir = resolve(repoRoot, parent);
+    if (!existsSync(dir)) {
+      continue;
+    }
+    for (const name of readdirSync(dir)) {
+      const workspace = join(dir, name);
+      if (
+        existsSync(join(workspace, "package.json")) &&
+        existsSync(join(workspace, "node_modules"))
+      ) {
+        found.push(workspace);
+      }
+    }
+  }
+  return found.toSorted();
+}
+
+/** The `version` field of a package manifest, or `"unknown"` when it will not parse. */
+function versionAt(dir: string): string {
+  try {
+    const manifest = readFileSync(join(dir, "package.json"), "utf8");
+    return (JSON.parse(manifest) as { version?: string }).version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Every dependency range a workspace declares, across both dependency blocks. */
+function declaredRanges(workspace: string): Record<string, string> {
+  const ranges: Record<string, string> = {};
+  try {
+    const manifest = JSON.parse(readFileSync(join(workspace, "package.json"), "utf8")) as Record<
+      string,
+      Record<string, string> | undefined
+    >;
+    for (const block of ["dependencies", "devDependencies"]) {
+      Object.assign(ranges, manifest[block] ?? {});
+    }
+  } catch {
+    // An unreadable manifest declares nothing, which leaves every entry to the dead-link rule.
+  }
+  return ranges;
+}
+
+/** Every `<name>` and `<@scope>/<name>` entry directly under a `node_modules`. */
+function entriesIn(nodeModules: string): string[] {
+  const found: string[] = [];
+  for (const name of readdirSync(nodeModules).toSorted()) {
+    if (name === ".bin" || name === ".cache") {
+      continue;
+    }
+    if (!name.startsWith("@")) {
+      found.push(name);
+      continue;
+    }
+    const scopeDir = join(nodeModules, name);
+    if (!lstatSync(scopeDir).isDirectory()) {
+      continue;
+    }
+    found.push(
+      ...readdirSync(scopeDir)
+        .toSorted()
+        .map((inner) => `${name}/${inner}`),
+    );
+  }
+  return found;
+}
+
+/**
+ * Every stale link in one workspace.
+ *
+ * A `workspace:` range is skipped outright — that link points back into this repo, so it is the
+ * correct answer by construction and its version is whatever the sibling currently declares.
+ *
+ * @param {string} workspace - Absolute path to a workspace member
+ * @param {string} [repoRoot] - Absolute repo root; defaults to this script's
+ * @returns {StaleLink[]}
+ */
+export function staleLinksIn(workspace: string, repoRoot: string = REPO_ROOT): StaleLink[] {
+  const nodeModules = join(workspace, "node_modules");
+  if (!existsSync(nodeModules)) {
+    return [];
+  }
+  const ranges = declaredRanges(workspace);
+  const found: StaleLink[] = [];
+
+  for (const specifier of entriesIn(nodeModules)) {
+    const path = join(nodeModules, ...specifier.split("/"));
+    const declared = ranges[specifier] ?? null;
+    if (declared?.startsWith("workspace:")) {
+      continue;
+    }
+    const version = versionAt(path);
+    const rootPath = join(repoRoot, "node_modules", ...specifier.split("/"));
+    const root = existsSync(rootPath) ? versionAt(rootPath) : null;
+
+    /*
+     * The manifest decides. A nested copy that satisfies the declared range is the answer this
+     * workspace asked for — `packages/import` pinning puppeteer-core to a major the root has moved
+     * past is the case this must not delete.
+     */
+    if (declared !== null) {
+      if (version === "unknown" || Bun.semver.satisfies(version, declared)) {
+        continue;
+      }
+      found.push({ declared, path, reason: "unsatisfied", root, specifier, version, workspace });
+      continue;
+    }
+
+    // No declared range: judge it by the layout it belongs to instead.
+    if (isDeadStoreLink(path, repoRoot)) {
+      found.push({
+        declared,
+        path,
+        reason: "dead-store-link",
+        root,
+        specifier,
+        version,
+        workspace,
+      });
+    }
+  }
+  return found;
+}
+
+/**
+ * True when `path` is a symlink into the isolated-linker store while the repo links hoisted.
+ *
+ * Gated on the configured linker so that switching back makes this rule stop firing, rather than
+ * deleting the layout the switch just asked for.
+ *
+ * @param {string} path - Absolute path to a `node_modules` entry
+ * @param {string} repoRoot - Absolute repo root
+ * @returns {boolean}
+ */
+export function isDeadStoreLink(path: string, repoRoot: string): boolean {
+  if (!linksHoisted(repoRoot)) {
+    return false;
+  }
+  try {
+    if (!lstatSync(path).isSymbolicLink()) {
+      return false;
+    }
+    const target = resolve(join(path, ".."), readlinkSync(path));
+    return target.startsWith(join(repoRoot, ISOLATED_STORE));
+  } catch {
+    return false;
+  }
+}
+
+/** Whether `bunfig.toml` selects the hoisted linker. */
+function linksHoisted(repoRoot: string): boolean {
+  try {
+    const bunfig = readFileSync(join(repoRoot, "bunfig.toml"), "utf8");
+    return /^\s*linker\s*=\s*"hoisted"/m.test(bunfig);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Every stale link across every workspace.
+ *
+ * @param {string[]} workspaces - Absolute workspace paths
+ * @param {string} [repoRoot] - Absolute repo root; defaults to this script's
+ * @returns {StaleLink[]}
+ */
+export function findStaleLinks(workspaces: string[], repoRoot: string = REPO_ROOT): StaleLink[] {
+  return workspaces.flatMap((workspace) => staleLinksIn(workspace, repoRoot));
+}
+
+/**
+ * Remove one stale entry, and the scope directory it leaves empty.
+ *
+ * The entry only, never the tree: a workspace's `node_modules` may also hold copies that are the
+ * correct answer, and resolution falls through to the root the moment this one is gone.
+ *
+ * @param {StaleLink} link
+ * @returns {void}
+ */
+export function removeStaleLink(link: StaleLink): void {
+  rmSync(link.path, { force: true, recursive: true });
+  const [scope] = link.specifier.split("/");
+  if (!link.specifier.startsWith("@") || scope === undefined) {
+    return;
+  }
+  const scopeDir = join(link.workspace, "node_modules", scope);
+  try {
+    if (readdirSync(scopeDir).length === 0) {
+      rmSync(scopeDir, { recursive: true });
+    }
+  } catch {
+    // Already gone, or not a directory. Either way there is nothing left to tidy.
+  }
+}
+
+/** One report line: what answered, what was asked for, and what will answer instead. */
+function describe(link: StaleLink): string {
+  const asked = link.declared === null ? "not declared here" : `declared ${link.declared}`;
+  const instead = link.root === null ? "nothing at the root" : `root ${link.root}`;
+  return `  ${relative(REPO_ROOT, link.path)}\n      resolves ${link.version} — ${asked}; falls through to ${instead}`;
+}
+
+if (import.meta.main) {
+  const fix = process.argv.includes("--fix");
+  const stale = findStaleLinks(workspacesWithLinks());
+
+  if (stale.length === 0) {
+    console.log("workspace links: every workspace resolves its dependencies as its manifest says.");
+    process.exit(0);
+  }
+
+  if (fix) {
+    for (const link of stale) {
+      removeStaleLink(link);
+    }
+    const names = [...new Set(stale.map((link) => link.specifier))];
+    const shown = `${names.slice(0, 4).join(", ")}${names.length > 4 ? ", …" : ""}`;
+    console.log(
+      `workspace links: removed ${stale.length} stale entr${stale.length === 1 ? "y" : "ies"} ` +
+        `(${shown}). Resolution now falls through to the root; no reinstall needed.`,
+    );
+    process.exit(0);
+  }
+
+  const lines = stale.map((link) => describe(link)).join("\n");
+  console.error(
+    `workspace links: ${stale.length} stale entr${stale.length === 1 ? "y" : "ies"} ` +
+      `${stale.length === 1 ? "shadows" : "shadow"} the root install, so this tree builds against ` +
+      `code its manifests rule out:\n${lines}\n\n` +
+      "Run `bun run links:clean` to remove them.",
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
… out

Bun's `isolated` linker points each workspace's `node_modules` at a store under `node_modules/.bun/`. This repo links **hoisted** (bunfig.toml, oven-sh/bun#23615), which writes real directories into the ROOT `node_modules/` and reaches into a workspace's own only for a conflict it cannot hoist. So a symlink left by an isolated install is in no later install's plan: nothing rewrites it, nothing removes it, and resolution walks UP from the importing file — so the leftover answers first and the correct root copy is never reached.

That is silent. The build succeeds, against code the manifest rules out.

It cost a working session to find. `packages/schema` resolved `@webref/css` to 8.5.8 against a declared `^8.7.1`, so `generate:schema` dropped every CSS property added since and `schema:verify` failed locally with a diff nobody had authored — on a machine where every other check was green, and against a commit whose CI was green, because CI installs clean and never sees this. `packages/studio` was resolving `@atlaskit/pragmatic-drag-and-drop` 1.8.1 against `^3.0.0`: two majors, underneath the drag-and-drop tests. 46 entries across six workspaces.

The manifest decides what may be deleted, not the file type. A nested copy that SATISFIES the declared range is the answer that workspace asked for — `packages/import` pins `puppeteer-core: ^24.9.0` while the root holds 25.7.0, and its own copy is the only correct answer. Only a copy the range rules out is stale. A leftover nothing declares is judged by where it points instead: a symlink into the isolated store, under a hoisted linker, belongs to a layout this repo abandoned — and the rule is gated on the configured linker, so switching back makes it stop firing rather than delete what the switch just asked for.

Removing one is a single `rm` of the entry, never the tree, and needs no reinstall: resolution falls through to the root copy immediately.

It runs itself, at both moments it matters — `postinstall`, where the staleness appears, and a non-blocking `pre-commit` step for a tree that drifted some other way. The check is ~20ms. There is no CI lane, because CI installs clean and a green PR is no evidence your tree is right; that is exactly what makes it worth automating locally.