### PR TITLE
fix(desktop): a bare jx-studio watched the whole home directory

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,14 +17,14 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.7-draft  | Partial     | 2026-08-20 |
 | `collab.md`               | 0.2.5-draft  | Partial     | 2026-08-20 |
 | `compiler.md`             | 0.3.1-draft  | Partial     | 2026-08-18 |
-| `desktop.md`              | 0.3.15-draft | Pending     | 2026-08-21 |
+| `desktop.md`              | 0.3.17-draft | Pending     | 2026-08-22 |
 | `extensions.md`           | 0.3.10-draft | Partial     | 2026-08-20 |
 | `imports.md`              | 0.1.9-draft  | Partial     | 2026-08-15 |
 | `jx-markdown.md`          | 0.1.8-draft  | Partial     | 2026-08-15 |
 | `parser.md`               | 0.2.9-draft  | Partial     | 2026-08-16 |
 | `relationships.md`        | 0.1.4-draft  | Partial     | 2026-08-15 |
 | `schema.md`               | 0.4.8-draft  | Partial     | 2026-08-16 |
-| `server.md`               | 0.2.10       | Implemented | 2026-08-20 |
+| `server.md`               | 0.2.11       | Implemented | 2026-08-22 |
 | `site-architecture.md`    | 0.5.16-draft | Partial     | 2026-08-19 |
 | `spec.md`                 | 0.5.4-draft  | Partial     | 2026-08-18 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -72,6 +72,8 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.3.17-draft** (2026-08-22) — §9.2: the session watches a project or nothing — a root with no project.json is declined rather than scanned recursively.
+- **0.3.16-draft** (2026-08-22) — §9.2: the launcher adopts its working directory as a project root only when that directory holds a project.json — a named root is still taken at its word.
 - **0.3.15-draft** (2026-08-21) — §9.3: released builds are published to jxsuite.cachix.org and the flake names it, so a consumer substitutes jx-studio instead of building it; verify-cache proves that after each release. The release also builds aarch64-linux as an advisory leg beside the x86_64 gate, and nix.yml runs on pushes to main so pull requests inherit a warm Actions cache for the npm tarball derivations cache.nixos.org cannot serve.
 - **0.3.14-draft** (2026-08-20) — §9.3: the desktop entry ships under a stable id and claims the app_id Chromium actually gives an --app window, so the taskbar/dock can resolve the brand icon.
 - **0.3.13-draft** (2026-08-20) — Chromium launcher reaches PAL parity: its own adapter over createProjectServer (§9.1), multi-window through a cross-process window registry (§9.4), a server-to-client push channel behind live sidebar sync and focus, buildSite behind View: Open in Browser, appInfo for the About screen, and an OS-opener fallback so preview links and sign-in leave the app at all (§3.5, §9.5). New Window becomes the `view.newWindow` command rather than a native-menu-only item, and the native menu drops its duplicate accelerators (§4.2a).
@@ -212,6 +214,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `server.md`
 
+- **0.2.11** (2026-08-22) — §3.1: watch-policy.ts — watchers watch only directories and regular files, and contain symlinks to the root, so a socket cannot throw and a link out cannot walk the filesystem.
 - **0.2.10** (2026-08-20) — The loopback project server's RPC socket carries server-initiated frames (ProjectServerHandle.push) — the loopback twin of the dev server's named fs SSE event, and the channel a desktop launcher raises a window over (§4.2).
 - **0.2.9** (2026-08-18) — §4.2: the Studio shell's report-only Trusted Types header is removed — see spec.md §21.5.
 - **0.2.8** (2026-08-18) — §4.2: both entry points send the Studio shell a report-only Trusted Types policy, and nothing else.

--- a/docs/framework/build/dev-server.md
+++ b/docs/framework/build/dev-server.md
@@ -10,6 +10,7 @@ spec:
 code:
   - packages/server/src/server.ts
   - packages/server/src/watch.ts
+  - packages/server/src/watch-policy.ts
   - packages/server/src/resolve.ts
 ---
 
