### PR TITLE
feat(studio): Cloudflare is the lead AI recommendation, and can be reconnected

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -14,7 +14,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 
 | Spec                      | Version      | Status      | Updated    |
 | ------------------------- | ------------ | ----------- | ---------- |
-| `ai.md`                   | 0.1.7-draft  | Partial     | 2026-08-20 |
+| `ai.md`                   | 0.1.8-draft  | Partial     | 2026-08-23 |
 | `collab.md`               | 0.2.5-draft  | Partial     | 2026-08-20 |
 | `compiler.md`             | 0.3.1-draft  | Partial     | 2026-08-18 |
 | `desktop.md`              | 0.3.19-draft | Pending     | 2026-08-22 |
@@ -35,7 +35,6 @@ This page is generated from the `> **Status: …**` markers in the specification
 
 ### Partial
 
-- `ai.md` §2 — Provider Contract
 - `collab.md` §5 — Version Skew
 - `compiler.md` §3 — Output Tiers
 - `desktop.md` §10 — SaaS / Cloud Mode

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -14,6 +14,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `ai.md`
 
+- **0.1.8-draft** (2026-08-23) — 2.1 Managed providers: a platform may broker credentials, Studio offers that path before the key form, and the models endpoint is specified as a capability probe that must answer 200 for every credential state — with cf_not_connected, cf_reconnect_required and cf_upstream_error distinguished.
 - **0.1.7-draft** (2026-08-20) — The Anthropic client yields an error event with code NOT_IMPLEMENTED; it does not throw (§2).
 - **0.1.6-draft** (2026-08-16) — §2 failures are problem documents and the mid-stream frame carries one; gap:ai-problem-details closed.
 - **0.1.5-draft** (2026-08-15) — Add §5 Standards Alignment: SSE, the IANA special-purpose address registries the SSRF guard uses, and the problem+json gap.

--- a/docs/studio/ai.md
+++ b/docs/studio/ai.md
@@ -41,6 +41,14 @@ On Jx Cloud that section leads with **Connect Cloudflare**: Studio brokers **Wor
 
 This option appears only where a platform can run that hosted flow. The desktop app and the dev server show the key form alone.
 
+#### When the connection expires
+
+A Cloudflare authorization does not last forever. When yours lapses, the same place in Preferences says so and the button reads **Reconnect Cloudflare** — one click through the same approval screen and the assistant works again. Nothing else about the project changes, and your model choice is remembered.
+
+:::doc-note
+If Cloudflare itself is briefly unreachable, Studio does **not** ask you to reconnect — reconnecting would not help. The assistant reports the provider as unavailable and keeps the connection you already have.
+:::
+
 ### Bring your own key
 
 Below the Cloudflare option (or on its own, everywhere else) is the **AI provider key** form:

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -518,6 +518,16 @@ export interface AiModelsResponse {
   defaultModel?: string;
   /** Set when the upstream provider was unreachable and defaults were returned. */
   upstreamError?: number | string;
+  /**
+   * Why the backend holds no working credentials, when it holds none.
+   *
+   * `configured: false` alone cannot tell "this user has never connected" from "this user's grant
+   * lapsed", and those are different sentences on screen — the second one explains a thing that
+   * used to work. `cf_upstream_error` is the third case and deliberately arrives WITH `configured:
+   * true`: Cloudflare being briefly unreachable is not a reason to send someone round an OAuth flow
+   * that fixes nothing.
+   */
+  code?: "cf_not_connected" | "cf_reconnect_required" | "cf_upstream_error";
 }
 
 // ─── Cloudflare publish surface ──────────────────────────────────────────────

--- a/packages/studio/src/services/ai-models.ts
+++ b/packages/studio/src/services/ai-models.ts
@@ -24,6 +24,7 @@ let cache: AiModel[] | null = null;
 let proxyConfigured = false;
 let proxyManaged = false;
 let proxyDefaultModel = "";
