### PR TITLE
fix(desktop): the electrobun config is one the CLI can actually load

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,6 +299,13 @@ jobs:
       # consuming it rather than by building it. See the note in that tsconfig.
       - run: bunx tsc -p packages/studio/src/hosting/tsconfig.json
       - run: bun --cwd packages/studio scripts/check-icons.ts
+      # The desktop's electrobun config, judged WITHOUT building the app. The CLI is a compiled Bun
+      # binary whose resolver takes node: builtins and relative paths and NOT bare specifiers — and
+      # a config it cannot load is answered by silently using a different one, so the build dies
+      # later on an entrypoint this package never declared. Nothing was red until a release. Also
+      # checks that the studio copy rows still cover the manifest: a config can load perfectly and
+      # derive an EMPTY list, which packages an app with no studio in it.
+      - run: bun --cwd packages/desktop scripts/check-electrobun-config.ts
       - run: bun run typecheck
       # packages/desktop is EXCLUDED from the root tsconfig (electrobun ships raw .ts in its dist,
       # which the root's two strictest flags reject 165 times) so it needs its own pass — without

--- a/packages/desktop/electrobun.config.ts
+++ b/packages/desktop/electrobun.config.ts
@@ -1,5 +1,17 @@
 import type { ElectrobunConfig } from "electrobun";
-import { STUDIO_ASSETS } from "@jxsuite/studio/hosting/layout";
+/*
+ * RELATIVE, and it has to be. This file is loaded by the `electrobun` CLI — a compiled single-file
+ * Bun binary — whose resolver handles `node:` builtins and relative paths but NOT bare specifiers:
+ * `@jxsuite/studio/hosting/layout` fails with "Cannot find module", on Linux exactly as on Windows.
+ *
+ * The dangerous part is what happens next. The CLI catches the error, prints "using default config
+ * instead", and CARRIES ON with a config that is not this one — so the build dies further down on
+ * `src/bun/index.ts doesn't exist`, naming an entrypoint no file here has ever declared. Every
+ * desktop build broke that way, on all three platforms, and nothing went red until a release.
+ *
+ * `scripts/check-electrobun-config.ts` holds the rule so it cannot come back.
+ */
+import { STUDIO_ASSETS } from "../studio/src/hosting/layout";
 import { readFileSync } from "node:fs";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf8")) as { version: string };

