### PR TITLE
ci: the nix build runs on the release pull request alone

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,13 +6,16 @@
 #
 # Five callers, one definition:
 #
-#   * `workflow_call` from test.yml, which owns the PULL-REQUEST leg. It used to be an
-#     `on: pull_request` trigger here, and that is precisely what made it unusable as a required
-#     status check: a path-filtered workflow that does not fire leaves a required check pending
-#     forever. test.yml has no `paths:` filter and its `changes` job decides instead
-#     (scripts/ci/affected.ts, `NIX_INPUTS`), so the Nix build now reports into the single `ci`
-#     aggregate that branch protection names — which is what lets a dependency bump that breaks
-#     packaging block its own auto-merge.
+#   * `workflow_call` from test.yml, which owns the PULL-REQUEST leg — on the RELEASE pull request
+#     alone (`startsWith(github.head_ref, 'release-please--')`). It used to be an `on: pull_request`
+#     trigger here, and that is precisely what made it unusable as a required status check: a
+#     path-filtered workflow that does not fire leaves a required check pending forever. test.yml
+#     has no `paths:` filter, so the Nix build reports into the single `ci` aggregate that branch
+#     protection names. It was then gated on the derivation's inputs, which is most Dependabot pull
+#     requests and by far the slowest job in that workflow; it is now gated on the release branch
+#     instead. The cost of that is explicit: a dependency bump which breaks packaging no longer
+#     blocks its own auto-merge, and surfaces on the release pull request, where `ci` still requires
+#     this job and a human is already reading the diff.
 #   * `push` to `main`, path-filtered. This one exists for the CACHE, not the check: GitHub
 #     Actions caches are branch-scoped, and a PR may read the default branch's cache but never
 #     another PR's. Without a run on `main` there is no base cache for any PR to inherit, and every
@@ -33,9 +36,10 @@ on:
   push:
     branches:
       - main
-    # The same inputs scripts/ci/affected.ts uses to decide the pull-request leg (its NIX_INPUTS
-    # list). Keep the two in step: affected.ts's own test asserts this file has no `pull_request`
-    # trigger, but nothing can assert that two path lists agree with each other.
+    # This filter is now the ONLY path list for the Nix build; affected.ts no longer carries a
+    # Counterpart (`NIX_INPUTS` is gone, along with the gate it fed). It is a CACHE trigger, not a
+    # Check: it decides when `main` refreshes the cache every pull request inherits, so being a
+    # Little generous here is cheap and being narrow is what leaves a PR refetching ~1000 tarballs.
     paths:
       # The derivation, the generated dependency set, and the lockfile it is generated from.
       - "flake.nix"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
       has_tests: ${{ steps.affected.outputs.has_tests }}
       all_workspaces: ${{ steps.affected.outputs.all_workspaces }}
       lens_mutants: ${{ steps.affected.outputs.gate_lens_mutants }}
-      nix: ${{ steps.affected.outputs.gate_nix }}
       bundles: ${{ steps.affected.outputs.gate_bundle }}
       mode: ${{ steps.affected.outputs.mode }}
     steps:
@@ -433,9 +432,16 @@ jobs:
   # `ci`, and the Nix package is the ONLY consumer of bun.nix and the flake inputs. Without this,
   # a bump that breaks packaging would land on main and first be noticed by a release refusing to
   # advance. The gate is scripts/ci/affected.ts's NIX_INPUTS.
+  # THE RELEASE PULL REQUEST ONLY. It used to run on any diff touching the derivation's inputs —
+  # `bun.lock`, `package.json`, `packages/desktop/**` — which is most Dependabot pull requests, and
+  # it is by far the slowest job here. The trade taken deliberately: a dependency bump that breaks
+  # packaging no longer blocks its own auto-merge, and is caught on the release pull request
+  # instead, where `ci` still requires this job and a human is already reading the diff. The two
+  # legs that were never about pull requests are untouched — nix.yml still builds on `push: main`
+  # and nightly to keep the cache warm, and release-please.yml still gates the `release` branch on
+  # it, BARE, so a broken derivation can never reach a `nix run github:jxsuite/jx/release` user.
   nix:
