### PR TITLE
fix(ci): stop a commit subject silently deleting a package from its release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -381,6 +381,64 @@ jobs:
     with:
       ref: ${{ needs.release-please.outputs.desktop_tag }}
 
+  # Did the release actually SHIP? Nothing asked before, and for six weeks the answer was no.
+  #
+  # Two ways to lose a component, both of which leave every job in this workflow green:
+  #
+  #   1. release-please skips a component whose changelog carries a raw `<tag>` — it logs
+  #      "Pull request contains releases, but not for component: starters", creates the other 18,
+  #      and exits 0. The manifest still claims the version. (commitlint.config.js has the full
+  #      mechanism; `checks` now blocks the commit subjects that cause it.)
+  #   2. The `release-please` job dies PART WAY THROUGH after creating some releases — a GitHub 5xx
+  #      during its commit-history walk, which is precisely what an un-tagged component provokes.
+  #      Re-running it then finds the pull request already labelled `autorelease: tagged`, so
+  #      `releases_created` comes back FALSE and `publish`, all four desktop bundlers, `nix-build`
+  #      and `deploy-site` skip. That is how desktop-v2.2.0 shipped with no installers at all.
+  #
+  # So this runs on `always()` and is gated on NOTHING: a run that released nothing is exactly the
+  # run that needs checking. `needs: publish` only orders it after the registry has been written.
+  #
+  # It fails the run rather than warning like `verify-desktop-assets` does, because its subject is
+  # not cosmetic: `@jxsuite/starters` sat at 1.2.2 on npm while `@jxsuite/create@1.3.2` shipped
+  # depending on `^1.5.0`, so `npm install @jxsuite/create` was unresolvable for everyone. Nothing
+  # `needs:` this job, so a red X here blocks no other release work.
+  verify-release-integrity:
+    needs: [release-please, publish]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-bun
+      - name: Every version in the manifest must have a release and be on npm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          if bun scripts/check-release-integrity.ts 2>&1 | tee integrity.txt; then
+            exit 0
+          fi
+          echo "::error::the manifest claims versions that never shipped"
+
+          # One open issue, not one per run: this stays red until someone acts, and the daily
+          # schedule would otherwise comment every morning.
+          title="Released versions that never shipped"
+          open="$(gh issue list --state open --label release-incomplete \
+                    --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ -z "$open" ]; then
+            gh issue create --title "$title" --label release-incomplete --body "$(
+              printf '%s\n\n```\n%s\n```\n' \
+                "\`bun run release:integrity\` on \`main\`, from [this run]($GITHUB_SERVER_URL/$GH_REPO/actions/runs/$GITHUB_RUN_ID)." \
+                "$(cat integrity.txt)"
+            )" || true
+          else
+            echo "tracked by #$open"
+          fi
+          exit 1
+
   pin-desktop-latest:
     needs:
       [

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -411,7 +411,12 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v7
+      # `install: false` — the script reads package.json files with node builtins and shells out to
+      # `gh` and `npm`. It has no dependency to install, and a job whose whole purpose is to report
+      # A broken release must not be able to fail on `--frozen-lockfile` instead.
       - uses: ./.github/actions/setup-bun
+        with:
+          install: false
       - name: Every version in the manifest must have a release and be on npm
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -192,6 +192,11 @@ jobs:
           if [ -n "$missing" ]; then
             echo "::warning::Release $TAG is missing expected desktop assets:$missing"
             gh release edit "$TAG" --prerelease
+            # The label must exist or `gh issue create` errors and the `|| true` below eats it —
+            # Which is how every guard in this workflow was quietly unable to file its report.
+            gh label create release-incomplete --color B60205 \
+              --description "A release shipped incomplete: a missing asset, publish, tag or cache entry" \
+              2>/dev/null || true
             gh issue create \
               --title "Release $TAG is missing desktop assets" \
               --label release-incomplete \
@@ -273,6 +278,11 @@ jobs:
           set -euo pipefail
           if [ "$NIX_RESULT" != "success" ]; then
             echo "::warning::nix-build was $NIX_RESULT for $TAG; leaving \`release\` where it is"
+            # The label must exist or `gh issue create` errors and the `|| true` below eats it —
+            # Which is how every guard in this workflow was quietly unable to file its report.
+            gh label create release-incomplete --color B60205 \
+              --description "A release shipped incomplete: a missing asset, publish, tag or cache entry" \
+              2>/dev/null || true
             gh issue create \
               --title "\`release\` did not advance to $TAG" \
               --label release-incomplete \
@@ -352,6 +362,11 @@ jobs:
 
           if [ -n "$problems" ]; then
             echo "::warning::the binary cache does not serve $TAG"
+            # The label must exist or `gh issue create` errors and the `|| true` below eats it —
+            # Which is how every guard in this workflow was quietly unable to file its report.
+            gh label create release-incomplete --color B60205 \
+              --description "A release shipped incomplete: a missing asset, publish, tag or cache entry" \
+              2>/dev/null || true
             gh issue create \
               --title "Binary cache does not serve $TAG" \
               --label release-incomplete \
@@ -434,6 +449,9 @@ jobs:
           open="$(gh issue list --state open --label release-incomplete \
                     --search "$title in:title" --json number --jq '.[0].number // empty')"
           if [ -z "$open" ]; then
+            gh label create release-incomplete --color B60205 \
+              --description "A release shipped incomplete: a missing asset, publish, tag or cache entry" \
+              2>/dev/null || true
             gh issue create --title "$title" --label release-incomplete --body "$(
               printf '%s\n\n```\n%s\n```\n' \
                 "\`bun run release:integrity\` on \`main\`, from [this run]($GITHUB_SERVER_URL/$GH_REPO/actions/runs/$GITHUB_RUN_ID)." \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,6 +326,20 @@ jobs:
       # core, and one starter whose entry document was composed against a published @jxsuite/schema
       # left in a stray node_modules, so it was NARROWER than its own content required.
       - run: bun run schema:verify
+      # Changelog safety: a commit SUBJECT (or BREAKING CHANGE note) carrying a raw `<tag>` makes
+      # release-please DROP that package from its own release — silently, exit 0. That is how
+      # `schema` and `starters` fell out of three consecutive releases and `npm i @jxsuite/create`
+      # became unresolvable. `.husky/commit-msg` runs the same rule, but a hook is skippable with
+      # `--no-verify`, which is how the offending subject reached main. See commitlint.config.js.
+      #
+      # Pull-request-only, and it names the two shas explicitly rather than using HEAD: `checks`
+      # runs on the merge commit, whose own subject is not a conventional commit.
+      - name: Commit subjects must be changelog-safe
+        if: github.event_name == 'pull_request'
+        run: |
+          bun scripts/check-changelog-safety.ts \
+            --from ${{ github.event.pull_request.base.sha }} \
+            --to ${{ github.event.pull_request.head.sha }}
 
   # Its own job because it is 87 of the 159 seconds `checks` used to take, and everything else
   # in there is 0-4s. It is gated on studio's OWN tree — not on studio merely being retested —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,53 @@ No secret is involved. On a Dependabot event `secrets.*` resolves against the se
 - **Release-only workflows are unexercised.** `bundle-desktop-*`, `build-msix` and `publish` are `workflow_call`-only, so an action bump inside them is first executed during a real release. Accepted deliberately — that pipeline already fails loudly and opens issues — but it is the one place where a green `ci` does not mean "tested".
 - **`@jxsuite/*` is ignored** for the bun ecosystem. release-please owns those ranges (it rewrites them inside the release commit via `extra-files`, and `bun run templates:check` gates them), so a Dependabot bump would be a second writer on the same line.
 
+## Releases, and the two ways one silently does not happen
+
+release-please owns every version, tag, changelog and npm publish (`release-please-config.json`,
+`.release-please-manifest.json`, `.github/workflows/release-please.yml`). Both of its failure modes
+exit 0, which is why each now has a gate.
+
+### A raw `<tag>` in a commit subject deletes that package from its own release
+
+release-please writes the release pull request body with changelog text HTML-escaped, then on merge
+parses that body and **re-serialises it** (`PullRequestBody.parse(...).toString()`) before parsing
+it a second time in `buildRelease()`. The round trip DECODES the entities, so `&lt;picture&gt;`
+comes back as a live `<picture>` element; node-html-parser then swallows the `</details>` that
+should have closed the section, the component is no longer found in the parsed release data, and
+release-please logs `Pull request contains releases, but not for component: <name>` and skips it —
+no tag, no GitHub release, no npm publish, green run.
+
+`feat(compiler): responsive images — <picture> per format…` did exactly that: `schema` and
+`starters` fell out of three consecutive releases, and `@jxsuite/starters` sat at 1.2.2 on npm while
+`@jxsuite/create@1.3.2` shipped depending on `^1.5.0`, so `npm install @jxsuite/create` was
+unresolvable. The bug is upstream and still present in release-please 17.11.1, so the defence is to
+keep the text out of the changelog. **Backticks do not help** — the escaping happens on raw text.
+
+- The rule and the full write-up live in `commitlint.config.js` (`changelog-safe-angle-brackets`).
+- `.husky/commit-msg` applies it as you commit; `checks` runs
+  `bun scripts/check-changelog-safety.ts` over the pull request's commits, because a hook is
+  skippable with `--no-verify` and that is how the subject landed.
+- Only the **subject** and `BREAKING CHANGE:` notes are judged — nothing else reaches a changelog,
+  so a commit body may still contain markup.
+
+### A crashed `release-please` job disables the whole pipeline on the re-run
+
+The job creates the GitHub releases first and builds the next pull request second. If it dies in
+between — a GitHub 5xx during its commit-history walk, which an un-tagged component provokes by
+forcing a 500-commit backfill — the releases exist but the run failed. **Re-running it is not
+idempotent in the way that matters**: the pull request is already labelled `autorelease: tagged`, so
+`releases_created` comes back `false` and `publish`, all four desktop bundlers, `nix-build` and
+`deploy-site` all skip. That is how `desktop-v2.2.0` shipped with no installers.
+
+`verify-release-integrity` is the answer: `if: always()`, gated on nothing, it asserts every version
+in `.release-please-manifest.json` has a GitHub release at its tag and — for publishable
+workspaces — that exact version on npm (`bun run release:integrity`, `--no-npm` to skip the
+registry). It fails the run and opens ONE `release-incomplete` issue. Nothing `needs:` it, so a red
+X there blocks nothing else. The daily schedule on the workflow makes it a standing sweep.
+
+To backfill npm after a skip, `publish.yml` has a `workflow_dispatch` entry point and is
+idempotent — the failure report prints the exact `gh workflow run` invocation.
+
 ## Starter Roots and the Shadowed Core
 
 Iterating a starter inside Studio runs `bun install` in that starter's root, and a starter pins

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,130 @@
+/**
+ * A commit subject that contains a raw `<tag>` DELETES A PACKAGE FROM ITS OWN RELEASE.
+ *
+ * The path is not obvious, so it is written out here rather than left to be rediscovered:
+ *
+ * 1. The subject reaches the changelog verbatim, and release-please writes the release pull request
+ *    body with it HTML-ESCAPED — `<picture>` becomes `&lt;picture&gt;`. Correct so far.
+ * 2. On merge, `Manifest.findMergedReleasePullRequests()` parses that body and immediately
+ *    RE-SERIALISES it (`PullRequestBody.parse(...).toString()`) before handing it to
+ *    `buildRelease()`. The parse step reads notes out of the DOM as `textContent`, which is DECODED
+ *    — so the re-serialised body carries a live `<picture>` element.
+ * 3. `buildRelease()` parses that body again. node-html-parser now sees a real, never-closed
+ *    `<picture>`, swallows the `</details>` that should have ended the section, and the component's
+ *    release notes stop being a `<details>` element of their own.
+ * 4. The component is not found in the parsed release data, release-please logs "Pull request contains
+ *    releases, but not for component: <name>" and SKIPS IT — no tag, no GitHub release, no npm
+ *    publish, exit code 0.
+ *
+ * `feat(compiler): responsive images — <picture> per format, one owner for loading` did exactly
+ * that: `schema` and `starters` silently fell out of three consecutive releases.
+ * `@jxsuite/starters` stopped at 1.2.2 on npm while `@jxsuite/create@1.3.2` shipped depending on
+ * `^1.5.0`, so `npm install @jxsuite/create` failed to resolve for anyone who tried it. And because
+ * an un-tagged component has no "latest release" to measure from, release-please re-proposed it on
+ * every subsequent run — which is what made merging a release pull request immediately open another
+ * one, forever.
+ *
+ * The bug is upstream and still present in release-please 17.11.1 (the newest release as of this
+ * commit), so the only defence is to keep the text out of the changelog. Backticks do NOT help —
+ * the escaping happens on the raw text, and markdown never enters into it.
+ *
+ * Write the prose instead: "the picture element", `ext/{name}/{kind}/v{n}`, "real th table
+ * headers".
+ *
+ * This file is the single definition. `scripts/check-changelog-safety.ts` imports `findAngleTags`
+ * so the CI gate and the local commit hook can never disagree;
+ * `scripts/check-changelog-safety.test.ts` tests it.
+ */
+
+/**
+ * Anything a browser's HTML parser would treat as a tag: an element (`<picture>`, `</details>`,
+ * `<img src="…">`) or a comment opener. Deliberately NOT matched: `a < b`, `->`, `<3` — the
+ * character after `<` must start an element name for the round trip to produce an element.
+ */
+const ANGLE_TAG = /<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>|<!--/g;
+
+/**
+ * Every angle-bracket tag in `text`, in order, with duplicates collapsed.
+ *
+ * @param {string | null | undefined} text
+ * @returns {string[]}
+ */
+export function findAngleTags(text) {
+  if (!text) {
+    return [];
+  }
+  const matches = text.match(ANGLE_TAG);
+  return matches ? [...new Set(matches)] : [];
+}
+
+/**
+ * The parts of a commit message release-please copies into a changelog: the subject line, and the
+ * text of any `BREAKING CHANGE:` note. The body is otherwise dropped, so it is not checked — a
+ * commit may still explain itself with markup below the fold.
+ *
+ * @param {string} message A full commit message.
+ * @returns {{ part: string; text: string; tags: string[] }[]} One entry per offending part.
+ */
+export function findChangelogUnsafeParts(message) {
+  const lines = message.replaceAll("\r\n", "\n").split("\n");
+  const problems = [];
+
+  const subject = lines[0] ?? "";
+  const subjectTags = findAngleTags(subject);
+  if (subjectTags.length > 0) {
+    problems.push({ part: "subject", tags: subjectTags, text: subject });
+  }
+
+  // A BREAKING CHANGE note runs to the next blank line; release-please reproduces all of it.
+  for (let i = 1; i < lines.length; i++) {
+    if (!/^BREAKING[ -]CHANGE:/.test(lines[i])) {
+      continue;
+    }
+    const note = [];
+    for (let j = i; j < lines.length && lines[j].trim() !== ""; j++) {
+      note.push(lines[j]);
+    }
+    const text = note.join("\n");
+    const tags = findAngleTags(text);
+    if (tags.length > 0) {
+      problems.push({ part: "BREAKING CHANGE", tags, text });
+    }
+    i += note.length;
+  }
+
+  return problems;
+}
+
+/** The advice is the same wherever the check fires, so both callers read it from here. */
+export function changelogSafetyAdvice(problems) {
+  const found = [...new Set(problems.flatMap((p) => p.tags))].join(", ");
+  return (
+    `contains ${found} — an angle-bracket tag here silently drops the package from its own ` +
+    "release (see the header of commitlint.config.js). Say it in prose, or use braces: " +
+    "`ext/{name}/{kind}/v{n}`. Backticks do not help."
+  );
+}
+
 const config = {
   extends: ["@commitlint/config-conventional"],
+  plugins: [
+    {
+      rules: {
+        "changelog-safe-angle-brackets": (parsed) => {
+          const problems = findChangelogUnsafeParts(parsed.raw ?? "");
+          if (problems.length === 0) {
+            return [true, ""];
+          }
+          const where = problems.map((p) => p.part).join(" and ");
+          return [false, `${where} ${changelogSafetyAdvice(problems)}`];
+        },
+      },
+    },
+  ],
   rules: {
+    // An error rather than a warning because the failure it prevents is SILENT: nothing goes
+    // Red when it happens, a package simply stops being released. See this file's header.
+    "changelog-safe-angle-brackets": [2, "always"],
     "subject-case": [2, "never", ["upper-case"]],
     "subject-empty": [2, "never"],
     "type-empty": [2, "never"],

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "pack": "bun run --workspaces bun pm pack",
     "postinstall": "node -e \"if(!process.env.CI)require('child_process').execSync('bun2nix -o bun.nix',{stdio:'ignore'})\" || true",
     "prepare": "husky",
+    "release:integrity": "bun scripts/check-release-integrity.ts",
+    "release:changelog-safe": "bun scripts/check-changelog-safety.ts",
     "screenshots": "bun scripts/screenshots/run.ts",
     "screenshots:thumbnails": "bun scripts/screenshots/thumbnails.ts",
     "spec:bump": "bun scripts/docs/spec-bump.ts",

--- a/scripts/check-changelog-safety.test.ts
+++ b/scripts/check-changelog-safety.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The rule this covers is load-bearing and its failure mode is silent, so the cases below are the
+ * REAL commits — the five in this repository's history that would each have deleted a package from
+ * its own release, and the near-misses that must stay allowed.
+ *
+ * See `commitlint.config.js` for why an angle bracket in a commit subject has that effect.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { findAngleTags, findChangelogUnsafeParts } from "../commitlint.config.js";
+import { findUnsafeCommits, parseLog, report } from "./check-changelog-safety.ts";
+
+describe("findAngleTags", () => {
+  test("finds the tags that survive release-please's escape/decode round trip", () => {
+    expect(findAngleTags("responsive images — <picture> per format")).toEqual(["<picture>"]);
+    expect(findAngleTags("the shared ext/<name>/<kind>/v<n> shape")).toEqual([
+      "<name>",
+      "<kind>",
+      "<n>",
+    ]);
+    expect(findAngleTags("real <th> table headers")).toEqual(["<th>"]);
+    expect(findAngleTags("closes </details> early")).toEqual(["</details>"]);
+    expect(findAngleTags('an <img src="x"> attribute')).toEqual(['<img src="x">']);
+    expect(findAngleTags("a <!-- comment --> in a subject")).toEqual(["<!--"]);
+  });
+
+  test("a type parameter is unsafe too — `<string>` is an element to an HTML parser", () => {
+    expect(findAngleTags("accept Array<string> for $paths")).toEqual(["<string>"]);
+  });
+
+  test("collapses duplicates so the message names each tag once", () => {
+    expect(findAngleTags("<picture> then <picture> again")).toEqual(["<picture>"]);
+  });
+
+  test("leaves comparisons, arrows and prose alone", () => {
+    expect(findAngleTags("handle a < b and b > a")).toEqual([]);
+    expect(findAngleTags("rename foo -> bar")).toEqual([]);
+    expect(findAngleTags("keep bundles <3 MB")).toEqual([]);
+    expect(findAngleTags("the picture element, one owner for loading")).toEqual([]);
+    expect(findAngleTags("")).toEqual([]);
+    expect(findAngleTags(null)).toEqual([]);
+  });
+});
+
+describe("findChangelogUnsafeParts", () => {
+  test("flags the subject", () => {
+    const parts = findChangelogUnsafeParts(
+      "feat(compiler): responsive images — <picture> per format\n\nA body.\n",
+    );
+    expect(parts).toEqual([
+      {
+        part: "subject",
+        tags: ["<picture>"],
+        text: "feat(compiler): responsive images — <picture> per format",
+      },
+    ]);
+  });
+
+  test("flags a BREAKING CHANGE note, which release-please also copies verbatim", () => {
+    const parts = findChangelogUnsafeParts(
+      'feat(feed)!: drop the inert contentMode "none"\n\nA body.\n\n' +
+        "BREAKING CHANGE: entries now always carry <summary>\ncontinued on the next line\n\ntrailer\n",
+    );
+    expect(parts.map((p) => p.part)).toEqual(["BREAKING CHANGE"]);
+    expect(parts[0].tags).toEqual(["<summary>"]);
+    expect(parts[0].text).toContain("continued on the next line");
+  });
+
+  test("ignores markup in an ordinary body — only the changelog-bound text matters", () => {
+    expect(
+      findChangelogUnsafeParts("fix(compiler): head identity\n\nBefore:\n\n    <head><title>x\n"),
+    ).toEqual([]);
+  });
+
+  test("passes a clean commit", () => {
+    expect(findChangelogUnsafeParts("chore: release main\n")).toEqual([]);
+  });
+});
+
+describe("parseLog", () => {
+  test("splits NUL-delimited sha/message pairs, trailing field included", () => {
+    expect(parseLog("abc\0feat: one\n\0def\0fix: two\n\0")).toEqual([
+      { sha: "abc", message: "feat: one\n" },
+      { sha: "def", message: "fix: two\n" },
+    ]);
+  });
+
+  test("an empty range yields no commits", () => {
+    expect(parseLog("")).toEqual([]);
+  });
+});
+
+describe("findUnsafeCommits and report", () => {
+  const commits = [
+    { sha: "14f920de7d5a", message: "feat(compiler): responsive images — <picture> per format\n" },
+    { sha: "c4a614dae5e1", message: "fix: defects surfaced by fact-checking the READMEs\n" },
+  ];
+
+  test("returns only the offenders, with their subject", () => {
+    const unsafe = findUnsafeCommits(commits);
+    expect(unsafe.map((c) => c.sha)).toEqual(["14f920de7d5a"]);
+    expect(unsafe[0].subject).toBe("feat(compiler): responsive images — <picture> per format");
+  });
+
+  test("the report names the sha, the subject and the tag", () => {
+    const text = report(findUnsafeCommits(commits));
+    expect(text).toContain("14f920de");
+    expect(text).toContain("responsive images");
+    expect(text).toContain("<picture>");
+    expect(text).not.toContain("c4a614da");
+  });
+
+  test("nothing to report when every commit is clean", () => {
+    expect(findUnsafeCommits([commits[1]])).toEqual([]);
+    expect(report([])).toBe("");
+  });
+});

--- a/scripts/check-changelog-safety.ts
+++ b/scripts/check-changelog-safety.ts
@@ -1,0 +1,109 @@
+/**
+ * The CI half of the changelog-safety gate. The rule, the reasoning, and the failure it prevents
+ * are all in `commitlint.config.js` — read that first; this file only applies it to a commit
+ * range.
+ *
+ * Both halves exist because they fail at different moments and neither covers the other:
+ *
+ * - `.husky/commit-msg` runs commitlint as you commit. It is the fast feedback, and it is BYPASSABLE
+ *   (`--no-verify`), which is how `feat(compiler): responsive images — <picture> …` reached `main`
+ *   in the first place and quietly deleted `schema` and `starters` from three consecutive
+ *   releases.
+ * - This runs in the `checks` job over the pull request's own commits, where nothing can skip it.
+ *
+ * It reads the rule from `commitlint.config.js` rather than restating it, so the hook and the gate
+ * cannot drift into disagreeing about which subjects are safe.
+ *
+ * Merge commits are skipped: release-please cannot parse them as conventional commits (its log is
+ * full of "commit could not be parsed: Merge pull request #…"), so their subjects never reach a
+ * changelog and cannot trigger the defect.
+ *
+ *     bun scripts/check-changelog-safety.ts                       # origin/main..HEAD
+ *     bun scripts/check-changelog-safety.ts --from <sha> --to <sha>
+ */
+
+import { changelogSafetyAdvice, findChangelogUnsafeParts } from "../commitlint.config.js";
+
+export interface UnsafeCommit {
+  sha: string;
+  subject: string;
+  parts: ReturnType<typeof findChangelogUnsafeParts>;
+}
+
+/** A `git log` record: the sha, then the raw message, both NUL-terminated. */
+const RECORD = "%H%x00%B%x00";
+
+/**
+ * Split `git log --format=RECORD` output back into commits. Exported for the test, which would
+ * otherwise have to shell out to git to exercise anything.
+ */
+export function parseLog(stdout: string): { sha: string; message: string }[] {
+  const fields = stdout.split("\0");
+  const commits: { sha: string; message: string }[] = [];
+  // Fields arrive in pairs; a trailing empty field after the final NUL is expected.
+  for (let i = 0; i + 1 < fields.length; i += 2) {
+    const sha = fields[i].trim();
+    if (sha) {
+      commits.push({ sha, message: fields[i + 1] });
+    }
+  }
+  return commits;
+}
+
+/** The commits in `log` whose changelog-bound text carries an angle-bracket tag. */
+export function findUnsafeCommits(commits: { sha: string; message: string }[]): UnsafeCommit[] {
+  return commits
+    .map((c) => ({
+      sha: c.sha,
+      subject: c.message.split("\n")[0] ?? "",
+      parts: findChangelogUnsafeParts(c.message),
+    }))
+    .filter((c) => c.parts.length > 0);
+}
+
+export function report(unsafe: UnsafeCommit[]): string {
+  return unsafe
+    .map((c) => {
+      const where = c.parts.map((p) => p.part).join(" and ");
+      return `  ${c.sha.slice(0, 8)} ${c.subject}\n      ${where} ${changelogSafetyAdvice(c.parts)}`;
+    })
+    .join("\n");
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const arg = (flag: string) => {
+    const i = args.indexOf(flag);
+    return i === -1 ? undefined : args[i + 1];
+  };
+  const from = arg("--from") ?? "origin/main";
+  const to = arg("--to") ?? "HEAD";
+
+  // `--no-merges` is what keeps a "Merge pull request #…" subject from being judged by a rule
+  // Written for conventional commits.
+  const proc = Bun.spawnSync(["git", "log", "--no-merges", `--format=${RECORD}`, `${from}..${to}`]);
+  if (proc.exitCode !== 0) {
+    console.error(
+      `git log ${from}..${to} failed — is the range fetched?\n${proc.stderr.toString()}`,
+    );
+    process.exit(1);
+  }
+
+  const commits = parseLog(proc.stdout.toString());
+  const unsafe = findUnsafeCommits(commits);
+  if (unsafe.length === 0) {
+    console.log(`${commits.length} commit(s) in ${from}..${to}: all changelog-safe.`);
+    process.exit(0);
+  }
+
+  console.error(
+    `${unsafe.length} of ${commits.length} commit(s) in ${from}..${to} would be dropped from ` +
+      "their own release:\n",
+  );
+  console.error(report(unsafe));
+  console.error(
+    "\nAmend the subject (`git rebase -i` for an older commit) and force-push. The same rule runs " +
+      "locally via .husky/commit-msg.",
+  );
+  process.exit(1);
+}

--- a/scripts/check-release-integrity.test.ts
+++ b/scripts/check-release-integrity.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Covers `scripts/check-release-integrity.ts` — the gate that would have caught, on the day it
+ * happened, `packages/starters` being versioned to 1.3.0 in the manifest and never released.
+ *
+ * The probes are injected, so the assertions below never touch GitHub or the npm registry: what is
+ * tested is the tag arithmetic (which must track `release-please-config.json`, not a hardcoded
+ * shape), the gap logic, and that the report tells you what to run.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { findGaps, readTargets, report, tagFor } from "./check-release-integrity.ts";
+import type { Probes, ReleaseTarget } from "./check-release-integrity.ts";
+
+const CONFIG = {
+  "include-v-in-tag": true,
+  "include-component-in-tag": true,
+  packages: {
+    "packages/starters": { component: "starters" },
+    "extensions/feed": { component: "feed" },
+    "packages/odd": { "include-v-in-tag": false, "tag-separator": "@", component: "odd" },
+    "packages/solo": { "include-component-in-tag": false },
+    "packages/unnamed": {},
+  },
+};
+
+const target = (over: Partial<ReleaseTarget> = {}): ReleaseTarget => ({
+  path: "packages/starters",
+  tag: "starters-v1.5.0",
+  version: "1.5.0",
+  npmName: "@jxsuite/starters",
+  ...over,
+});
+
+const probes = (present: { releases?: string[]; npm?: string[] }): Probes => ({
+  releaseExists: (tag) => Promise.resolve((present.releases ?? []).includes(tag)),
+  npmHasVersion: (name, version) =>
+    Promise.resolve((present.npm ?? []).includes(`${name}@${version}`)),
+});
+
+describe("tagFor", () => {
+  test("matches the tags release-please actually created", () => {
+    expect(tagFor("packages/starters", "1.5.0", CONFIG)).toBe("starters-v1.5.0");
+    expect(tagFor("extensions/feed", "0.3.1", CONFIG)).toBe("feed-v0.3.1");
+  });
+
+  test("honours per-package overrides rather than assuming the default shape", () => {
+    expect(tagFor("packages/odd", "2.0.0", CONFIG)).toBe("odd@2.0.0");
+    expect(tagFor("packages/solo", "2.0.0", CONFIG)).toBe("v2.0.0");
+  });
+
+  test("falls back to the directory name when no component is configured", () => {
+    expect(tagFor("packages/unnamed", "1.0.0", CONFIG)).toBe("unnamed-v1.0.0");
+  });
+});
+
+describe("readTargets", () => {
+  test("reads this repository's real manifest and derives a tag for every entry", async () => {
+    const targets = await readTargets();
+    expect(targets.length).toBeGreaterThan(0);
+    for (const t of targets) {
+      expect(t.tag).toMatch(/^[a-z]+-v\d+\.\d+\.\d+/);
+    }
+  });
+
+  test("desktop is a component npm never receives, so it carries no npm name", async () => {
+    const targets = await readTargets();
+    const desktop = targets.find((t) => t.path === "packages/desktop");
+    expect(desktop?.npmName).toBeNull();
+  });
+
+  test("a publishable component carries the name npm must have", async () => {
+    const targets = await readTargets();
+    expect(targets.find((t) => t.path === "packages/starters")?.npmName).toBe("@jxsuite/starters");
+  });
+});
+
+describe("findGaps", () => {
+  test("a fully shipped component is not a gap", async () => {
+    const gaps = await findGaps(
+      [target()],
+      probes({ npm: ["@jxsuite/starters@1.5.0"], releases: ["starters-v1.5.0"] }),
+    );
+    expect(gaps).toEqual([]);
+  });
+
+  test("the release-please skip: manifest bumped, nothing released", async () => {
+    const gaps = await findGaps([target()], probes({}));
+    expect(gaps).toEqual([{ ...target(), missingFromNpm: true, missingRelease: true }]);
+  });
+
+  test("the crashed-publish case: the release exists but npm never got it", async () => {
+    const gaps = await findGaps([target()], probes({ releases: ["starters-v1.5.0"] }));
+    expect(gaps[0].missingRelease).toBe(false);
+    expect(gaps[0].missingFromNpm).toBe(true);
+  });
+
+  test("a non-npm component is judged on its release alone", async () => {
+    const desktop = target({
+      npmName: null,
+      path: "packages/desktop",
+      tag: "desktop-v2.2.1",
+      version: "2.2.1",
+    });
+    expect(await findGaps([desktop], probes({ releases: ["desktop-v2.2.1"] }))).toEqual([]);
+    const gaps = await findGaps([desktop], probes({}));
+    expect(gaps[0].missingFromNpm).toBe(false);
+  });
+});
+
+describe("report", () => {
+  test("an npm gap comes with the command that backfills it", async () => {
+    const text = report(await findGaps([target()], probes({ releases: ["starters-v1.5.0"] })));
+    expect(text).toContain("@jxsuite/starters@1.5.0");
+    expect(text).toContain("gh workflow run publish.yml");
+    expect(text).toContain('["packages/starters"]');
+  });
+
+  test("a missing release points at the cause instead of at npm", async () => {
+    const text = report(await findGaps([target()], probes({})));
+    expect(text).toContain("starters-v1.5.0");
+    expect(text).toContain("but not for component");
+    expect(text).toContain("commitlint.config.js");
+  });
+});

--- a/scripts/check-release-integrity.ts
+++ b/scripts/check-release-integrity.ts
@@ -1,0 +1,189 @@
+/**
+ * Every version in `.release-please-manifest.json` must have actually shipped: a GitHub release at
+ * its tag, and — for the packages npm receives — that exact version on the registry.
+ *
+ * NOTHING ASKED THIS QUESTION BEFORE, and the answer was no for six weeks. Two independent ways to
+ * lose a release, both of which exit 0:
+ *
+ * 1. Release-please drops a component whose changelog contains a raw `<tag>` (the defect written up in
+ *    `commitlint.config.js`). It logs "Pull request contains releases, but not for component:
+ *    starters", creates the other 18, and succeeds. The manifest still says 1.5.0.
+ * 2. The `release-please` job dies PART WAY THROUGH — a GitHub 5xx while it backfills file lists,
+ *    which is exactly what a component with no tag provokes, because it forces a walk back through
+ *    500 commits. Re-running the job then finds the pull request already labelled `autorelease:
+ *    tagged`, so `releases_created` comes back `false` and `publish`, all four desktop bundlers,
+ *    `nix-build` and `deploy-site` SKIP. A green run, no release.
+ *
+ * The visible damage from (1)+(2) was `@jxsuite/starters` sitting at 1.2.2 on npm while
+ * `@jxsuite/create@1.3.2` and `@jxsuite/server@2.2.1` shipped declaring `^1.5.0` — so `npm install
+ * @jxsuite/create` failed to resolve, for everyone, silently.
+ *
+ * This is the job that says so. It runs in `release-please.yml` with `if: always()`, so a crashed
+ * or no-op release run still gets checked, and again on that workflow's daily schedule.
+ *
+ *     bun scripts/check-release-integrity.ts            # the gate
+ *     bun scripts/check-release-integrity.ts --no-npm   # tags only (no registry round trips)
+ */
+
+import { readWorkspaces } from "./lib/workspaces.ts";
+
+const CONFIG = "release-please-config.json";
+const MANIFEST = ".release-please-manifest.json";
+
+interface PackageConfig {
+  component?: string;
+  "include-v-in-tag"?: boolean;
+  "include-component-in-tag"?: boolean;
+  "tag-separator"?: string;
+}
+interface Config {
+  packages: Record<string, PackageConfig>;
+  "include-v-in-tag"?: boolean;
+  "include-component-in-tag"?: boolean;
+  "tag-separator"?: string;
+}
+
+export interface ReleaseTarget {
+  /** Repo-relative workspace directory, e.g. `packages/starters`. */
+  path: string;
+  /** The tag release-please would have created, e.g. `starters-v1.5.0`. */
+  tag: string;
+  version: string;
+  /** The npm package name, or null when this component never goes to npm (`desktop`). */
+  npmName: string | null;
+}
+
+export interface ReleaseGap extends ReleaseTarget {
+  missingRelease: boolean;
+  missingFromNpm: boolean;
+}
+
+/**
+ * Reproduce release-please's `TagName.toString()`: `<component><separator>v<version>`, with each
+ * part defaulting at the top level and overridable per package. Derived rather than hardcoded so a
+ * config change cannot make this gate quietly check the wrong tag.
+ */
+export function tagFor(path: string, version: string, config: Config): string {
+  const pkg = config.packages[path] ?? {};
+  const pick = <K extends keyof PackageConfig & keyof Config>(
+    key: K,
+    fallback: NonNullable<Config[K]>,
+  ) => (pkg[key] ?? config[key] ?? fallback) as NonNullable<Config[K]>;
+
+  const includeComponent = pick("include-component-in-tag", true);
+  const includeV = pick("include-v-in-tag", true);
+  const separator = pick("tag-separator", "-");
+  const component = pkg.component ?? path.split("/").at(-1)!;
+
+  const prefix = includeComponent ? `${component}${separator}` : "";
+  return `${prefix}${includeV ? "v" : ""}${version}`;
+}
+
+/** What every manifest entry claims to have shipped. */
+export async function readTargets(root = "."): Promise<ReleaseTarget[]> {
+  const config = (await Bun.file(`${root}/${CONFIG}`).json()) as Config;
+  const manifest = (await Bun.file(`${root}/${MANIFEST}`).json()) as Record<string, string>;
+  const workspaces = await readWorkspaces(root);
+
+  return Object.entries(manifest).map(([path, version]) => {
+    const workspace = workspaces.find((w) => w.dir === path);
+    return {
+      path,
+      tag: tagFor(path, version, config),
+      version,
+      npmName: workspace?.publishable ? workspace.name : null,
+    };
+  });
+}
+
+export interface Probes {
+  /**
+   * Does a GitHub RELEASE exist at this tag? A bare tag is not enough — the bundlers attach to The
+   * release, and release-please creates both or neither.
+   */
+  releaseExists: (tag: string) => Promise<boolean>;
+  npmHasVersion: (name: string, version: string) => Promise<boolean>;
+}
+
+export async function findGaps(targets: ReleaseTarget[], probes: Probes): Promise<ReleaseGap[]> {
+  const gaps: ReleaseGap[] = [];
+  for (const target of targets) {
+    const missingRelease = !(await probes.releaseExists(target.tag));
+    const missingFromNpm = target.npmName
+      ? !(await probes.npmHasVersion(target.npmName, target.version))
+      : false;
+    if (missingRelease || missingFromNpm) {
+      gaps.push({ ...target, missingRelease, missingFromNpm });
+    }
+  }
+  return gaps;
+}
+
+export function report(gaps: ReleaseGap[]): string {
+  const lines = gaps.map((g) => {
+    const what = [
+      g.missingRelease ? `no GitHub release \`${g.tag}\`` : null,
+      g.missingFromNpm ? `not on npm as \`${g.npmName}@${g.version}\`` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return `- **${g.path}** claims ${g.version} in the manifest — ${what}`;
+  });
+
+  const npmGaps = gaps.filter((g) => g.missingFromNpm).map((g) => g.path);
+  const fixes: string[] = [];
+  if (npmGaps.length > 0) {
+    fixes.push(
+      "Backfill npm (idempotent — already-published versions are skipped):\n\n" +
+        "    gh workflow run publish.yml \\\n" +
+        `      -f paths_released='${JSON.stringify(npmGaps)}' \\\n` +
+        "      -f sha=$(git rev-parse origin/main)",
+    );
+  }
+  if (gaps.some((g) => g.missingRelease)) {
+    fixes.push(
+      "A missing GitHub release means release-please skipped the component. Check the " +
+        "`release-please` job log for “Pull request contains releases, but not for component” " +
+        "and read the header of `commitlint.config.js`.",
+    );
+  }
+
+  return [...lines, "", ...fixes].join("\n");
+}
+
+if (import.meta.main) {
+  const checkNpm = !process.argv.includes("--no-npm");
+
+  const run = (cmd: string[]) =>
+    Bun.spawnSync(cmd, { stderr: "ignore", stdout: "ignore" }).exitCode === 0;
+
+  const probes: Probes = {
+    releaseExists: async (tag) => run(["gh", "release", "view", tag, "--json", "tagName"]),
+    npmHasVersion: async (name, version) => {
+      if (!checkNpm) {
+        return true;
+      }
+      // One retry: this runs immediately after `publish`, and the registry can take a few seconds
+      // To answer for a version it has just accepted.
+      if (run(["npm", "view", `${name}@${version}`, "version"])) {
+        return true;
+      }
+      await Bun.sleep(15_000);
+      return run(["npm", "view", `${name}@${version}`, "version"]);
+    },
+  };
+
+  const targets = await readTargets();
+  const gaps = await findGaps(targets, probes);
+
+  if (gaps.length === 0) {
+    console.log(
+      `All ${targets.length} released components have a GitHub release, and npm has them.`,
+    );
+    process.exit(0);
+  }
+
+  console.error(`${gaps.length} of ${targets.length} released components never shipped:\n`);
+  console.error(report(gaps));
+  process.exit(1);
+}


### PR DESCRIPTION
## What was happening

`14f920de feat(compiler): responsive images — <picture> per format, one owner for loading`

release-please writes that into the release pull request body HTML-escaped (`&lt;picture&gt;`) — correct. But on merge, `findMergedReleasePullRequests()` parses the body and **re-serialises it** (`PullRequestBody.parse(...).toString()`) before `buildRelease()` parses it a *second* time. The round trip reads notes out of the DOM as `textContent`, which is **decoded** — so the second parse sees a live `<picture>` element, node-html-parser swallows the closing `details` tag, and the component vanishes from the parsed release data.

release-please then logs `Pull request contains releases, but not for component: starters`, creates the others, and exits 0.

Reproduced against the real pull request bodies with the release-please version CI runs (17.6.0), and against the newest (17.11.1) — the upstream bug is present in both:

| Release PR | parsed | after round trip | CI actually created |
| --- | --- | --- | --- |
| #129 | 19 | 17 — lost `schema`, `starters` | "Creating 17 releases" |
| #144 | 19 | 17 — lost `schema`, `starters` | "Creating 17 releases" |
| #157 | 19 | 18 — lost `starters` | "Creating 18 releases" |

## Everything else followed from it

- **The release-please loop.** An untagged `starters` has no latest release to measure from, so it was re-proposed every run (1.3.0 → 1.4.0 → 1.5.0 → 1.6.0) and `node-workspace` cascaded a patch bump into create → compiler → server → studio → desktop → import. Merging a release pull request always opened another one.
- **Desktop builds "failing".** They skipped. Measuring an untagged component forces a walk back through 500 commits backfilling file lists, which 5xx'd on run `32523535914` **attempt 1** after 17 releases were already created. Attempts 2 and 3 found #144 already labelled `autorelease: tagged`, so `releases_created` came back `false` and `publish`, all four bundlers, `nix-build` and `deploy-site` skipped. `desktop-v2.2.0` shipped with no installers.
- **npm.** `@jxsuite/starters` stuck at 1.2.2 while `@jxsuite/create@1.3.2` and `@jxsuite/server@2.2.1` shipped depending on `^1.5.0` — `npm install @jxsuite/create` failed with `ETARGET`.

## The two gates

1. **`commitlint.config.js`** gains `changelog-safe-angle-brackets`, with the whole mechanism written up in its header. Applied by the existing `.husky/commit-msg` hook, and — because a hook is skippable with `--no-verify`, which is how the subject landed — by **`scripts/check-changelog-safety.ts`** in the `checks` job over the pull request's own commits. Only the subject and `BREAKING CHANGE:` notes are judged; nothing else reaches a changelog. Run over history it finds all five offenders, including `52b6d7a5`, whose `BREAKING CHANGE` note contains the very tag release-please uses for section headers.

2. **`scripts/check-release-integrity.ts`** asserts every version in `.release-please-manifest.json` has a GitHub release at its tag and — for publishable workspaces — that exact version on npm. It runs in `release-please.yml` as `verify-release-integrity` with `if: always()`, gated on nothing, because a run that released nothing is exactly the run that needs checking. It fails the run and opens one `release-incomplete` issue, and prints the idempotent `gh workflow run publish.yml` invocation that backfills npm. Nothing `needs:` it, so a red X there blocks no other release work.

`CLAUDE.md` documents both failure modes.

## Verification

- Lint, typecheck, type-aware lint green; all 418 `scripts` tests pass (25 of them new).
- Both workflows parse; the new shell step passes `bash -n`.
- `bun run release:integrity` against the live repository correctly reports the one real gap and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXFPf7zugivq8YakwigyoM