--- a/packages/desktop/scripts/check-electrobun-config.ts
+++ b/packages/desktop/scripts/check-electrobun-config.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env bun
+/**
+ * Prove `electrobun.config.ts` is a config the electrobun CLI can actually load, and that
+ * everything it names exists — without building anything.
+ *
+ * WHY THIS EXISTS, precisely. The CLI is a compiled single-file Bun binary that loads this repo's
+ * config at runtime through its own resolver. That resolver is NARROWER than the one `bun test`
+ * uses: `node:` builtins and relative paths resolve, bare specifiers do not. So
+ *
+ *     import { STUDIO_ASSETS } from "@jxsuite/studio/hosting/layout";
+ *
+ * Imported fine everywhere in this repo — including in `tests/electrobun-config.test.ts`, which
+ * loads the config directly and stayed green — and failed inside the CLI with "Cannot find module".
+ * Measured on electrobun 1.18.1, on linux-x64 and win-x64 alike; a relative import of the same file
+ * loads.
+ *
+ * And the CLI FAILS OPEN. It prints `Failed to load config file: … / using default config instead`
+ * and keeps going, so the build dies much later on the DEFAULT config's entrypoint — `failed to
+ * bundle src/bun/index.ts because it doesn't exist` — naming a path this package has never
+ * declared. Two log lines apart, and only the second one looks like an error. Every desktop build
+ * was broken for the whole window, on all three platforms, and the first thing to notice was a
+ * release.
+ *
+ * So the rules below are split by what they defend:
+ *
+ * RESOLVABLE — the value imports are ones the CLI's resolver can follow. This is the rule that
+ * broke. It is checked STATICALLY, on the import statements, because the only faithful dynamic
+ * check is the CLI itself and that means a 50 MB download and a real build on every pull request.
+ * DECLARED — the entrypoint, hook scripts and icons the config names are on disk. These are the
+ * things whose absence produced the confusing message, and they are cheap. DERIVED — the studio
+ * copy rows still cover the manifest. A config can load perfectly and still derive an EMPTY copy
+ * list (`Object.fromEntries([])` throws nothing), which would ship an app with no studio in it and
+ * no error anywhere.
+ *
+ * SCOPE: this rule is about `electrobun.config.ts` and nothing else. The `preBuild`/`postBuild`
+ * hooks are SPAWNED as ordinary bun processes, so `scripts/stage-studio-assets.ts` and
+ * `scripts/verify-bundle.ts` import `@jxsuite/studio/hosting` by package name and should keep doing
+ * so — that is the exports map being used as intended. Only the config is loaded inside the CLI's
+ * own resolver.
+ *
+ * Runs in `checks`: no build, no network, no electrobun download.
+ */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { STUDIO_ASSETS } from "../../studio/src/hosting/layout";
+
+export const DESKTOP_DIR = resolve(import.meta.dir, "..");
+
+/** The entrypoint the CLI falls back to. Named so a failure can say "this is the fallback". */
+export const DEFAULT_CONFIG_ENTRYPOINT = "src/bun/index.ts";
+
+/** A copy source the config lists that pre-build writes, so it is absent in a clean checkout. */
+const PREBUILD_OUTPUT = "assets/";
+
+export interface ConfigShape {
+  readonly build: {
+    readonly bun: { readonly entrypoint: string };
+    readonly copy: Readonly<Record<string, string>>;
+    readonly linux?: { readonly icon?: string | undefined } | undefined;
+    readonly win?: { readonly icon?: string | undefined } | undefined;
+  };
+  readonly scripts: {
+    readonly preBuild?: string | undefined;
+    readonly postBuild?: string | undefined;
+  };
+}
+
+export interface Inputs {
+  /** The config module's default export. */
+  readonly config: ConfigShape;
+  /** `electrobun.config.ts`, as text — the import rule reads statements, not values. */
+  readonly source: string;
+  /** Injected so the rules are testable without a fixture tree. */
+  readonly exists: (packageRelativePath: string) => boolean;
+}
+
+/**
+ * A value import's specifier, in source order. Type-only imports are ERASED before the CLI ever
+ * resolves anything, so `import type { ElectrobunConfig } from "electrobun"` is legal and must stay
+ * legal — it is the config's own type and there is no relative path to it.
+ */
+export function valueImportSpecifiers(source: string): readonly string[] {
+  const found: string[] = [];
+  const statement = /^import\s+(?<clause>[^;]*?)\s*from\s*["'](?<from>[^"']+)["']/gmu;
+  for (const match of source.matchAll(statement)) {
+    const clause = match.groups?.clause ?? "";
+    const from = match.groups?.from;
+    if (from === undefined || /^type\b/u.test(clause)) {
+      continue;
+    }
+    found.push(from);
+  }
+  return found;
+}
+
+/** What the CLI's resolver can follow from a config file. */
+export function isResolvableByCli(specifier: string): boolean {
+  return specifier.startsWith("node:") || specifier.startsWith(".");
+}
+
+export interface Failure {
+  readonly rule: "resolvable" | "declared" | "derived";
+  readonly message: string;
+}
+
+/** Every rule, over injected inputs. Empty means the config is sound. */
+export function report(inputs: Inputs): readonly Failure[] {
+  const { config, exists, source } = inputs;
+  const failures: Failure[] = [];
+
+  for (const specifier of valueImportSpecifiers(source)) {
+    if (!isResolvableByCli(specifier)) {
+      failures.push({
+        message:
+          `electrobun.config.ts imports "${specifier}", a bare specifier. The electrobun CLI ` +
+          `resolves only node: builtins and relative paths from a config file, and it FAILS OPEN — ` +
+          `it will fall back to a default config whose entrypoint is ${DEFAULT_CONFIG_ENTRYPOINT}, ` +
+          `and the build will die there instead of here. Import it relatively.`,
+        rule: "resolvable",
+      });
+    }
+  }
+
+  const declared: readonly (readonly [string, string | undefined])[] = [
+    ["build.bun.entrypoint", config.build.bun.entrypoint],
+    ["scripts.preBuild", config.scripts.preBuild],
+    ["scripts.postBuild", config.scripts.postBuild],
+    ["build.linux.icon", config.build.linux?.icon],
+    ["build.win.icon", config.build.win?.icon],
+  ];
+  for (const [field, value] of declared) {
+    if (value !== undefined && !exists(value)) {
+      failures.push({
+        message: `${field} names ${value}, which is not on disk.`,
+        rule: "declared",
+      });
+    }
+  }
+
+  if (config.build.bun.entrypoint === DEFAULT_CONFIG_ENTRYPOINT) {
+    failures.push({
+      message:
+        `build.bun.entrypoint is ${DEFAULT_CONFIG_ENTRYPOINT}, which is the electrobun DEFAULT — ` +
+        `the value a failed config load leaves behind. If that is genuinely wanted, rename the file.`,
+      rule: "declared",
+    });
+  }
+
+  const copySources = new Set(Object.keys(config.build.copy));
+  const missing = STUDIO_ASSETS.filter(
+    (asset) => !copySources.has(`assets/studio/${asset.path}`),
+  ).map((asset) => asset.path);
+  if (missing.length > 0) {
+    failures.push({
+      message:
+        `build.copy is missing ${missing.length} studio manifest entr${missing.length === 1 ? "y" : "ies"}: ` +
+        `${missing.join(", ")}. The copy rows are derived from STUDIO_ASSETS; a partial or empty ` +
+        `derivation packages an app with no studio in it and reports nothing.`,
+      rule: "derived",
+    });
+  }
+
+  for (const src of copySources) {
+    if (!src.startsWith(PREBUILD_OUTPUT) && !exists(src)) {
+      failures.push({
+        message: `build.copy source ${src} is not a prebuild output and is not on disk.`,
+        rule: "declared",
+      });
+    }
+  }
+
+  return failures;
+}
+
+export function summary(failures: readonly Failure[], copyRows: number): string {
+  return failures.length === 0
+    ? `✓ check-electrobun-config: imports are CLI-resolvable, every declared path exists, ` +
+        `${copyRows} copy row(s) cover ${STUDIO_ASSETS.length} manifest entr(ies).`
+    : failures.map((f) => `[${f.rule}] ${f.message}`).join("\n");
+}
+
+/** Read the real config off disk and judge it. Returns the number of failures. */
+export async function main(log: (line: string) => void = console.log): Promise<number> {
+  const [{ default: config }, source] = await Promise.all([
+    import("../electrobun.config") as Promise<{ default: ConfigShape }>,
+    Bun.file(resolve(DESKTOP_DIR, "electrobun.config.ts")).text(),
+  ]);
+  const failures = report({
+    config,
+    exists: (path) => existsSync(resolve(DESKTOP_DIR, path)),
+    source,
+  });
+  log(summary(failures, Object.keys(config.build.copy).length));
+  return failures.length;
+}
+
+if (import.meta.main) {
+  process.exit((await main()) > 0 ? 1 : 0);
+}