-    needs: changes
-    if: needs.changes.outputs.nix == 'true'
+    if: startsWith(github.head_ref, 'release-please--')
     # No `with:` — the defaults are the pull-request shape (ubuntu-latest, the checked-out ref, no
     # publish). No `secrets:` either: CACHIX_AUTH_TOKEN is only needed on the release leg, and a
     # pull request must not be able to write to the public cache.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,18 @@ So the invariant moved. `bun.nix` matches `bun.lock` **at every release**, not a
 - `.github/workflows/release-bun-nix.yml` commits the regenerated file to the **release pull request** — the branch that becomes the tag, and one a human is already watching.
 - `nix.yml`'s release leg (`publish: true`) runs the check BARE. A drift there is a failure, not a fixup: if the sync ever fails to land, the release build fails, `release` does not advance, and release-please opens an issue. A stale `bun.nix` cannot reach a user.
 
-### The Nix build is part of `ci`
+### The Nix build runs on the release pull request, and nowhere else in `ci`
 
-`nix.yml` no longer has an `on: pull_request` trigger. A path-filtered workflow can never be a required check — it leaves the check pending forever when it does not fire — so test.yml (which has no `paths:` filter, and must never grow one) owns the pull-request leg via `workflow_call`, gated on `affected.ts`'s `NIX_INPUTS`, and the `ci` aggregate requires it. That is what lets a dependency bump which breaks packaging block its own auto-merge.
+`nix.yml` has no `on: pull_request` trigger. A path-filtered workflow can never be a required check — it leaves the check pending forever when it does not fire — so test.yml (which has no `paths:` filter, and must never grow one) owns the pull-request leg via `workflow_call`, and the `ci` aggregate requires it.
 
-`flake.nix`, `flake.lock` and `bun.nix` moved OUT of `affected.ts`'s GLOBAL list in the same change: no test suite reads them, so a weekly flake-input bump now runs the Nix build and nothing else instead of spending the whole matrix.
+**It is gated on the branch, not on the diff**: `startsWith(github.head_ref, 'release-please--')`. It was gated on the derivation's inputs (`bun.lock`, `package.json`, `packages/desktop/**`), which is most Dependabot pull requests, and it is by far the slowest job in the workflow.
+
+The cost of that is explicit and was accepted: **a dependency bump which breaks packaging no longer blocks its own auto-merge.** It surfaces one step later, on the release pull request, where `ci` still requires the job and a human is already reading the diff — and behind that, `nix.yml`'s release leg runs BARE, so a broken derivation still cannot reach a `nix run github:jxsuite/jx/release` user. `skipped` is green and `failure` is not, which is what makes a branch gate enough.
+
+Consequences for agents:
+
+- **`affected.ts` no longer decides anything about Nix.** `NIX_INPUTS`, `Decision.nixBuild` and the `gate_nix` output are gone; do not reintroduce a path list for it. The only path list left is `nix.yml`'s own `push: main` filter, and that one is a **cache** trigger, not a check — it keeps `main`'s cache warm for every PR to inherit.
+- `flake.nix`, `flake.lock` and `bun.nix` stay in `affected.ts`'s `NO_TESTS`: no test suite reads them, so they must not fail open into the whole matrix either.
 
 ### Settings, not code
 