@@ -57,6 +58,17 @@ The server watches `root` (ignoring `node_modules/`, `dist/`, `.git/`, and frien
 ```
 
 Save a file and every connected page reloads. When the changed file matches a `builds` entry's `match` pattern, that bundle is rebuilt first, so the reload picks up fresh output. The one exception is the Studio editor itself: Studio pages never get the reload script, because Studio refreshes edited files in place and a full reload would discard open tabs and undo history.
+
+### What the watcher skips
+
+Beyond the ignored directory names, two kinds of entry are skipped whatever they are called:
+
+- **Anything that is not a directory or a regular file** — unix sockets, FIFOs and device nodes. The operating system refuses to watch them, and a project directory that happens to hold one (a running agent's socket, say) would otherwise take the watcher down with it.
+- **Symlinks pointing outside the project.** A link that resolves back inside `root` is ordinary project content and its changes reload the page as usual. One that resolves outside is left alone, so the watcher stays inside the directory you pointed it at instead of following a link into the rest of the disk.
+
+:::doc-tip
+Set `watch.ignore` for names you want skipped — `node_modules/`, `dist/`, build caches. The two rules above are not configurable; they are what keeps a watch of one directory a watch of one directory.
+:::
 
 ### Restarting the server
 

--- a/packages/desktop/src/chromium/index.ts
+++ b/packages/desktop/src/chromium/index.ts
@@ -1,6 +1,6 @@
 // oxlint-disable unicorn/no-process-exit -- standalone launcher CLI; exit codes are its interface
 import { basename, isAbsolute, resolve } from "node:path";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import {
   codeService,
@@ -104,9 +104,29 @@ import type { RecentProjectEntry } from "../rpc-schema";
    it the child would adopt the parent's cwd, and a New Window opened from a project directory would
    silently re-open that project. */
 const welcomeWindow = process.env.JX_STUDIO_NO_PROJECT === "1";
+
+/**
+ * The working directory, but only when it is a project — otherwise null.
+ *
+ * A bare `jx-studio` adopting its cwd is what makes "run it inside a project" open that project,
+ * and that stays. What it must not do is adopt a directory that is not one. Launched from a desktop
+ * entry or a shell sitting in `$HOME`, the unconditional fallback made the home directory the
+ * project root, and the session then watched all of it: every unix socket underneath raised a watch
+ * error, and `~/.wine/dosdevices/z:` (a link to `/`) took the walk out of the home directory
+ * altogether. The window showed the welcome screen throughout — `probeRootProject` had already
+ * decided a directory with no project.json is not a project — so the entire scan was work for a
+ * project that was never opened.
+ *
+ * A root named on the command line or in `JSONSX_PROJECT_ROOT` is still taken at its word; only the
+ * one nobody typed has to prove itself.
+ */
+export function implicitProjectRoot(cwd: string): string | null {
+  return existsSync(resolve(cwd, "project.json")) ? cwd : null;
+}
+
 const projectRoot = welcomeWindow
   ? null
-  : process.argv[2] || process.env.JSONSX_PROJECT_ROOT || process.cwd();
+  : process.argv[2] || process.env.JSONSX_PROJECT_ROOT || implicitProjectRoot(process.cwd());
 
 /**
  * Ask an existing window for this project to come forward; report whether there was one.

--- a/packages/desktop/src/project-session.ts
+++ b/packages/desktop/src/project-session.ts
@@ -472,12 +472,40 @@ export function createProjectSession(initialRoot: string | null) {
     }
   }
 
+  /** The last root refused below — so the refusal is logged once, not once per re-arm. */
+  let unwatchableRoot: string | null = null;
+
+  /**
+   * Start watching the active project, or refuse and say so once.
+   *
+   * This asks exactly what the shell asks: `probeRootProject` reads `project.json` and, without
+   * one, reports "no project" and the window shows the welcome screen. A recursive watch of that
+   * root is then a scan of someone's directory tree on behalf of a project that is not open — and a
+   * root is not always small. `jx-studio ~` is the case that matters: the launcher no longer ADOPTS
+   * a non-project working directory, but a root named on the command line is still taken at its
+   * word, and this is where taking it at its word stops being expensive.
+   *
+   * Nothing is lost by waiting. Every way a project can arrive — `openProject`, `createProject`,
+   * `setWindowProject` — re-roots the session and calls back here, and by then the `project.json`
+   * exists. A directory that becomes a project some other way is not watched until the window is
+   * pointed at it, which is also when the sidebar would first have anything to show.
+   */
   function startWatching(): void {
     stopWatching();
-    if (projectRoot && fileEventSink) {
-      const sink = fileEventSink;
-      watcherHandle = createFsWatcher(projectRoot, (events) => sink(events));
+    if (!projectRoot || !fileEventSink) {
+      return;
     }
+    if (!existsSync(resolve(projectRoot, "project.json"))) {
+      // Once per root: startWatching runs again on every re-root and every sink registration.
+      if (unwatchableRoot !== projectRoot) {
+        unwatchableRoot = projectRoot;
+        console.log(`[desktop] not watching ${projectRoot} — no project.json, so no project here`);
+      }
+      return;
+    }
+    unwatchableRoot = null;
+    const sink = fileEventSink;
+    watcherHandle = createFsWatcher(projectRoot, (events) => sink(events));
   }
 
   /** Register (or clear) the sink that receives batched filesystem events for the active project. */

--- a/packages/desktop/tests/chromium-index.test.ts
+++ b/packages/desktop/tests/chromium-index.test.ts
@@ -23,6 +23,10 @@ function toUrlPath(absPath: string): string {
 mkdirSync(join(FIXTURES, "public"), { recursive: true });
 mkdirSync(STUDIO_ASSETS, { recursive: true });
 writeFileSync(join(FIXTURES, "hello.txt"), "Hello Index");
+// A directory that is a project, and one that merely is a directory (what `$HOME` looks like).
+mkdirSync(join(FIXTURES, "implicit-project"), { recursive: true });
+mkdirSync(join(FIXTURES, "implicit-not-a-project"), { recursive: true });
+writeFileSync(join(FIXTURES, "implicit-project", "project.json"), '{"name":"implicit"}');
 writeFileSync(join(FIXTURES, "public", "pub.css"), "body { margin: 0 }");
 writeFileSync(join(STUDIO_ASSETS, "index.html"), "<html>studio-shell</html>");
 // The iframe canvas assets the launcher must serve (staged by scripts/stage-studio-assets.ts).
@@ -1099,6 +1103,24 @@ describe("appInfo", () => {
     const info = (await rpc("appInfo")) as { channel: string; updateStatus?: string };
     expect(info.channel).toBe("system");
     expect(info.updateStatus).toBeUndefined();
+  });
+});
+
+// ─── The working directory as a project root ────────────────────────────────
+
+describe("implicitProjectRoot", () => {
+  test("adopts the working directory when it holds a project.json", () => {
+    // The workflow the fallback exists for: `jx-studio` typed inside a project opens it.
+    expect(chromiumIndex.implicitProjectRoot(join(FIXTURES, "implicit-project"))).toBe(
+      join(FIXTURES, "implicit-project"),
+    );
+  });
+
+  test("refuses a working directory that is not a project", () => {
+    // The regression: launched from a desktop entry or a shell sitting in $HOME, the old
+    // Unconditional fallback made the home directory the project root and the session watched all
+    // Of it — while the window showed the welcome screen, because nothing there was a project.
+    expect(chromiumIndex.implicitProjectRoot(join(FIXTURES, "implicit-not-a-project"))).toBeNull();
   });
 });
 

--- a/packages/desktop/tests/project-session-watch.test.ts
+++ b/packages/desktop/tests/project-session-watch.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Project-session-watch.test.ts — which roots the session agrees to watch.
+ *
+ * A root with no project.json is not a project: `probeRootProject` says so and the window shows the
+ * welcome screen. Watching one recursively is a scan of somebody's directory tree for a project
+ * that is never opened — `jx-studio ~` is how that was found. `createFsWatcher` is mocked so the
+ * decision itself is what is under test, rather than a real inotify race.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const watched: string[] = [];
+const closed = mock(() => Promise.resolve());
+
+void mock.module("@jxsuite/server/refactor", () => ({
+  applyRename: () => Promise.resolve({ edits: [] }),
+  createFsWatcher: (root: string) => {
+    watched.push(root);
+    return { close: closed };
+  },
+  findReferences: () => Promise.resolve({ files: [] }),
+}));
+
+const { createProjectSession } = await import("../src/project-session");
+
+const FIXTURES = resolve(import.meta.dir, "_fixtures_session_watch");
+const PROJECT = resolve(FIXTURES, "a-project");
+const BARE = resolve(FIXTURES, "just-a-directory");
+
+rmSync(FIXTURES, { force: true, recursive: true });
+mkdirSync(PROJECT, { recursive: true });
+mkdirSync(BARE, { recursive: true });
+writeFileSync(resolve(PROJECT, "project.json"), '{"name":"a-project"}');
+
+afterAll(() => {
+  rmSync(FIXTURES, { force: true, recursive: true });
+});
+
+/** Run `fn` with console.log captured, returning the lines it wrote. */
+function capturingLogs(fn: () => void): string[] {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => lines.push(args.join(" "));
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+}
+
+beforeEach(() => {
+  watched.length = 0;
+  closed.mockClear();
+});
+
+describe("the session watches a project", () => {
+  test("registering the sink starts the watcher on a root holding a project.json", () => {
+    const session = createProjectSession(PROJECT);
+    const logs = capturingLogs(() => session.setFileEventSink(() => {}));
+    expect(watched).toEqual([PROJECT]);
+    expect(logs.filter((line) => line.includes("not watching"))).toEqual([]);
+    session.dispose();
+  });
+
+  test("a sink is what starts it — a root alone watches nothing", () => {
+    const session = createProjectSession(PROJECT);
+    expect(watched).toEqual([]);
+    session.dispose();
+  });
+});
+
+describe("the session refuses a root that is not a project", () => {
+  test("no project.json means no watcher, and a line saying why", () => {
+    const session = createProjectSession(BARE);
+    const logs = capturingLogs(() => session.setFileEventSink(() => {}));
+    expect(watched).toEqual([]);
+    expect(logs.some((line) => line.includes("not watching") && line.includes(BARE))).toBe(true);
+    session.dispose();
+  });
+
+  test("the refusal is logged once per root, not once per attempt to arm", () => {
+    const session = createProjectSession(BARE);
+    const logs = capturingLogs(() => {
+      session.setFileEventSink(() => {});
+      // Re-arming the same root — what a second sink registration or a no-op re-root does.
+      session.setFileEventSink(() => {});
+      session.setProjectRoot(BARE);
+    });
+    expect(logs.filter((line) => line.includes("not watching"))).toHaveLength(1);
+    session.dispose();
+  });
+
+  test("re-rooting onto a real project arms the watcher that the bare root did not", () => {
+    const session = createProjectSession(BARE);
+    capturingLogs(() => {
+      session.setFileEventSink(() => {});
+      expect(watched).toEqual([]);
+      session.setProjectRoot(PROJECT);
+    });
+    expect(watched).toEqual([PROJECT]);
+    session.dispose();
+  });
+
+  test("leaving a project for a bare root closes the watcher it had", () => {
+    const session = createProjectSession(PROJECT);
+    capturingLogs(() => {
+      session.setFileEventSink(() => {});
+      expect(watched).toEqual([PROJECT]);
+      session.setProjectRoot(BARE);
+    });
+    expect(closed).toHaveBeenCalled();
+    session.dispose();
+  });
+});

--- a/packages/server/src/refactor/watcher.ts
+++ b/packages/server/src/refactor/watcher.ts
@@ -9,6 +9,7 @@
 import { watch as chokidarWatch } from "chokidar";
 import { coalesceFsEvents, toFsEvent } from "./fs-events.ts";
 import { invalidateReferenceCache } from "./find-refs.ts";
+import { createWatchIgnore } from "../watch-policy.ts";
 import type { FsEventPayload } from "./fs-events.ts";
 
 const IGNORE_SEGMENTS = ["node_modules", ".git", "dist", ".jx", ".direnv", ".devenv"];
@@ -36,9 +37,14 @@ export function createFsWatcher(
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   const watcher = chokidarWatch(root, {
+    /* Left on deliberately: a symlink inside a project is project content, and its events belong
+       in the sidebar. It is the link pointing OUT of the root that walks the watcher off into the
+       rest of the filesystem, and createWatchIgnore drops exactly those — along with the sockets
+       and device nodes fs.watch answers with ENXIO. */
+    followSymlinks: true,
     ignoreInitial: true,
     ignorePermissionErrors: true,
-    ignored: (path) => isIgnored(path),
+    ignored: createWatchIgnore(root, isIgnored),
   });
 
   watcher.on("all", (eventType, changedPath) => {
@@ -59,6 +65,15 @@ export function createFsWatcher(
         buffer = [];
       }
     }, debounceMs);
+  });
+
+  /* An `error` with no listener is not logged by an EventEmitter, it is THROWN — which is how a
+     directory holding a few unix sockets took the whole launcher down rather than losing a few
+     watches. The filter above means these should now be rare; the listener means they are never
+     fatal when they are not. */
+  watcher.on("error", (err) => {
+    const error = err as NodeJS.ErrnoException;
+    console.error(`[fs-watch] ${error.message ?? String(error)}`);
   });
 
   return {

--- a/packages/server/src/watch-policy.ts
+++ b/packages/server/src/watch-policy.ts
@@ -1,0 +1,79 @@
+/**
+ * Watch-policy.ts — the entry filter both filesystem watchers hand to chokidar.
+ *
+ * A watcher is pointed at a directory a **user** chose, and a user's directory holds things that
+ * are not project content and that `fs.watch` does not merely decline to watch:
+ *
+ * - **Unix sockets, FIFOs and device nodes** answer `fs.watch` with `ENXIO`, which chokidar turns
+ *   into an `error` event — one per entry, and fatal to a watcher with no `error` listener.
+ * - **A symlink out of the tree** is followed by default, so one link can turn a project watcher into
+ *   a walk of the whole filesystem. `~/.wine/dosdevices/z:` points at `/`, and that is exactly what
+ *   it did.
+ *
+ * Both were reached at once by a launcher that adopted `$HOME` as a project root. That defect is
+ * fixed where it was made (`packages/desktop/src/chromium/index.ts`), but a watcher must survive
+ * being pointed at an ordinary directory rather than depend on never being pointed at one — so the
+ * rules live here, stated once, because `watch.ts` (dev server) and `refactor/watcher.ts` (desktop
+ * session) both need them and neither owns the other.
+ *
+ * Symlinks are contained rather than banned: a link resolving back inside the root is project
+ * content (a workspace member, a shared assets directory) and keeps its events. Only one leaving
+ * the root — or dangling, which is what `find -xtype l -delete` leaves behind in a nix bundle — is
+ * dropped.
+ *
+ * @docs framework/build/dev-server
+ */
+
+import { realpathSync } from "node:fs";
+import { resolve, sep } from "node:path";
+import type { Stats } from "node:fs";
+
+/** Is `candidate` the base directory itself, or somewhere beneath it? */
+function isInside(base: string, candidate: string): boolean {
+  return candidate === base || candidate.startsWith(base.endsWith(sep) ? base : base + sep);
+}
+
+/**
+ * Resolve `root` through any symlinks so containment is judged against real paths on both sides. An
+ * unresolvable root is not this function's error to raise — chokidar reports it — so the lexical
+ * path stands in and every symlink under it then reads as "outside".
+ */
+function realBase(root: string): string {
+  try {
+    return realpathSync(root);
+  } catch {
+    return resolve(root);
+  }
+}
+
+/**
+ * Build the `ignored` predicate for a watcher rooted at `root`, composing the caller's own
+ * path-name rule (`node_modules`, `dist`, …) with the entry-kind rules above.
+ *
+ * Chokidar calls this with the entry's `lstat` during its directory walk and without stats before
+ * it has them; a stats-less call can only be judged by name, so it is.
+ */
+export function createWatchIgnore(
+  root: string,
+  isIgnoredPath: (path: string) => boolean,
+): (path: string, stats?: Stats) => boolean {
+  let base: string | null = null;
+  return (path: string, stats?: Stats): boolean => {
+    if (isIgnoredPath(path)) {
+      return true;
+    }
+    if (!stats) {
+      return false;
+    }
+    if (stats.isSymbolicLink()) {
+      base ??= realBase(root);
+      try {
+        return !isInside(base, realpathSync(path));
+      } catch {
+        return true;
+      }
+    }
+    // Anything that is not a directory or a regular file is a socket, a FIFO or a device node.
+    return !stats.isDirectory() && !stats.isFile();
+  };
+}

--- a/packages/server/src/watch.ts
+++ b/packages/server/src/watch.ts
@@ -4,6 +4,7 @@ import { watch as chokidarWatch } from "chokidar";
 import { relative } from "node:path";
 import { rebuild } from "./build.ts";
 import { coalesceFsEvents, toFsEvent } from "./refactor/fs-events.ts";
+import { createWatchIgnore } from "./watch-policy.ts";
 import { invalidateReferenceCache } from "./refactor/find-refs.ts";
 import type { BuildEntry } from "./types.ts";
 import type { FsEventPayload } from "./refactor/fs-events.ts";
@@ -201,9 +202,12 @@ export function createWatcher(
       pollInterval: 10,
       stabilityThreshold: debounceMs,
     },
+    /* See watch-policy.ts: `ignore` is a name rule and cannot see that an entry is a unix socket
+       (ENXIO from fs.watch) or a symlink pointing out of the project (a walk of the filesystem). */
+    followSymlinks: true,
     ignoreInitial: true,
     ignorePermissionErrors: true,
-    ignored: (watchedPath) => shouldIgnore(watchedPath, ignore),
+    ignored: createWatchIgnore(root, (watchedPath) => shouldIgnore(watchedPath, ignore)),
   });
 
   watcher.on("all", (eventType, changedPath) => {

--- a/packages/server/tests/refactor-watcher-gaps.test.ts
+++ b/packages/server/tests/refactor-watcher-gaps.test.ts
@@ -9,19 +9,35 @@ import { join } from "node:path";
 import type { FsEventPayload } from "../src/refactor/fs-events";
 
 type AllListener = (eventType: string, changedPath: string) => void;
+type ErrorListener = (error: unknown) => void;
 
 class FakeWatcher {
   closed = false;
   private listeners: AllListener[] = [];
+  private errorListeners: ErrorListener[] = [];
 
-  on(_event: "all", listener: AllListener): this {
-    this.listeners.push(listener);
+  on(event: "all" | "error", listener: AllListener | ErrorListener): this {
+    if (event === "error") {
+      this.errorListeners.push(listener as ErrorListener);
+    } else {
+      this.listeners.push(listener as AllListener);
+    }
     return this;
   }
 
   emit(eventType: string, changedPath: string): void {
     for (const listener of this.listeners) {
       listener(eventType, changedPath);
+    }
+  }
+
+  /** Chokidar's `error` event. An EventEmitter with no listener for it THROWS instead of logging. */
+  emitError(error: unknown): void {
+    if (this.errorListeners.length === 0) {
+      throw error;
+    }
+    for (const listener of this.errorListeners) {
+      listener(error);
     }
   }
 
@@ -74,6 +90,33 @@ describe("createFsWatcher — event filtering and debounce", () => {
       ]);
     } finally {
       await handle.close();
+    }
+  });
+});
+
+describe("createFsWatcher — watch errors", () => {
+  test("logs a watch error instead of letting it throw", () => {
+    const handle = createFsWatcher(ROOT, () => {});
+    const watcher = lastWatcher!;
+    const logged: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => logged.push(args.join(" "));
+    try {
+      // What a unix socket under the watched root produces. Before the listener existed, one of
+      // These ended the launcher; a home directory holds a dozen.
+      const enxio = Object.assign(new Error("ENXIO: no such device or address, watch 'a.sock'"), {
+        code: "ENXIO",
+      });
+      expect(() => watcher.emitError(enxio)).not.toThrow();
+      expect(logged.some((line) => line.includes("ENXIO"))).toBe(true);
+
+      // A thrown non-Error still has to produce a line rather than "undefined".
+      logged.length = 0;
+      watcher.emitError("plain string failure");
+      expect(logged.some((line) => line.includes("plain string failure"))).toBe(true);
+    } finally {
+      console.error = original;
+      void handle.close();
     }
   });
 });

--- a/packages/server/tests/watch-policy.test.ts
+++ b/packages/server/tests/watch-policy.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Watch-policy.test.ts — the entry filter that keeps a watcher inside its project.
+ *
+ * Every case here is a thing found under a real home directory when a launcher adopted it as a
+ * project root: unix sockets fs.watch answers with ENXIO, and `~/.wine/dosdevices/z:`, a symlink to
+ * `/`.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { lstatSync, mkdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Stats } from "node:fs";
+import { createWatchIgnore } from "../src/watch-policy";
+
+const ROOT = join(import.meta.dir, "_fixtures_watch_policy", "project");
+const OUTSIDE = join(import.meta.dir, "_fixtures_watch_policy", "outside");
+
+mkdirSync(join(ROOT, "pages"), { recursive: true });
+mkdirSync(OUTSIDE, { recursive: true });
+writeFileSync(join(ROOT, "project.json"), "{}");
+writeFileSync(join(OUTSIDE, "secret.txt"), "not project content");
+
+function link(target: string, name: string): string {
+  const path = join(ROOT, name);
+  rmSync(path, { force: true });
+  symlinkSync(target, path);
+  return path;
+}
+
+const escaping = link(OUTSIDE, "z:");
+const contained = link(join(ROOT, "pages"), "alias");
+const dangling = link(join(OUTSIDE, "gone"), "dangling");
+
+afterAll(() => {
+  rmSync(join(import.meta.dir, "_fixtures_watch_policy"), { force: true, recursive: true });
+});
+
+const ignore = createWatchIgnore(ROOT, (path) => path.includes("/node_modules/"));
+
+describe("createWatchIgnore", () => {
+  test("keeps directories and regular files", () => {
+    const file = join(ROOT, "project.json");
+    const dir = join(ROOT, "pages");
+    expect(ignore(file, statSync(file))).toBe(false);
+    expect(ignore(dir, statSync(dir))).toBe(false);
+  });
+
+  test("applies the caller's own name rule before looking at the entry at all", () => {
+    // No stats: a name rule is all there is to judge by, and it still decides.
+    expect(ignore(join(ROOT, "node_modules", "left-pad"))).toBe(true);
+    expect(ignore(join(ROOT, "pages", "index.json"))).toBe(false);
+  });
+
+  test("drops a symlink whose target leaves the root, keeps one that stays inside", () => {
+    // The `.wine/dosdevices/z:` case: following it is how one watcher became a filesystem walk.
+    expect(ignore(escaping, lstatSync(escaping))).toBe(true);
+    expect(ignore(contained, lstatSync(contained))).toBe(false);
+  });
+
+  test("drops a dangling symlink rather than reporting its unresolvable target", () => {
+    expect(ignore(dangling, lstatSync(dangling))).toBe(true);
+  });
+
+  test("drops entries that are neither a directory nor a regular file", () => {
+    // A unix socket — fs.watch answers ENXIO, which chokidar raises as an `error` event.
+    const socketish = {
+      isDirectory: () => false,
+      isFile: () => false,
+      isSymbolicLink: () => false,
+    } as unknown as Stats;
+    expect(ignore(join(ROOT, "app.sock"), socketish)).toBe(true);
+  });
+
+  test("falls back to the lexical path when the root itself cannot be resolved", () => {
+    const gone = join(import.meta.dir, "_fixtures_watch_policy", "no-such-root");
+    const ignoreGone = createWatchIgnore(gone, () => false);
+    // Nothing can be inside an unresolvable root, so every symlink under it reads as escaping.
+    expect(ignoreGone(escaping, lstatSync(escaping))).toBe(true);
+  });
+});

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,9 +2,9 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.3.15-draft
+**Version:** 0.3.17-draft
 **Status:** Pending
-**Updated:** 2026-08-21
+**Updated:** 2026-08-22
 **License:** MIT
 
 ---
@@ -821,12 +821,24 @@ which is how filesystem events reach the sidebar and how a focus request reaches
 The entry point performs, in order:
 
 1. Resolves the project root: the first positional argument, else `JSONSX_PROJECT_ROOT`, else the
-   working directory — unless `JX_STUDIO_NO_PROJECT` marks it a welcome window (§9.4)
+   working directory **but only when it holds a `project.json`** — unless `JX_STUDIO_NO_PROJECT`
+   marks it a welcome window (§9.4). A root that was named is taken at its word; the one nobody
+   typed has to prove itself, because the launcher is also started from a desktop entry and from a
+   shell sitting anywhere. Adopting a directory that is not a project bought nothing — the shell
+   shows the welcome screen either way, since `probeRootProject` reads the same `project.json` —
+   and cost a recursive filesystem watch of, in the reported case, the whole home directory
+   (what such a watcher will and will not descend into is `server.md` §3.1)
 2. **Raises an existing window instead of opening a second one** for a project already open (§9.4)
 3. Locates a Chromium binary via `CHROMIUM_BIN` or PATH (`chromium`, `chromium-browser`,
    `google-chrome`, `google-chrome-stable`); this binary is also the import pipeline's browser
 4. Starts `createProjectServer()` on an ephemeral loopback port, and hosts the sign-in redirect on it
-5. Points the session's filesystem-event sink at the server's push channel, so the sidebar is live
+5. Points the session's filesystem-event sink at the server's push channel, so the sidebar is live.
+   **Registering the sink is what starts the watcher, and the session watches a project or nothing
+   at all:** with no `project.json` at the root it logs one line and declines, because that is the
+   same root `probeRootProject` reports as "no project" — a recursive watch of it would be a scan
+   of a user's directory tree on behalf of a project the window is not showing. Nothing is lost by
+   waiting, since every way a project can arrive (`openProject`, `createProject`,
+   `setWindowProject`) re-roots the session and arms the watcher then
 6. Publishes itself in the window registry and starts watching for focus requests
 7. Launches Chromium with app-mode flags:
    - `--app=<serverUrl>/__studio__/index.html?token=<rpcToken>` — frameless window, gated surface
@@ -1102,6 +1114,8 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.3.17-draft** (2026-08-22) — §9.2: the session watches a project or nothing — a root with no project.json is declined rather than scanned recursively.
+- **0.3.16-draft** (2026-08-22) — §9.2: the launcher adopts its working directory as a project root only when that directory holds a project.json — a named root is still taken at its word.
 - **0.3.15-draft** (2026-08-21) — §9.3: released builds are published to jxsuite.cachix.org and the flake names it, so a consumer substitutes jx-studio instead of building it; verify-cache proves that after each release. The release also builds aarch64-linux as an advisory leg beside the x86_64 gate, and nix.yml runs on pushes to main so pull requests inherit a warm Actions cache for the npm tarball derivations cache.nixos.org cannot serve.
 - **0.3.14-draft** (2026-08-20) — §9.3: the desktop entry ships under a stable id and claims the app_id Chromium actually gives an --app window, so the taskbar/dock can resolve the brand icon.
 - **0.3.13-draft** (2026-08-20) — Chromium launcher reaches PAL parity: its own adapter over createProjectServer (§9.1), multi-window through a cross-process window registry (§9.4), a server-to-client push channel behind live sidebar sync and focus, buildSite behind View: Open in Browser, appInfo for the About screen, and an OS-opener fallback so preview links and sign-in leave the app at all (§3.5, §9.5). New Window becomes the `view.newWindow` command rather than a native-menu-only item, and the native menu drops its duplicate accelerators (§4.2a).
@@ -1136,4 +1150,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.3.15-draft_
+_Jx Studio Desktop Architecture Specification v0.3.17-draft_

--- a/specs/server.md
+++ b/specs/server.md
@@ -2,9 +2,9 @@
 
 ## Development Server with Live Reload, Proxy Resolution, and Studio API
 
-**Version:** 0.2.10
+**Version:** 0.2.11
 **Status:** Implemented
-**Updated:** 2026-08-20
+**Updated:** 2026-08-22
 **License:** MIT
 
 ---
@@ -81,6 +81,13 @@ SSE (Server-Sent Events) endpoint backed by `src/watch.ts`. A chokidar watcher o
 1. Runs the `preReload` hook, if configured (e.g. `jx dev`'s site rebuild)
 2. Selectively rebuilds any `builds` entries whose `match` covers the changed file, broadcasting a reload on success
 3. Otherwise broadcasts a reload only when `reloadOnAnyChange` is set
+
+**What a watcher will not watch (`src/watch-policy.ts`).** `watch.ignore` is a rule about names, and two things that break a watcher cannot be recognised by name. Both watchers — this one and the desktop session's (`refactor/watcher.ts`) — therefore compose it with an entry-kind rule:
+
+- **Only directories and regular files are watched.** A unix socket, FIFO or device node answers `fs.watch` with `ENXIO`, which chokidar raises as an `error` event; a watcher without an `error` listener does not log that, it throws. Both watchers listen.
+- **Symlinks are contained, not banned.** A link resolving back inside the root is project content and keeps its events; one resolving outside it, or dangling, is dropped. Following a link out of the root turns a project watcher into a walk of the filesystem — `~/.wine/dosdevices/z:` points at `/`, and a launcher that had adopted the home directory as its project root found it.
+
+The second rule is a containment invariant, not a convenience: **a watcher never emits an event for a path outside the root it was given.**
 
 Two event streams share the connection: the default (unnamed) `reload` message that the injected client (`injectSSE`) turns into `location.reload()`, and named `fs` events — coalesced structured filesystem events that the Studio shell subscribes to for its sidebar while the preview iframe ignores them. Heartbeats every 15 s keep connections alive.
 
@@ -323,6 +330,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.2.11** (2026-08-22) — §3.1: watch-policy.ts — watchers watch only directories and regular files, and contain symlinks to the root, so a socket cannot throw and a link out cannot walk the filesystem.
 - **0.2.10** (2026-08-20) — The loopback project server's RPC socket carries server-initiated frames (ProjectServerHandle.push) — the loopback twin of the dev server's named fs SSE event, and the channel a desktop launcher raises a window over (§4.2).
 - **0.2.9** (2026-08-18) — §4.2: the Studio shell's report-only Trusted Types header is removed — see spec.md §21.5.
 - **0.2.8** (2026-08-18) — §4.2: both entry points send the Studio shell a report-only Trusted Types policy, and nothing else.
@@ -347,4 +355,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_`@jxsuite/server` Specification v0.2.10_
+_`@jxsuite/server` Specification v0.2.11_


### PR DESCRIPTION
Reported from a NixOS launch: `jx-studio` from `~` floods the terminal with `ENXIO` stack traces and the app is unstable. The log's own first three lines name the cause — `Project root: /home/batonac`.

## Diagnosis

Two independent defects that only become a disaster together.

**The launcher adopted the home directory as a project.** `chromium/index.ts` resolved its root as `argv[2] || JSONSX_PROJECT_ROOT || process.cwd()`, unconditionally, and `project-session.ts` pointed a recursive chokidar watcher at the result. The electrobun entry never had that fallback; only the NixOS path did.

The work was wasted either way. `chromium/platform.ts` already knows a directory with no `project.json` is not a project — `probeRootProject` returns `null` and the welcome screen shows. The backend was scanning a home directory for a project the frontend had declined to open.

**The watcher could not survive an ordinary directory.** Its ignore rule matched *names* only (`node_modules`, `.git`, `dist`…), and two things that break a watcher have no name:

- **Unix sockets, FIFOs and device nodes.** `fs.watch` answers `ENXIO`; chokidar raises it as an `error` event, and `refactor/watcher.ts` had **no `error` listener** — an EventEmitter does not log an unhandled `error`, it throws. Every trace in the report is one of those. (`watch.ts` had a listener; this one didn't.)
- **`~/.wine/dosdevices/z:` — a symlink to `/`.** `followSymlinks` defaults to true, which is how `/run/docker.sock`, `/nix/var/nix/daemon-socket/socket` and `/dev/log` appear in a log about a home directory. One watcher had become a walk of the entire filesystem.

Both directions were reproduced against a fixture of the same shape (a socket, a FIFO, a `z:` link to `/`). Unpatched, the watcher escaped through the link and died with an uncaught `ELOOP` at `/run/udev/watch/27` within seconds. Patched: no uncaught exception, no path outside the root, and an in-project symlink still reports its events.

## Fix

Three layers, because each is a defect on its own.

1. **`implicitProjectRoot(cwd)`** (`chromium/index.ts`) — the working directory is adopted only when it holds a `project.json`. A root that was *named* is still taken at its word; only the one nobody typed has to prove itself.
2. **`packages/server/src/watch-policy.ts`** (new) — `createWatchIgnore(root, nameRule)`, composed into both watchers. Only directories and regular files are watched. Symlinks are **contained, not banned**: one resolving back inside the root is project content and keeps its events; one leaving the root, or dangling, is dropped. The invariant is that a watcher never emits for a path outside the root it was given.
3. **An `error` listener** on the session watcher, so a watch error is a log line rather than a dead launcher.

Then, on request: **the session refuses a root that is not a project at all.** With no `project.json` it logs one line and declines — deduped per root, since `startWatching()` runs again on every re-root and sink registration. Nothing is lost by waiting: `openProject`, `createProject` and `setWindowProject` all re-root the session and arm the watcher then. The root itself is still honoured; only the recursive watch declines.

## Verified

```
$ cd ~ && jx-studio          → Project root: (none — welcome window)     (was /home/batonac)
$ cd sites/blog && jx-studio → Project root: …/sites/blog                (watcher armed)
$ jx-studio ~                → not watching /home/batonac — no project.json, so no project here
                               Project root: /home/batonac               (root kept, watch declined)
```

- **server** 822 pass; `watch-policy.ts` and `refactor/watcher.ts` both 100% funcs / 100% lines
- **desktop** 664 pass; `project-session.ts` 96.39/97.42 → **97.59/98.30**
- Neither workspace's worst file moved, so no threshold ratchet is warranted
- Coverage manifest, lint, typecheck and all four docs gates green

## Specs & docs

- `specs/server.md` **0.2.11** — §3.1 gains the watch policy and the containment invariant
- `specs/desktop.md` **0.3.17-draft** — §9.2 step 1 (the cwd fallback now has a condition) and step 5 (the session watches a project or nothing)
- `docs/framework/build/dev-server.md` — a "What the watcher skips" section; `watch-policy.ts` added to its `code:` frontmatter and tagged `@docs`
- Generated reference pages regenerated

## Note for release

`bun.nix` / the Nix package needs a rebuild before an installed `jx-studio` picks this up — the reported build runs from `/nix/store/…-jx-studio-2.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDBuAs8MDRe4modGmxBan4
