### PR TITLE
fix(ci): studio-dist was gated on an output no job published

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
       all_workspaces: ${{ steps.affected.outputs.all_workspaces }}
       lens_mutants: ${{ steps.affected.outputs.gate_lens_mutants }}
       nix: ${{ steps.affected.outputs.gate_nix }}
+      bundles: ${{ steps.affected.outputs.gate_bundle }}
       mode: ${{ steps.affected.outputs.mode }}
     steps:
       - uses: actions/checkout@v7
@@ -401,7 +402,7 @@ jobs:
   # cannot merge.
   studio-dist:
     needs: changes
-    if: contains(fromJSON(needs.changes.outputs.gate_bundle), 'studio')
+    if: contains(fromJSON(needs.changes.outputs.bundles), 'studio')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/scripts/ci/affected.test.ts
+++ b/scripts/ci/affected.test.ts
@@ -150,9 +150,23 @@ describe("the nix build", () => {
     // Diff can reach studio's bundle. It consumes `gate_bundle`, which affected.ts already computes
     // For bundle-analysis, so there is no second gate to keep in step.
     const workflow = await Bun.file(".github/workflows/test.yml").text();
-    expect(workflow).toContain(
-      "if: contains(fromJSON(needs.changes.outputs.gate_bundle), 'studio')",
+    expect(workflow).toContain("if: contains(fromJSON(needs.changes.outputs.bundles), 'studio')");
+  });
+
+  test("every needs.changes output a job reads is one the changes job declares", async () => {
+    // A `needs.<job>.outputs.<name>` that the producing job never declares is not an error in
+    // Actions — it resolves to the empty string. So `contains(fromJSON(""), 'studio')` is simply
+    // False, forever, and the job it guards silently never runs. That is exactly how studio-dist
+    // Shipped dead: affected.ts sets the STEP output `gate_bundle`, the changes job forwarded
+    // Five other outputs and not that one, and nothing anywhere said so.
+    const workflow = await Bun.file(".github/workflows/test.yml").text();
+    const block = workflow.slice(workflow.indexOf("    outputs:"), workflow.indexOf("    steps:"));
+    const declared = new Set([...block.matchAll(/^ {6}(\w+):/gm)].map((m) => m[1]));
+    const read = new Set(
+      [...workflow.matchAll(/needs\.changes\.outputs\.(\w+)/g)].map((m) => m[1]),
     );
+    expect(declared.size).toBeGreaterThan(0);
+    expect([...read].filter((name) => !declared.has(name))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Follow-up to #166, which merged before this landed.

`affected.ts` sets the **step** output `gate_bundle`. The `changes` job forwards five of its step outputs as **job** outputs — and not that one. A `needs.<job>.outputs.<name>` that the producing job never declares is not an error in Actions: it resolves to the empty string. So

```
if: contains(fromJSON(needs.changes.outputs.gate_bundle), 'studio')
```

evaluated `contains(fromJSON(""), 'studio')` → **false, forever**. `studio-dist` has never run once since it landed, and it is on `main` in that state now.

It is forwarded here as `bundles`, matching how `gate_nix` and `gate_lens_mutants` are already renamed on the way out.

## Why the existing assertion missed it

#166 added a test pinning that the `if:` line exists. That checks the line is *written*, not that it can ever be *true* — so it passed against a permanently-false condition.

The new assertion is general instead of specific: **every `needs.changes.outputs.X` the workflow reads must be declared in the `changes` job's `outputs:` block.** It covers the six existing consumers as well as any future one, and it fails for the right reason — a typo or an unforwarded output, not a changed string.

Verified by deleting the `bundles:` line and watching it go red, then restoring it.

## What the gate does once it can run

All four steps, run locally against this commit:

```
✓ check-studio-dist: 204 emitted file(s), 59.7 MB, all accounted for;
  every css url() resolves; 4 unreachable stylesheet pattern(s) on the backlog.
bundle budget: studio.js       2932314 bytes (97.7% of 3000000) — OK.
bundle budget: iframe-entry.js  241843 bytes (93.0% of  260000) — OK.
bundle budget: chunks         11812285 bytes (94.5% of 12500000) — OK.
bundle budget: workers        13617430 bytes (97.3% of 14000000) — OK.
index.html clean
```

So the gate goes green on first run — but note the budgets are **tight**: `studio.js` at 97.7% and `workers` at 97.3% of their ceilings. Worth knowing that this check starts life close to its limits rather than with room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