--- a/scripts/ci/affected.test.ts
+++ b/scripts/ci/affected.test.ts
@@ -72,75 +72,67 @@ describe("nothing at all", () => {
     const d = decide([".github/workflows/publish.yml", ".github/dependabot.yml"], workspaces);
     expect(d.testDirs).toEqual([]);
     expect(d.bundles).toEqual([]);
-    expect(d.nixBuild).toBe(false);
   });
 
   test("an empty diff runs nothing", () => {
     const d = decide([], workspaces);
     expect(d.testDirs).toEqual([]);
-    expect(d.nixBuild).toBe(false);
+    expect(d.bundles).toEqual([]);
   });
 });
 
 describe("the nix build", () => {
-  // The gate that lets `nix / build` be part of the required `ci` check. Before it, the Nix
-  // Workflow carried its own path-filtered `on: pull_request`, which can never be required: a
-  // Path-filtered workflow that does not fire leaves the check pending forever.
-  test("the flake and its lockfile run the nix build and NOTHING else", () => {
-    // This is the shape of a Dependabot flake-input bump. It used to be in GLOBAL, which spent
-    // The entire ~22-job matrix to answer a question only `nix build` can answer — no test suite
-    // Reads flake.nix, flake.lock or bun.nix.
+  /*
+   * It runs on the RELEASE pull request alone. It used to be gated on the derivation's own inputs
+   * — bun.lock, package.json, packages/desktop/** — which is most Dependabot pull requests, and it
+   * is by far the slowest job in this workflow. The trade is deliberate and it is a real one: a
+   * dependency bump that breaks packaging no longer blocks its own auto-merge. It is caught one
+   * step later instead, on the release pull request, where `ci` still requires this job.
+   */
+  test("nix is gated on the release branch, not on a diff", async () => {
+    const workflow = await Bun.file(".github/workflows/test.yml").text();
+    expect(workflow).toContain("if: startsWith(github.head_ref, 'release-please--')");
+    expect(workflow).toContain("uses: ./.github/workflows/nix.yml");
+    // `head_ref` is empty on `push`, so the push-to-main run of THIS workflow does not build nix.
+    // Nix.yml's own `push: main` trigger owns that leg, and it exists for the cache, not the check.
+    expect(workflow).not.toContain("needs.changes.outputs.nix");
+  });
+
+  test("the branch prefix is the one release-please actually opens", () => {
+    // Not derivable from release-please-config.json: the branch name is release-please's default,
+    // `release-please--branches--<target>`. Pinned from the merged pull requests in this repo
+    // (#171, #164, #159 … all `release-please--branches--main`), and asserted here so a change to
+    // `separate-pull-requests` or a branch-prefix setting has to come past this line.
+    expect("release-please--branches--main".startsWith("release-please--")).toBe(true);
+  });
+
+  test("ci still depends on nix, so a red derivation blocks the RELEASE pull request", async () => {
+    // The whole value of moving it: skipped is green, failed is not. `ci` is the one name branch
+    // Protection points at, and a nix job it does not depend on could not block anything.
+    const workflow = await Bun.file(".github/workflows/test.yml").text();
+    expect(workflow).toContain(
+      "needs: [changes, test, checks, lens-mutants, studio-dist, nix, coverage-comment]",
+    );
+  });
+
+  test("the derivation's inputs still cost NOTHING in the test matrix", () => {
+    // This is what kept flake.nix out of GLOBAL, and it outlives the gate: no test suite reads
+    // These, so they must not fail open into the whole ~22-job fan-out either.
     for (const path of ["flake.nix", "flake.lock", "bun.nix"]) {
       const d = decide([path], workspaces);
-      expect(d.nixBuild).toBe(true);
       expect(d.mode).toBe("affected");
       expect(d.testDirs).toEqual([]);
       expect(d.bundles).toEqual([]);
     }
   });
 
-  test("the lockfile runs both — it moves the dependency set the tests AND the derivation use", () => {
-    const d = decide(["bun.lock"], workspaces);
-    expect(d.nixBuild).toBe(true);
-    expect(d.mode).toBe("all");
-  });
-
-  test("the desktop app, the workflow, and the generator's own source are inputs", () => {
-    expect(decide(["packages/desktop/package.nix"], workspaces).nixBuild).toBe(true);
-    expect(decide([".github/workflows/nix.yml"], workspaces).nixBuild).toBe(true);
-    expect(decide(["scripts/check-bun-nix.ts"], workspaces).nixBuild).toBe(true);
-  });
-
-  test("a change the derivation cannot notice does not pay for a nix build", () => {
-    expect(decide(["docs/start/install.md"], workspaces).nixBuild).toBe(false);
-    expect(decide(["packages/studio/src/studio.ts"], workspaces).nixBuild).toBe(false);
-    expect(decide([".github/workflows/publish.yml"], workspaces).nixBuild).toBe(false);
-  });
-
-  test("an unclassified path fails OPEN into the nix build too", () => {
-    // `src = lib.cleanSource ../..` — the derivation's input IS the tree, so a path nobody has
-    // Classified is a path that may well change what it builds.
-    expect(decide(["some-new-toplevel-dir/thing.ts"], workspaces).nixBuild).toBe(true);
-  });
-
   test("nix.yml must not ALSO carry its own pull_request trigger", async () => {
-    // Two triggers would mean two builds of the same commit on every pull request, in different
-    // Concurrency groups, neither cancelling the other. test.yml owns this leg now.
+    // Two triggers would mean two builds of the same commit on the release pull request, in
+    // Different concurrency groups, neither cancelling the other. test.yml owns this leg.
     const workflow = await Bun.file(".github/workflows/nix.yml").text();
     const triggers = workflow.slice(workflow.indexOf("\non:"), workflow.indexOf("\npermissions:"));
     expect(triggers).not.toContain("pull_request:");
     expect(triggers).toContain("workflow_call:");
-  });
-
-  test("test.yml requires the nix job, and gates it on this script's output", async () => {
-    const workflow = await Bun.file(".github/workflows/test.yml").text();
-    expect(workflow).toContain("gate_nix");
-    expect(workflow).toContain("uses: ./.github/workflows/nix.yml");
-    // The `ci` aggregate is the ONE name branch protection points at; a nix job it does not
-    // Depend on is a nix job that cannot block an auto-merge.
-    expect(workflow).toContain(
-      "needs: [changes, test, checks, lens-mutants, studio-dist, nix, coverage-comment]",
-    );
   });
 
   test("test.yml requires studio-dist, and gates it on this script's output", async () => {
@@ -151,6 +143,22 @@ describe("the nix build", () => {
     // For bundle-analysis, so there is no second gate to keep in step.
     const workflow = await Bun.file(".github/workflows/test.yml").text();
     expect(workflow).toContain("if: contains(fromJSON(needs.changes.outputs.bundles), 'studio')");
+  });
+
+  test("every output the changes job forwards is one this script actually writes", async () => {
+    /*
+     * The mirror of the rule below, and the same silent failure from the other end: a job output
+     * Wired to `steps.affected.outputs.<name>` that the script never writes resolves to the empty
+     * String, so every consumer of it quietly reads false. `gate_nix` became exactly that the
+     * Moment the nix gate was deleted, and only this assertion would have said so.
+     */
+    const workflow = await Bun.file(".github/workflows/test.yml").text();
+    const script = await Bun.file("scripts/ci/affected.ts").text();
+    const block = workflow.slice(workflow.indexOf("    outputs:"), workflow.indexOf("    steps:"));
+    const wired = [...block.matchAll(/steps\.affected\.outputs\.(\w+)/g)].map((m) => m[1]);
+    const written = new Set([...script.matchAll(/^ {4}(\w+):/gm)].map((m) => m[1]));
+    expect(wired.length).toBeGreaterThan(0);
+    expect(wired.filter((name) => !written.has(name))).toEqual([]);
   });
 
   test("every needs.changes output a job reads is one the changes job declares", async () => {

--- a/scripts/ci/affected.ts
+++ b/scripts/ci/affected.ts
@@ -50,37 +50,6 @@ const GLOBAL = [
 ];
 
 /**
- * The inputs to the Nix build, and the reason the `nix` job in test.yml exists at all.
- *
- * This is a translation of the `paths:` filter nix.yml carries on its `push` leg — which is where
- * the pull-request leg used to live. It moved because a required status check must come from a
- * workflow that ALWAYS runs: a path-filtered workflow that does not fire leaves the check pending
- * forever, so the Nix build could never be required while it gated itself. Now test.yml (no
- * `paths:`) always runs, this decides, and the Nix build reports into the one `ci` aggregate that
- * branch protection names. Which is the point: a dependency bump that breaks packaging has to be
- * able to block its own auto-merge.
- *
- * `flake.nix`, `flake.lock` and `bun.nix` are here rather than in GLOBAL, which is where the first
- * two lived. GLOBAL means "runs the entire test matrix", and these three cannot change the outcome
- * of a single test: no suite reads them (scripts/check-bun-nix.test.ts is the one file that does,
- * and it runs unconditionally in the `changes` job, not in the matrix). Leaving them in GLOBAL made
- * a Dependabot flake-input bump — four commits' worth of nixpkgs, weekly — spend the whole ~22-job
- * matrix to answer a question only `nix build` can answer.
- *
- * `bun.lock` and `package.json` stay in GLOBAL AND appear here: they genuinely move both.
- */
-const NIX_INPUTS = [
-  "flake.nix",
-  "flake.lock",
-  "bun.nix",
-  "bun.lock",
-  "package.json",
-  "packages/desktop/**",
-  ".github/workflows/nix.yml",
-  "scripts/check-bun-nix.ts",
-];
-
-/**
  * Dependency edges that exist in the filesystem but not in any `package.json`. Each declares the
  * test file that justifies it; those files are asserted to exist at startup, so deleting one reds
  * this script — the FIRST job in the graph — instead of silently un-gating a suite.
@@ -163,8 +132,9 @@ const EXTRA_EDGES: ExtraEdge[] = [
  * workspace prefix, nor an extra edge, nor GLOBAL, turns everything on (see FAIL OPEN above).
  */
 const NO_TESTS = [
-  // The Nix derivation's inputs. They gate the `nix` job (NIX_INPUTS above) and no test suite
-  // Reads them, so they must not also FAIL OPEN into the whole matrix.
+  // The Nix derivation's inputs. No test suite reads them, so they must not FAIL OPEN into the
+  // Whole matrix. Nothing here gates the `nix` job any more — it runs on the release pull request
+  // Alone (test.yml), so this list is only about keeping the test matrix off them.
   "flake.nix",
   "flake.lock",
   "bun.nix",
@@ -267,24 +237,15 @@ interface Decision {
   reason: string;
   testDirs: string[];
   lensMutants: boolean;
-  nixBuild: boolean;
   bundles: string[];
 }
 
 export function decide(changed: string[], workspaces: Workspace[]): Decision {
-  // The Nix build is decided over the whole diff, independently of everything below, because it
-  // Is not a function of the workspace graph — `src` is the tree, and what can break the build is
-  // The derivation's own inputs. Computing it here also means it survives the early returns.
-  const nixBuild = changed.some((p) => matches(p, NIX_INPUTS));
-
   const all = (reason: string): Decision => ({
     mode: "all",
     reason,
     testDirs: workspaces.map((w) => w.dir),
     lensMutants: true,
-    // FAIL OPEN, the same way the test matrix does: a path nobody classified may well be one the
-    // Derivation notices, and `src = lib.cleanSource ../..` means almost any file can be.
-    nixBuild: true,
     bundles: [...BUNDLES],
   });
 
@@ -294,7 +255,6 @@ export function decide(changed: string[], workspaces: Workspace[]): Decision {
       reason: "no files changed",
       testDirs: [],
       lensMutants: false,
-      nixBuild: false,
       bundles: [],
     };
   }
@@ -369,7 +329,6 @@ export function decide(changed: string[], workspaces: Workspace[]): Decision {
     // Would not have survived before. Gating on the test set instead would fire this 87s job on
     // Most PRs in the repo, since studio sits downstream of nearly everything.
     lensMutants: changedWorkspaces.has("packages/studio") || edgeTargets.has("packages/studio"),
-    nixBuild,
     bundles,
   };
 }
@@ -424,7 +383,6 @@ async function main(): Promise<void> {
       reason: `${event} is never gated`,
       testDirs: workspaces.map((w) => w.dir),
       lensMutants: true,
-      nixBuild: true,
       bundles: [...BUNDLES],
     };
   } else {
@@ -436,7 +394,6 @@ async function main(): Promise<void> {
             reason: "could not determine the diff",
             testDirs: workspaces.map((w) => w.dir),
             lensMutants: true,
-            nixBuild: true,
             bundles: [...BUNDLES],
           }
         : decide(changed, workspaces);
@@ -452,7 +409,6 @@ async function main(): Promise<void> {
     has_tests: String(include.length > 0),
     all_workspaces: JSON.stringify(workspaces.map((w) => w.flag)),
     gate_lens_mutants: String(decision.lensMutants),
-    gate_nix: String(decision.nixBuild),
     gate_bundle: JSON.stringify(decision.bundles),
     has_bundle: String(decision.bundles.length > 0),
   };
@@ -486,7 +442,6 @@ async function main(): Promise<void> {
     ...workspaces.map((w) => `| \`${w.flag}\` | ${ran.has(w.dir) ? "ran" : "not affected"} |`),
     "",
     `lens-mutants: ${decision.lensMutants ? "ran" : "not affected"} · ` +
-      `nix build: ${decision.nixBuild ? "ran" : "not affected"} · ` +
       `bundles: ${decision.bundles.length > 0 ? decision.bundles.join(", ") : "none"}`,
   ].join("\n");
 


### PR DESCRIPTION
The Nix build was gated on the derivation's inputs — `bun.lock`, `package.json`, `packages/desktop/**` — which is **most Dependabot pull requests**, and it is by far the slowest job in the workflow. The value it bought there did not match what it cost on every unrelated bump.

It is gated on the branch now:

```yaml
nix:
  if: startsWith(github.head_ref, 'release-please--')
```

## The one thing worth verifying first

That release-please's own pull request actually gets check runs. It is not obvious in this repo — a `GITHUB_TOKEN` push raises no `pull_request` event, which is precisely why `bun.nix` cannot be regenerated on a Dependabot branch. So I checked rather than assumed:

| PR | checks | `ci` | `nix / build` |
| --- | --- | --- | --- |
| #171 | 12 | success | **success** |
| #164 | 20 | success | **success** |

## The cost, stated plainly

**A dependency bump which breaks packaging no longer blocks its own auto-merge.** It surfaces one step later, on the release pull request, where `ci` still requires the job and a human is already reading the diff — and behind that, `nix.yml`'s release leg runs **bare**, so a broken derivation still cannot reach a `nix run github:jxsuite/jx/release` user.

What makes a branch gate sufficient is that `ci` tests for `failure`/`cancelled` rather than requiring success: `skipped` is green, `failure` is not.

The two legs that were never about pull requests are untouched — `push: main` and nightly still warm the cache, and `release-please.yml` still gates the `release` branch.

## The dead gate is deleted, not left wired to nothing

`NIX_INPUTS`, `Decision.nixBuild` and the `gate_nix` output are gone. `nix.yml`'s `push: main` path filter is now the only path list for the derivation, and its comment says what it is: a **cache** trigger, not a check.

`flake.nix` / `flake.lock` / `bun.nix` stay in `affected.ts`'s `NO_TESTS` — no test suite reads them, so they must not fail open into the matrix either. That property has its own test, which outlives the gate.

## A second silent-wiring bug, found by doing this

Deleting `gate_nix` left `nix: ${{ steps.affected.outputs.gate_nix }}` in the `changes` job's `outputs:`, wired to something no longer written. That is the **same failure as the `studio-dist` one from #167, from the other end**: it resolves to the empty string and every consumer quietly reads false.

Removed — and asserted. There are now two rules, and they are mirrors:

- every output a job **reads** must be one the `changes` job **declares** (#167)
- every output the job **forwards** must be one the script actually **writes** (here)

Verified by putting the dead line back and watching it go red.

## Docs

`CLAUDE.md`'s "The Nix build is part of `ci`" section is rewritten to match, including the accepted trade-off and a "do not reintroduce a path list for it" note, since the old text told the next reader the opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