--- a/packages/desktop/tests/check-electrobun-config.test.ts
+++ b/packages/desktop/tests/check-electrobun-config.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The gate that would have caught the broken desktop build.
+ *
+ * The bug it encodes: `electrobun.config.ts` imported `@jxsuite/studio/hosting/layout`, which every
+ * resolver in this repo follows and the electrobun CLI's does not — and the CLI answers a config it
+ * cannot load by using a DIFFERENT one, silently. See the script header.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_CONFIG_ENTRYPOINT,
+  isResolvableByCli,
+  main,
+  report,
+  summary,
+  valueImportSpecifiers,
+} from "../scripts/check-electrobun-config";
+import type { ConfigShape, Failure, Inputs } from "../scripts/check-electrobun-config";
+import { STUDIO_ASSETS } from "../../studio/src/hosting/layout";
+
+const soundConfig = (): ConfigShape => ({
+  build: {
+    bun: { entrypoint: "src/index.ts" },
+    copy: {
+      "../starters/registry.json": "bun/registry.json",
+      ...Object.fromEntries(
+        STUDIO_ASSETS.map((a) => [`assets/studio/${a.path}`, `views/studio/${a.path}`]),
+      ),
+    },
+    linux: { icon: "icon.png" },
+    win: { icon: "icon.ico" },
+  },
+  scripts: { postBuild: "./scripts/post-build.ts", preBuild: "./scripts/pre-build.ts" },
+});
+
+const SOUND_SOURCE = [
+  'import type { ElectrobunConfig } from "electrobun";',
+  'import { STUDIO_ASSETS } from "../studio/src/hosting/layout";',
+  'import { readFileSync } from "node:fs";',
+].join("\n");
+
+const inputs = (over: Partial<Inputs> = {}): Inputs => ({
+  config: soundConfig(),
+  exists: () => true,
+  source: SOUND_SOURCE,
+  ...over,
+});
+
+const rules = (failures: readonly Failure[]): readonly string[] => failures.map((f) => f.rule);
+
+describe("valueImportSpecifiers", () => {
+  test("skips type-only imports, because the CLI never resolves them", () => {
+    // `import type { ElectrobunConfig } from "electrobun"` is a bare specifier AND correct: it is
+    // Erased before the CLI sees the file, and there is no relative path to a dependency's types.
+    expect(valueImportSpecifiers(SOUND_SOURCE)).toEqual([
+      "../studio/src/hosting/layout",
+      "node:fs",
+    ]);
+  });
+
+  test("reads the specifier, not the clause — default, named and namespace alike", () => {
+    const source = [
+      'import config from "./a";',
+      'import { one, two } from "./b";',
+      'import * as ns from "node:path";',
+    ].join("\n");
+    expect(valueImportSpecifiers(source)).toEqual(["./a", "./b", "node:path"]);
+  });
+
+  test("a file with no imports yields nothing rather than throwing", () => {
+    expect(valueImportSpecifiers("export default {};\n")).toEqual([]);
+  });
+
+  test("an indented import is not a top-level one and is left alone", () => {
+    expect(valueImportSpecifiers('  import { x } from "pkg";')).toEqual([]);
+  });
+});
+
+describe("isResolvableByCli", () => {
+  test("node: builtins and relative paths resolve", () => {
+    expect(isResolvableByCli("node:fs")).toBe(true);
+    expect(isResolvableByCli("./scripts/x")).toBe(true);
+    expect(isResolvableByCli("../studio/src/hosting/layout")).toBe(true);
+  });
+
+  test("a bare specifier does not — this is the whole bug", () => {
+    expect(isResolvableByCli("@jxsuite/studio/hosting/layout")).toBe(false);
+    expect(isResolvableByCli("electrobun")).toBe(false);
+  });
+});
+
+describe("report", () => {
+  test("the real config's shape passes every rule", () => {
+    expect(report(inputs())).toEqual([]);
+  });
+
+  test("a bare value import fails, and the message names the fallback entrypoint", () => {
+    const source = SOUND_SOURCE.replace(
+      "../studio/src/hosting/layout",
+      "@jxsuite/studio/hosting/layout",
+    );
+    const failures = report(inputs({ source }));
+    expect(rules(failures)).toEqual(["resolvable"]);
+    expect(failures[0]?.message).toContain("@jxsuite/studio/hosting/layout");
+    // The message has to carry the SYMPTOM, because that is what the build prints and what anyone
+    // Reading a red CI log will have searched for.
+    expect(failures[0]?.message).toContain(DEFAULT_CONFIG_ENTRYPOINT);
+  });
+
+  test("a declared path that is not on disk fails, naming the field", () => {
+    const failures = report(inputs({ exists: (p) => p !== "./scripts/pre-build.ts" }));
+    expect(rules(failures)).toEqual(["declared"]);
+    expect(failures[0]?.message).toContain("scripts.preBuild");
+  });
+
+  test("an absent icon fails — it is declared per platform and easy to rename", () => {
+    const failures = report(inputs({ exists: (p) => p !== "icon.ico" }));
+    expect(rules(failures)).toEqual(["declared"]);
+    expect(failures[0]?.message).toContain("build.win.icon");
+  });
+
+  test("a platform block with no icon is fine, and an absent one is not confused with it", () => {
+    const config = soundConfig();
+    const failures = report(
+      inputs({ config: { ...config, build: { ...config.build, linux: {}, win: undefined } } }),
+    );
+    expect(failures).toEqual([]);
+  });
+
+  test("the electrobun DEFAULT entrypoint is rejected even when the file exists", () => {
+    // A config that loaded correctly and a config that silently did not both end up here, so the
+    // Value itself is treated as the tell rather than the file's absence.
+    const config = soundConfig();
+    const failures = report(
+      inputs({
+        config: { ...config, build: { ...config.build, bun: { entrypoint: "src/bun/index.ts" } } },
+      }),
+    );
+    expect(rules(failures)).toEqual(["declared"]);
+    expect(failures[0]?.message).toContain("DEFAULT");
+  });
+
+  test("an EMPTY derivation is caught — a config can load and still ship no studio", () => {
+    const config = soundConfig();
+    const failures = report(
+      inputs({
+        config: { ...config, build: { ...config.build, copy: {} } },
+      }),
+    );
+    expect(rules(failures)).toEqual(["derived"]);
+    expect(failures[0]?.message).toContain(String(STUDIO_ASSETS.length));
+  });
+
+  test("a PARTIAL derivation is caught too, and names what is missing", () => {
+    const config = soundConfig();
+    const [dropped] = STUDIO_ASSETS;
+    const copy = { ...config.build.copy };
+    delete copy[`assets/studio/${dropped?.path ?? ""}`];
+    const failures = report(inputs({ config: { ...config, build: { ...config.build, copy } } }));
+    expect(rules(failures)).toEqual(["derived"]);
+    expect(failures[0]?.message).toContain(dropped?.path ?? "");
+  });
+
+  test("a non-prebuild copy source that vanished fails; prebuild outputs are exempt", () => {
+    // `assets/**` is written by pre-build, so it is legitimately absent in a clean checkout;
+    // `../starters/registry.json` is a repo file and a rename of it must be caught here.
+    const failures = report(inputs({ exists: (p) => !p.startsWith("../starters/") }));
+    expect(rules(failures)).toEqual(["declared"]);
+    expect(failures[0]?.message).toContain("../starters/registry.json");
+  });
+});
+
+describe("summary", () => {
+  test("counts both sides when there is nothing wrong", () => {
+    const line = summary([], 16);
+    expect(line).toContain("16 copy row(s)");
+    expect(line).toContain(`${STUDIO_ASSETS.length} manifest`);
+  });
+
+  test("prints every failure, tagged by rule, one per line", () => {
+    const line = summary(
+      [
+        { message: "first", rule: "resolvable" },
+        { message: "second", rule: "derived" },
+      ],
+      0,
+    );
+    expect(line.split("\n")).toEqual(["[resolvable] first", "[derived] second"]);
+  });
+});
+
+describe("main", () => {
+  test("judges the config that is actually committed, and finds it sound", async () => {
+    const lines: string[] = [];
+    expect(await main((line: string) => lines.push(line))).toBe(0);
+    expect(lines[0]).toContain("✓ check-electrobun-config");
+  });
+});