+let proxyCode: AiModelsResponse["code"];
 
 /**
  * One-shot capability probe shared by every credentials gate, plus the hosts to repaint when it
@@ -39,7 +40,8 @@ export function invalidateModelCache() {
   proxyConfigured = false;
   proxyManaged = false;
   proxyDefaultModel = "";
-  /* The probe's result IS the three flags above. Clearing them while keeping the settled promise
+  proxyCode = undefined;
+  /* The probe's result IS the flags above. Clearing them while keeping the settled promise
      would strand every gate on a permanent "unconfigured, unmanaged" reading — ensureProxyProbe
      would no-op forever and the managed option would vanish until a full reload. */
   proxyProbe = null;
@@ -89,6 +91,16 @@ export function isProxyConfigured(): boolean {
 /** Whether the platform manages AI credentials itself (cloud Workers AI). */
 export function isManagedProxy(): boolean {
   return proxyManaged;
+}
+
+/**
+ * Why the proxy reported itself unconfigured, when it said so.
+ *
+ * Undefined on any backend that does not send one — every gate must treat that as "no reason given"
+ * and fall back to the plain connect wording.
+ */
+export function proxyStateCode(): AiModelsResponse["code"] {
+  return proxyCode;
 }
 
 /** The proxy's preferred model id ("" when it does not declare one). */
@@ -161,6 +173,7 @@ export async function fetchAvailableModels(
   proxyConfigured = data.configured === true;
   proxyManaged = data.managed === true;
   proxyDefaultModel = data.defaultModel ?? "";
+  proxyCode = data.code;
   cache = (data.models || []).map((m) => ({ id: m.id, name: m.name || m.id }));
   return cache;
 }

--- a/packages/studio/src/ui/ai-managed-connect.ts
+++ b/packages/studio/src/ui/ai-managed-connect.ts
@@ -24,6 +24,7 @@ import {
   fetchAvailableModels,
   isManagedProxy,
   isProxyConfigured,
+  proxyStateCode,
 } from "../services/ai-models";
 
 export interface ManagedConnectOptions {
@@ -91,17 +92,31 @@ export function createManagedConnect(opts: ManagedConnectOptions): ManagedConnec
     if (!canOffer()) {
       return nothing;
     }
+    /*
+     * A lapsed grant and a fresh one get different words. The backend distinguishes them because
+     * "connect" is an invitation and "reconnect" is an explanation — and on a managed platform the
+     * lapsed case is the common one: a Cloudflare access token lives an hour.
+     */
+    const lapsed = proxyStateCode() === "cf_reconnect_required";
+    const busyLabel = lapsed ? "Reconnecting…" : "Connecting…";
     return html`
-      <div class="ai-managed-connect">
-        <div>Use Workers AI on your own Cloudflare account — no API key needed.</div>
+      <div class="ai-managed-connect" data-jx-recommended="cloudflare">
+        <div class="ai-managed-connect-lede">
+          ${
+            lapsed
+              ? "Your Cloudflare connection has expired. Reconnect to keep using the assistant."
+              : "Recommended — run the assistant on Workers AI in your own Cloudflare account. No API key to create, copy or rotate."
+          }
+        </div>
         <sp-button
           size="s"
+          variant="accent"
           ?disabled=${busy}
           @click=${() => {
             void connect();
           }}
         >
-          ${busy ? "Connecting…" : "Connect Cloudflare"}
+          ${busy ? busyLabel : lapsed ? "Reconnect Cloudflare" : "Connect Cloudflare"}
         </sp-button>
         ${connectError ? html`<div class="ai-managed-connect-error">${connectError}</div>` : nothing}
         <div class="ai-managed-connect-divider">— or bring your own key —</div>

--- a/packages/studio/styles/shell.css
+++ b/packages/studio/styles/shell.css
@@ -753,6 +753,13 @@
   gap: 10px;
   width: 100%;
 }
+/* The lede reads as the recommendation, so it carries weight the divider beneath it does not. */
+.ai-managed-connect-lede {
+  color: var(--fg);
+  font-size: var(--spectrum-font-size-75, 12px);
+  max-width: 280px;
+  text-align: center;
+}
 .ai-managed-connect-error {
   color: var(--danger);
   font-size: var(--spectrum-font-size-50, 11px);

--- a/packages/studio/tests/ai-managed-connect.test.ts
+++ b/packages/studio/tests/ai-managed-connect.test.ts
@@ -199,3 +199,80 @@ describe("ensureProbe", () => {
     expect(container.querySelector(".ai-managed-connect")).toBeTruthy();
   });
 });
+
+/**
+ * The Cloudflare option is the RECOMMENDATION on a managed platform, and it has two moods.
+ *
+ * Both matter to the same outage. studio.jxsuite.com showed the BYOK key form alone, because
+ * /ai/models answered 500, the probe threw, and `managed` stayed false — so the block below never
+ * rendered at all. With the backend answering 200 and a reason, the block renders, and a lapsed
+ * grant has to say so: "Connect Cloudflare" is an invitation, and this user already accepted it.
+ */
+describe("the recommendation, and its two moods", () => {
+  /** Answer the probe exactly as the backend now does for a given state. */
+  function probeAnswers(body: Record<string, unknown>) {
+    fetchImpl = async () => Response.json(body, { status: 200 });
+  }
+
+  async function renderFresh() {
+    /* The PAL half of canOffer(): a host that cannot run the hosted OAuth flow must not be offered
+       it. Set in every case here, including the two that expect the block to stay hidden, so those
+       prove the PROBE hid it rather than a missing platform method. */
+    platform.cfConnect = async () => ({ connected: true });
+    invalidateModelCache();
+    const { container, mc } = makeConnect();
+    mc.ensureProbe();
+    await flush();
+    return { container, mc };
+  }
+
+  test("a never-connected user is invited, with the Cloudflare button as the accent action", async () => {
+    probeAnswers({ code: "cf_not_connected", configured: false, managed: true, models: [] });
+    const { container, mc } = await renderFresh();
+    expect(mc.canOffer()).toBe(true);
+    const button = container.querySelector("sp-button");
+    expect(button?.textContent?.trim()).toBe("Connect Cloudflare");
+    // Accent is what makes it read as the recommendation rather than one of two equal choices.
+    expect(button?.getAttribute("variant")).toBe("accent");
+    expect(container.querySelector(".ai-managed-connect-lede")?.textContent).toContain(
+      "Recommended",
+    );
+    // BYOK stays reachable — prioritised is not the same as exclusive.
+    expect(container.querySelector(".ai-managed-connect-divider")?.textContent).toContain(
+      "bring your own key",
+    );
+  });
+
+  test("a lapsed grant is asked to RECONNECT, and told why", async () => {
+    probeAnswers({ code: "cf_reconnect_required", configured: false, managed: true, models: [] });
+    const { container } = await renderFresh();
+    expect(container.querySelector("sp-button")?.textContent?.trim()).toBe("Reconnect Cloudflare");
+    expect(container.querySelector(".ai-managed-connect-lede")?.textContent).toContain("expired");
+  });
+
+  test("a transient upstream error does NOT send the user round the OAuth flow", async () => {
+    /* `cf_upstream_error` arrives with configured:true precisely so this block stays hidden —
+       reconnecting fixes nothing when the fault is Cloudflare's, and offering it would teach the
+       user that the button does not work. */
+    probeAnswers({ code: "cf_upstream_error", configured: true, managed: true, models: [] });
+    const { container, mc } = await renderFresh();
+    expect(mc.canOffer()).toBe(false);
+    expect(container.querySelector(".ai-managed-connect")).toBeNull();
+  });
+
+  test("a backend that sends no code still renders the plain invitation", async () => {
+    // Older backends, and the dev server. No reason given is not an error state.
+    probeAnswers({ configured: false, managed: true, models: [] });
+    const { container } = await renderFresh();
+    expect(container.querySelector("sp-button")?.textContent?.trim()).toBe("Connect Cloudflare");
+  });
+
+  test("a probe that fails outright leaves the option hidden — the shape of the outage", async () => {
+    /* Pinned as the CONTRAST to the cases above: this is what the product actually did, and the
+       reason the fix had to be a 200 with a code rather than a tidier error status. */
+    fetchImpl = async () => Response.json({ error: "boom" }, { status: 500 });
+    const { container, mc } = await renderFresh();
+    expect(mc.canOffer()).toBe(false);
+    expect(container.querySelector(".ai-managed-connect")).toBeNull();
+  });
+});

--- a/packages/studio/tests/chat-panel.test.ts
+++ b/packages/studio/tests/chat-panel.test.ts
@@ -46,6 +46,9 @@ void mock.module("../src/services/ai-models", () => ({
   invalidateModelCache: () => {},
   isManagedProxy: () => false,
   isProxyConfigured: () => false,
+  // Every named export ai-managed-connect.ts imports must be here: a partial mock.module() of a
+  // Module someone else imports is a SyntaxError at link time, not a missing stub at call time.
+  proxyStateCode: () => {},
 }));
 
 const { mount, render, unmount } = await import("../src/panels/chat-panel");

--- a/packages/studio/tests/preferences-dialog.test.ts
+++ b/packages/studio/tests/preferences-dialog.test.ts
@@ -23,6 +23,9 @@ void mock.module("../src/services/ai-models", () => ({
   invalidateModelCache: () => {},
   isManagedProxy: () => false,
   isProxyConfigured: () => false,
+  // Every named export ai-managed-connect.ts imports must be here: a partial mock.module() of a
+  // Module someone else imports is a SyntaxError at link time, not a missing stub at call time.
+  proxyStateCode: () => {},
 }));
 
 installMockPlatform();

--- a/specs/ai.md
+++ b/specs/ai.md
@@ -2,9 +2,9 @@
 
 ## AI Assistant for Jx Studio
 
-**Version:** 0.1.7-draft
+**Version:** 0.1.8-draft
 **Status:** Partial
-**Updated:** 2026-08-20
+**Updated:** 2026-08-23
 **License:** MIT
 
 ---
@@ -31,6 +31,37 @@ built on `@vue/reactivity`.
   URL, and blocks cloud-metadata/link-local hosts (see `@jxsuite/server` §4.2).
 - Local and self-hosted OpenAI-compatible endpoints (e.g. LM Studio, Ollama's OpenAI shim) are
   supported by pointing the base URL at them.
+- A **managed** platform may broker credentials instead, so a user-supplied key is required only
+  where nothing else supplies one (§2.1).
+
+### 2.1 Managed providers
+
+> **Status: Implemented.** Jx Cloud brokers Cloudflare Workers AI on the user's own Cloudflare
+> account (`packages/studio/src/ui/ai-managed-connect.ts`, jx-platform `/api/v1/ai/*`).
+
+A platform that can obtain credentials on the user's behalf declares it, and Studio offers that path
+**before** the key form rather than beside it: on such a platform, connecting an account is the
+recommended route and bring-your-own-key remains available beneath it.
+
+The models endpoint is a **capability probe**, not merely a listing. Studio decides which paths to
+offer from its answer, so:
+
+- It **MUST** answer `200` for every credential state, including "no credentials" and "credentials
+  lapsed". A non-2xx makes the probe throw, and a client that cannot read the probe falls back to
+  offering the key form alone — which withdraws the connect affordance from precisely the users who
+  need it.
+- `managed: true` declares that the backend can obtain credentials itself. `configured` reports
+  whether it currently holds working ones.
+- `code` explains a `configured: false`, and distinguishes the two states that need different words
+  on screen: `cf_not_connected` (never connected — invite) and `cf_reconnect_required` (the grant
+  lapsed — explain, and offer reconnection).
+- `cf_upstream_error` is reported **with `configured: true`**. A provider that is briefly
+  unreachable is not a credential problem, and prompting for re-authorization would send the user
+  through a flow that cannot fix it.
+
+Brokered credentials are the platform's to hold and refresh; the client never sees them. A backend
+that cannot refresh a lapsed grant **MUST** report `cf_reconnect_required` rather than continuing to
+present the expired credential to the provider.
 
 > **Status: Partial.** The **Anthropic provider is not yet implemented** (planned). Its client
 > **yields** a single `error` event carrying `code: "NOT_IMPLEMENTED"` and a "use OpenAI" message —
@@ -120,6 +151,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.1.8-draft** (2026-08-23) — 2.1 Managed providers: a platform may broker credentials, Studio offers that path before the key form, and the models endpoint is specified as a capability probe that must answer 200 for every credential state — with cf_not_connected, cf_reconnect_required and cf_upstream_error distinguished.
 - **0.1.7-draft** (2026-08-20) — The Anthropic client yields an error event with code NOT_IMPLEMENTED; it does not throw (§2).
 - **0.1.6-draft** (2026-08-16) — §2 failures are problem documents and the mid-stream frame carries one; gap:ai-problem-details closed.
 - **0.1.5-draft** (2026-08-15) — Add §5 Standards Alignment: SSE, the IANA special-purpose address registries the SSRF guard uses, and the problem+json gap.
@@ -131,4 +163,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_Jx `@jxsuite/ai` Specification v0.1.7-draft — a stub, subject to expansion._
+_Jx `@jxsuite/ai` Specification v0.1.8-draft — a stub, subject to expansion._


### PR DESCRIPTION
Studio half of the Cloudflare AI fix. The platform half is in the private platform repo; **both are needed** — this one reads a reason the backend could not previously send.

## What was actually wrong

The Cloudflare option was **not deprioritised — it was absent.**

`/ai/models` is a *capability probe*, not a listing: the credentials gate reads `configured` and `managed` off it to decide which paths to offer. On studio.jxsuite.com it answered **HTTP 500**, so the fetch threw, `isManagedProxy()` stayed false, and `createManagedConnect().render()` returned `nothing`. What was left was the BYOK key form alone — with no way to connect or reconnect Cloudflare from inside the product.

```
/api/v1/ai/models:1  Failed to load resource: the server responded with a status of 500
```

Ordering was never the bug; availability was. `managedConnect.render()` has always been emitted *before* the key form.

That is why the fix on the backend had to be **200 with a reason** rather than a tidier error status, and why the 500 case is pinned here as a test asserting the option stays hidden — it is the contrast that explains the shape of the contract.

## What an online user now sees

| state | lede | button |
| --- | --- | --- |
| never connected | *Recommended — run the assistant on Workers AI in your own Cloudflare account. No API key to create, copy or rotate.* | **Connect Cloudflare**, `variant="accent"` |
| grant lapsed | *Your Cloudflare connection has expired. Reconnect to keep using the assistant.* | **Reconnect Cloudflare** |
| provider briefly down | — | *(block hidden)* |

- **Accent** is what makes it read as the recommendation rather than one of two equal choices. Bring-your-own-key keeps its place beneath the `— or bring your own key —` divider: prioritised is not exclusive.
- **Reconnect** matters more than it looks. A Cloudflare access token lives one hour, so on a managed platform the lapsed state is the *common* one, and "Connect" is the wrong word for someone who already did.
- **The outage case is deliberately silent.** `cf_upstream_error` arrives with `configured: true`, so the block stays hidden — sending someone round an OAuth flow that cannot fix a provider outage teaches them the button does not work.

## Contract

`AiModelsResponse.code` (`@jxsuite/protocol`) carries the reason; `proxyStateCode()` exposes it to gates. `specs/ai.md` §2.1 makes it normative:

- the endpoint **MUST** answer 200 for every credential state, including "no credentials" and "lapsed";
- a managed platform's path is offered **before** the key form;
- a backend that cannot refresh a lapsed grant **MUST** report it rather than keep presenting an expired credential.

§2 no longer claims a user-supplied key is *required* — that stopped being true when brokering shipped.

## Note for reviewers

Two suites `mock.module` `services/ai-models`. A **partial** mock of a module that someone else imports is a link-time `SyntaxError`, not a missing stub at call time, so both gained the new export — worth knowing, because the failure names the export rather than the mock.

## Verification

9127 studio tests pass (0 fail); `ai-managed-connect.ts` 100% lines / 100% functions, `ai-models.ts` 100% / 98.67%. Lint, both typechecks, type-aware lint, `docs:check`, `docs:status`, `docs:standards`, `docs:markdown`, `docs:claims` and `check-styles` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