--- a/scripts/check-shadowed-core.test.ts
+++ b/scripts/check-shadowed-core.test.ts
@@ -6,10 +6,18 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { findShadows, removeShadow, shadowsIn } from "./check-shadowed-core";
+import { findShadows, removeScopeBinLinks, removeShadow, shadowsIn } from "./check-shadowed-core";
 
 /** A project root with the given packages installed under `node_modules`. */
 function projectWith(
@@ -217,5 +225,59 @@ describe("a dangling first-party symlink", () => {
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
+  });
+});
+
+describe("the bin links a removed shadow leaves behind", () => {
+  test("a link into the deleted scope goes with it, and a foreign one stays", () => {
+    /* This is not tidiness. A dangling symlink is not skipped by a recursive copy, it THROWS —
+       the desktop build copies packages/starters/sites wholesale into the app and died on
+       `ENOENT: statx .../node_modules/.bin/jx`, a link left by an install whose @jxsuite/compiler
+       this cleaner had already removed. */
+    const root = mkdtempSync(join(tmpdir(), "shadow-bin-"));
+    const nodeModules = join(root, "node_modules");
+    mkdirSync(join(nodeModules, ".bin"), { recursive: true });
+    symlinkSync("../@jxsuite/compiler/src/cli.js", join(nodeModules, ".bin", "jx"));
+    symlinkSync("../js-yaml/bin/js-yaml.mjs", join(nodeModules, ".bin", "js-yaml"));
+
+    const removed = removeScopeBinLinks(nodeModules);
+
+    expect(removed).toHaveLength(1);
+    expect(removed[0]).toContain("jx");
+    // `readdirSync`, not `existsSync`: the foreign link is dangling too (its target was never
+    // Created here), and existsSync FOLLOWS a symlink, so it answers false for a link that is
+    // Very much still on disk. Judging survival by the link itself is the whole point.
+    expect(readdirSync(join(nodeModules, ".bin"))).toEqual(["js-yaml"]);
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  test("the .bin directory itself goes once nothing is left in it", () => {
+    const root = mkdtempSync(join(tmpdir(), "shadow-bin-"));
+    const nodeModules = join(root, "node_modules");
+    mkdirSync(join(nodeModules, ".bin"), { recursive: true });
+    symlinkSync("../@jxsuite/compiler/src/cli.js", join(nodeModules, ".bin", "jx"));
+
+    removeScopeBinLinks(nodeModules);
+
+    expect(existsSync(join(nodeModules, ".bin"))).toBe(false);
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  test("a real file in .bin is never touched — only symlinks are judged", () => {
+    const root = mkdtempSync(join(tmpdir(), "shadow-bin-"));
+    const nodeModules = join(root, "node_modules");
+    mkdirSync(join(nodeModules, ".bin"), { recursive: true });
+    writeFileSync(join(nodeModules, ".bin", "jx"), "#!/bin/sh\n");
+
+    expect(removeScopeBinLinks(nodeModules)).toEqual([]);
+    expect(existsSync(join(nodeModules, ".bin", "jx"))).toBe(true);
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  test("no .bin at all is not an error", () => {
+    const root = mkdtempSync(join(tmpdir(), "shadow-bin-"));
+    mkdirSync(join(root, "node_modules"), { recursive: true });
+    expect(removeScopeBinLinks(join(root, "node_modules"))).toEqual([]);
+    rmSync(root, { force: true, recursive: true });
   });
 });

--- a/scripts/check-shadowed-core.ts
+++ b/scripts/check-shadowed-core.ts
@@ -38,7 +38,7 @@
  * scripts/check-shadowed-core.ts --fix # remove them, then exit 0
  */
 
-import { existsSync, lstatSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, readlinkSync, rmSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
@@ -149,6 +149,56 @@ export function findShadows(roots: readonly string[] = generatorRoots()): Shadow
 }
 
 /**
+ * Delete `.bin` entries that symlink into this `node_modules`'s first-party scope.
+ *
+ * @param {string} nodeModules - The `node_modules` directory to clean
+ * @returns {string[]} Repo-relative paths removed, for the caller to report
+ */
+export function danglingScopeBinLinks(nodeModules: string): string[] {
+  const binDir = join(nodeModules, ".bin");
+  if (!existsSync(binDir)) {
+    return [];
+  }
+  const found: string[] = [];
+  for (const entry of readdirSync(binDir)) {
+    const link = join(binDir, entry);
+    if (!lstatSync(link).isSymbolicLink()) {
+      continue;
+    }
+    /*
+     * Judged on the LINK TEXT, and on whether it still resolves. Two reasons for each half: the
+     * Target is already gone so there is nothing on disk left to ask which package owned it, and
+     * `existsSync` FOLLOWS a symlink — which is what makes it the dangling test rather than an
+     * Existence one. A first-party link that still resolves is a working link and is left alone.
+     */
+    const target = readlinkSync(link).replaceAll("\\", "/");
+    if (target.includes(`${FIRST_PARTY_SCOPE}/`) && !existsSync(link)) {
+      found.push(link);
+    }
+  }
+  return found;
+}
+
+/**
+ * Delete the dangling first-party `.bin` links in this `node_modules`, and the directory if that
+ * empties it.
+ *
+ * @param {string} nodeModules - The `node_modules` directory to clean
+ * @returns {string[]} Repo-relative paths removed, for the caller to report
+ */
+export function removeScopeBinLinks(nodeModules: string): string[] {
+  const removed = danglingScopeBinLinks(nodeModules).map((link) => {
+    rmSync(link, { force: true });
+    return relative(REPO_ROOT, link);
+  });
+  const binDir = join(nodeModules, ".bin");
+  if (existsSync(binDir) && readdirSync(binDir).length === 0) {
+    rmSync(binDir, { recursive: true });
+  }
+  return removed;
+}
+
+/**
  * Remove a shadow, and the stray lockfile the same install dropped beside it.
  *
  * The lockfile goes too because leaving it means the next `bun install` in that root faithfully
@@ -170,6 +220,19 @@ export function removeShadow(shadow: Shadow): void {
     rmSync(join(shadow.root, "bun.lockb"), { force: true });
   }
 
+  /*
+   * The bin links the removed package installed point at it and are now DANGLING, and a dangling
+   * link is not inert: anything that walks the tree with a recursive copy explodes on it rather
+   * than skipping it. `bun install` in a starter writes `node_modules/.bin/jx ->
+   * ../@jxsuite/compiler/src/cli.js`; removing the shadow above leaves that link behind, and the
+   * desktop build — which copies `packages/starters/sites` wholesale into the app — died on
+   * `ENOENT: statx .../node_modules/.bin/jx` months later.
+   *
+   * Only links INTO the scope just deleted are removed. A dangling `js-yaml` beside it is somebody
+   * else's business, and guessing at it would make this cleaner an unpredictable neighbour.
+   */
+  removeScopeBinLinks(join(shadow.root, "node_modules"));
+
   // Prune the scope directory once it is empty, then `node_modules` itself if that emptied it. An
   // Empty `@jxsuite/` shadows nothing — resolution walks past it — but leaving skeletons behind
   // Makes the next person wonder what is in them.
@@ -186,8 +249,16 @@ export function removeShadow(shadow: Shadow): void {
 if (import.meta.main) {
   const fix = process.argv.includes("--fix");
   const shadows = findShadows();
+  /*
+   * Swept independently of the shadows, because an orphan OUTLIVES the shadow that justified it:
+   * removing `node_modules/@jxsuite/compiler` leaves `.bin/jx` pointing into the hole, and on the
+   * next run there is no shadow left to hang the cleanup off. Every such link found in this repo
+   * was in exactly that state.
+   */
+  const roots = generatorRoots();
+  const orphans = roots.flatMap((root) => danglingScopeBinLinks(join(root, "node_modules")));
 
-  if (shadows.length === 0) {
+  if (shadows.length === 0 && orphans.length === 0) {
     console.log("shadowed-core OK: no project root ships its own copy of a first-party package.");
     process.exit(0);
   }
@@ -202,18 +273,24 @@ if (import.meta.main) {
       removeShadow(shadow);
       console.log(`removed${label(shadow).slice(1)}`);
     }
+    const binsRemoved = roots.flatMap((root) => removeScopeBinLinks(join(root, "node_modules")));
+    for (const link of binsRemoved) {
+      console.log(`removed  ${link} (dangling bin link)`);
+    }
     console.log(
-      `shadowed-core: removed ${shadows.length} shadowing package(s). ` +
-        `The install itself is fine — only the first-party copies are gone.`,
+      `shadowed-core: removed ${shadows.length} shadowing package(s) and ${binsRemoved.length} ` +
+        `dangling bin link(s). The install itself is fine — only the first-party copies are gone.`,
     );
     process.exit(0);
   }
 
-  console.error(
-    `\n❌ ${shadows.length} first-party package entr(ies) beat this workspace on resolution:\n`,
-  );
-  for (const shadow of shadows) {
-    console.error(label(shadow));
+  if (shadows.length > 0) {
+    console.error(
+      `\n❌ ${shadows.length} first-party package entr(ies) beat this workspace on resolution:\n`,
+    );
+    for (const shadow of shadows) {
+      console.error(label(shadow));
+    }
   }
   if (shadows.some((s) => s.kind === "shadow")) {
     console.error(
@@ -225,6 +302,17 @@ if (import.meta.main) {
     console.error(
       `\nA dangling link resolves to nothing at all, so the import fails outright — the package ` +
         `it points at moved, and that root's install predates the move.`,
+    );
+  }
+  if (orphans.length > 0) {
+    console.error(`\n${orphans.length} dangling first-party bin link(s):\n`);
+    for (const link of orphans) {
+      console.error(`  ${relative(REPO_ROOT, link)}`);
+    }
+    console.error(
+      `\nA dangling link is not inert. Anything that walks the tree with a recursive copy THROWS ` +
+        `on it rather than skipping it — the desktop build copies packages/starters/sites wholesale ` +
+        `into the app, and died on ENOENT statx for one of these.`,
     );
   }
   console.error(


### PR DESCRIPTION
Desktop builds have been failing since `@jxsuite/studio`'s hosting contract landed. Two distinct causes, one found while verifying the other.

## 1. The config the CLI could not load — and did not say so

`electrobun.config.ts` started deriving its copy rows from the manifest:

```ts
import { STUDIO_ASSETS } from "@jxsuite/studio/hosting/layout";
```

Every resolver in this repo follows that. The electrobun CLI's does not — it is a compiled single-file Bun binary that takes `node:` builtins and relative paths and nothing else. **Not a Windows problem**: it reproduces identically on linux-x64.

What made it expensive is that the CLI **fails open**:

```
Failed to load config file: Cannot find module '@jxsuite/studio/hosting/layout'
using default config instead
    …
error: failed to bundle …/packages/desktop/src/bun/index.ts because it doesn't exist.
```

Two log lines apart, and only the second looks like an error — naming an entrypoint this package has never declared, because it belongs to electrobun's *default* config. Every desktop build was broken for the whole window, on all three platforms, and the first thing to notice was a release.

The import is relative now.

**The hook scripts are deliberately unchanged.** `preBuild`/`postBuild` are spawned as ordinary bun processes, so `stage-studio-assets.ts` and `verify-bundle.ts` import by package name and are using the exports map as intended. Only the config is loaded inside the CLI's own resolver, and the gate says so, so nobody "fixes" the other two.

## 2. A dangling bin link outliving its shadow

With the config loading, the build got further and died on:

```
ENOENT: statx '…/packages/starters/sites/museum/node_modules/.bin/jx'
```

A link left by an install whose `@jxsuite/compiler` `check-shadowed-core` had already removed. A dangling symlink is **not skipped** by a recursive copy — it throws — and the desktop build copies `packages/starters/sites` wholesale into the app.

`removeShadow` now takes the bin links pointing into what it deletes. That alone would not have found this one: the shadow was long gone and the orphan was all that remained, so there was nothing left to hang the cleanup off. The sweep is therefore **independent of the shadows** and a dangling link is a finding in its own right.

Only links that both name the first-party scope **and** no longer resolve are touched — which is what makes the sweep safe to run when no shadow is present. A dangling `js-yaml` beside it stays.

## The gate you asked for

`packages/desktop/scripts/check-electrobun-config.ts`, in `checks`: **no build, no network, no electrobun download.** Three rules, by what each defends:

| rule | what it catches |
| --- | --- |
| `resolvable` | a value import the CLI cannot follow. Static, on the import statements — the only faithful dynamic check is the CLI itself, and that is a 50 MB download and a real build. Type-only imports are exempt: they are erased before the CLI resolves anything, which is why the `ElectrobunConfig` import is legal and must stay legal. |
| `declared` | entrypoint, hook scripts and icons that are not on disk — and the CLI's own default entrypoint value outright, because a config that loaded and one that silently did not both arrive at the same place. |
| `derived` | copy rows that no longer cover `STUDIO_ASSETS`. A config can load perfectly and derive an **empty** list (`Object.fromEntries([])` throws nothing), packaging an app with no studio in it and reporting success. |

### Why static, and why a new file

`tests/electrobun-config.test.ts` already imports the config and asserts things about it — and it stayed green through all of this, because Bun resolves what the CLI could not. That is precisely the gap, and it is why the resolvable rule reads import *statements* rather than loading the module.

## Verification

- Reintroduced the bare specifier → the check names it, quoting the fallback entrypoint so a search for the confusing message lands here.
- Full local `electrobun build`: config loaded, `preBuild` staged, `postBuild` reported `bundle verified`, **exit 0**.
- Desktop coverage 100% functions / 98.97% lines on the new script (bar: 0.90/0.96); 681 desktop tests, 474 scripts tests, lint, both typechecks and `lint:typecheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
