### PR TITLE
fix(canvas): project files load on a host that does not serve them at its root

### DIFF
--- a/docs/extending/embedding/platform-adapter.md
+++ b/docs/extending/embedding/platform-adapter.md
@@ -25,7 +25,7 @@ Core members are required on every adapter. Grouped by family:
 
 | Family          | Members                                                                                                                                                                                                        |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Identity        | `id`, `projectRoot` (get/set), `canvasUrl?`                                                                                                                                                                    |
+| Identity        | `id`, `projectRoot` (get/set), `canvasUrl?`, `documentBaseUrl?`                                                                                                                                                |
 | Session/project | `activate`, `openProject`, `probeRootProject`, `createDestination`, `createProject`, `resolveSiteContext`                                                                                                      |
 | Filesystem      | `listDirectory`, `readFile`, `writeFile`, `uploadFile`, `deleteFile`, `renameFile`, `createDirectory`, `locateFile`, `searchFiles`, `discoverComponents`                                                       |
 | Git             | `gitStatus`, `gitBranches`, `gitLog`, `gitStage`, `gitUnstage`, `gitCommit`, `gitPush`, `gitPull`, `gitFetch`, `gitCheckout`, `gitCreateBranch`, `gitDiff`, `gitShow`, `gitDiscard`, `gitInit`, `gitAddRemote` |
@@ -35,6 +35,14 @@ Core members are required on every adapter. Grouped by family:
 All paths passed into adapter methods are project-relative; translating them to whatever the backend expects (a server-root prefix, an absolute path, a repo path) is the adapter's job. A core member may still answer "not available" through its return type — `codeService` resolves `null` on platforms without code tooling — but the member itself must exist.
 
 `uploadFile` is the one member that carries binary. It takes `string | File | Blob | ArrayBuffer`, and every caller — the image field's Upload button, a file dropped on the canvas or the Files panel, the Library — hands it whatever the browser gave them, usually a `File`. If your transport is HTTP you can post that body straight through. **If your transport serializes its arguments** (JSON over RPC or a WebSocket, as the desktop adapters do), a `File` becomes `{}` on the wire: base64-encode it in the adapter before the call and decode it in the backend. `@jxsuite/studio/base64` exports `toBase64` for exactly this, and it passes a `string` through untouched so callers that already hold base64 keep working.
+
+`documentBaseUrl` is the other declaration worth knowing about. The canvas renders in an iframe and resolves a component `$ref` by fetching it — `readFile` is not reachable from that realm — so **project files have to exist at a URL**. The default base is `<canvas origin>/<projectRoot>/`, which is already correct for any backend that serves the project tree from its web root: the dev server does, and so does the desktop's loopback server.
+
+Set `documentBaseUrl` when your `projectRoot` is an **identifier rather than a served path**. Jx Cloud's is `owner/repo@branch`, so the default addressed nothing and every `$ref` fetch missed. Point it at whatever route serves your project tree, ending in `/`; Studio appends the project-relative path to it.
+
+:::doc-warning
+If your host answers a missing file with a single-page fallback — the app shell at **HTTP 200** rather than a 404 — a wrong base does not fail cleanly. The fetch succeeds, and the renderer reports `Unexpected token '<', "<!doctype "…` from the JSON parser. Studio now names that case explicitly, but the cure is a base that resolves.
+:::
 
 `createDestination` is a declaration, not a method: set it to `"path"` if your backend writes projects to a filesystem, or `"repo"` if a project is a remote repository. Studio uses it to decide which destination fields the New Project modal collects, and hands the answer back to `createProject` as `opts.destination`. **Your adapter must honor that destination and must not substitute one of its own** — a create with no usable destination is an error, not a cue to fall back to a default directory or account.
 

--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,7 +17,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.8-draft  | Partial     | 2026-08-23 |
 | `collab.md`               | 0.2.5-draft  | Partial     | 2026-08-20 |
 | `compiler.md`             | 0.3.1-draft  | Partial     | 2026-08-18 |
-| `desktop.md`              | 0.3.19-draft | Pending     | 2026-08-22 |
+| `desktop.md`              | 0.3.20-draft | Pending     | 2026-08-23 |
 | `extensions.md`           | 0.3.10-draft | Partial     | 2026-08-20 |
 | `imports.md`              | 0.1.9-draft  | Partial     | 2026-08-15 |
 | `jx-markdown.md`          | 0.1.8-draft  | Partial     | 2026-08-15 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -73,6 +73,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.3.20-draft** (2026-08-23) — 3.1 adds the Canvas member family and states that the canvas needs project files at a URL rather than behind readFile: documentBaseUrl defaults to the canvas origin plus projectRoot and must be set by a platform whose root is an identifier rather than a served path.
 - **0.3.19-draft** (2026-08-22) — 10 SaaS/Cloud is Partial rather than Future: the adapter shipped and is deployed (10.1 Implemented, with what it implements and what it deliberately omits), collaboration shipped as a CRDT rather than the sketched lock model (10.3), and 10.2's storage table is marked Pending because the deployed backend is git-backed.
 - **0.3.18-draft** (2026-08-22) — 3.3 the init bundle loads through a declared boot slot rather than an exact-string replace on the shipped document.
 - **0.3.17-draft** (2026-08-22) — §9.2: the session watches a project or nothing — a root with no project.json is declined rather than scanned recursively.

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -139,12 +139,31 @@ export async function resolve(source: string | JxDocument): Promise<JxDocument> 
   if (_resolveCache.has(source)) {
     return _resolveCache.get(source)!;
   }
-  const p = fetch(source).then((res) => {
+  const p = fetch(source).then(async (res) => {
     if (!res.ok) {
       throw new Error(`Jx: failed to fetch ${source} (${res.status})`);
     }
+    /*
+     * `res.ok` is not enough on a single-page host. A static host configured with an SPA fallback
+     * answers a path it does not have with the APPLICATION SHELL at HTTP 200, so a missing document
+     * arrives looking like a successful fetch and dies inside `res.json()` as
+     * `Unexpected token '<', "<!doctype "... is not valid JSON` — a parser error for what is
+     * actually a 404. Jx Cloud did this to every component `$ref` in the canvas.
+     *
+     * Checked on the content type rather than by sniffing the body: a host that says `text/html`
+     * has told us plainly, and saying so costs nothing.
+     */
+    // Optional-chained: a response that carries no headers at all is one we have no EVIDENCE
+    // About, and guessing is worse than proceeding. Every real `Response` has them.
+    const contentType = res.headers?.get("Content-Type") ?? "";
+    if (contentType.includes("text/html")) {
+      throw new Error(
+        `Jx: ${source} returned HTML, not a document — the host answered a missing file with its ` +
+          `app shell (a single-page fallback), so this path is not served.`,
+      );
+    }
     // Trust boundary: fetched sources are Jx documents by contract.
-    return res.json() as Promise<JxDocument>;
+    return (await res.json()) as JxDocument;
   });
   _resolveCache.set(source, p);
   return p;

--- a/packages/runtime/tests/runtime.test.ts
+++ b/packages/runtime/tests/runtime.test.ts
@@ -201,6 +201,34 @@ describe("resolve", () => {
     // oxlint-disable-next-line typescript/await-thenable -- bun-types types `.rejects.toThrow()` as void, but it returns a Promise at runtime that must be awaited
     await expect(resolve("http://example.com/missing.json")).rejects.toThrow("404");
   });
+
+  test("a 200 carrying HTML is a MISSING file, and says so", async () => {
+    /* A static host with a single-page fallback answers a path it does not have with the app shell
+       at HTTP 200, so `res.ok` is true and the failure surfaces from `res.json()` as
+       `Unexpected token '<'` — a parser error for what is really a 404. Jx Cloud did this to every
+       component $ref in the Studio canvas. The message has to name the cause, because the parser's
+       does not. */
+    global.fetch = mock(() =>
+      Promise.resolve(
+        new Response("<!doctype html><html></html>", {
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        }),
+      ),
+    ) as any;
+    // oxlint-disable-next-line typescript/await-thenable -- see above
+    await expect(resolve("http://example.com/spa-fallback.json")).rejects.toThrow(
+      "returned HTML, not a document",
+    );
+  });
+
+  test("a response with no headers at all is still parsed — no evidence, no guess", async () => {
+    // The check is evidence-based. A custom fetch that omits headers must not be broken by it.
+    const payload = { tagName: "b" };
+    global.fetch = mock(() =>
+      Promise.resolve({ json: () => Promise.resolve(payload), ok: true }),
+    ) as any;
+    expect(await resolve("http://example.com/headerless.json")).toEqual(payload);
+  });
 });
 
 // ─── buildScope — Five-Shape state Grammar ───────────────────────────────────

--- a/packages/studio/src/canvas/canvas-live-render.ts
+++ b/packages/studio/src/canvas/canvas-live-render.ts
@@ -19,7 +19,7 @@ import {
   getEffectiveMedia,
   resolveLayoutDoc,
 } from "../site-context";
-import { canvasBaseOrigin } from "./canvas-origin";
+import { documentBase } from "./canvas-origin";
 import { componentRegistry, computeRelativePath } from "../files/components";
 import { prepareForEditMode } from "../utils/edit-display";
 import {
@@ -179,10 +179,8 @@ export async function resolveCanvasDocument(
     }
   }
 
-  const root = projectState?.projectRoot || "";
-  const docPrefix = root ? `${root}/` : "";
   const docBase = S.documentPath
-    ? `${canvasBaseOrigin()}/${docPrefix}${S.documentPath}`
+    ? new URL(S.documentPath, documentBase(projectState?.projectRoot)).href
     : undefined;
 
   // Substitute chosen dynamic route params ({$ref: "#/$params/x"} → literal), inject state.$page,

--- a/packages/studio/src/canvas/canvas-origin.ts
+++ b/packages/studio/src/canvas/canvas-origin.ts
@@ -26,6 +26,31 @@ export function canvasBaseOrigin(): string {
 }
 
 /**
+ * The base the canvas fetches PROJECT FILES against — component `$ref`s, `$src` modules, images.
+ *
+ * Two shapes, and the platform chooses. Most hosts serve the project tree from their web root, so
+ * `<canvas origin>/<projectRoot>/` is a real URL: the dev server serves by path (absolute
+ * filesystem paths included) and the desktop loopback does the same. Those set nothing.
+ *
+ * A host whose `projectRoot` is an IDENTIFIER rather than a served path sets `documentBaseUrl`. Jx
+ * Cloud is one — its root is `owner/repo@branch`, and the default produced a URL nothing answered,
+ * so every `$ref` fetch fell through to the SPA fallback. That fallback returns the marketing page
+ * at **HTTP 200**, so `res.ok` passed and the runtime's `res.json()` died on `Unexpected token
+ * '<'`; images failed the same way and reported nothing.
+ *
+ * @param {string | undefined} projectRoot - The active project root, for the default shape.
+ * @returns {string} A base URL ending in `/`, safe to pass to `new URL(relativePath, base)`.
+ */
+export function documentBase(projectRoot?: string): string {
+  const declared = hasPlatform() ? getPlatform().documentBaseUrl : undefined;
+  if (declared) {
+    return declared.endsWith("/") ? declared : `${declared}/`;
+  }
+  const root = projectRoot || "";
+  return `${canvasBaseOrigin()}/${root ? `${root}/` : ""}`;
+}
+
+/**
  * Build an absolute loopback-origin src for a PROJECT asset path referenced by a PARENT-realm
  * (shell) preview <img>. On the views:// shell a relative "/images/foo.png" resolves to
  * views://studio/images/foo.png, which the browser fetches immediately on paint — a stray request

--- a/packages/studio/src/platforms/cloud.ts
+++ b/packages/studio/src/platforms/cloud.ts
@@ -223,6 +223,15 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
     id: "cloud",
     projectRoot: root,
     canvasUrl: "/canvas.html",
+    /* The projectRoot here is the IDENTIFIER "owner/repo@branch", not a served path, so the canvas's
+       default base — <origin>/<projectRoot>/ — addressed nothing. Every component $ref fetch landed
+       on the SPA fallback, which answers the marketing page at HTTP 200, so res.ok passed and the
+       runtime's res.json() died on "Unexpected token '<'". Images failed the same way, silently.
+       The session serves the project tree at /raw.
+
+       Conditional because `base` is "" until a project is bound, and "/raw/" would be a confident
+       wrong answer — worse than the default, which at least fails visibly. */
+    ...(base ? { documentBaseUrl: `${base}/raw/` } : {}),
     /* Open Project routes through Studio's repo picker (write-access repos via listRepos +
        importProject) — sessions are URL-bound, so openProject() below never opens a dialog. */
     openProjectPicker: "repo-list",

--- a/packages/studio/src/types.ts
+++ b/packages/studio/src/types.ts
@@ -181,6 +181,23 @@ export interface StudioPlatform {
    * Not keyed on `id`: chromium and electrobun both report `"desktop"`, and only electrobun defers.
    */
   canvasUrlDeferred?: boolean;
+  /**
+   * Base URL the canvas fetches PROJECT FILES from — component `$ref`s, `$src` modules, images.
+   *
+   * The renderer resolves a `$ref` with `fetch(url).then(r => r.json())` from inside the iframe, so
+   * project files have to exist at a URL, not merely behind {@link readFile}. Hosts that serve the
+   * project tree from their web root need no value here: the default is `<canvas
+   * origin>/<projectRoot>/`, which is what the dev server and the desktop loopback both already
+   * answer.
+   *
+   * A host whose project files are NOT at a URL-shaped `projectRoot` must set this. Jx Cloud is
+   * one: its `projectRoot` is the identifier `owner/repo@branch`, nothing served the tree, and
+   * every `$ref` fetch landed on the SPA fallback — which answers HTML at **200**, so `res.ok`
+   * passed and the parse died on `Unexpected token '<'`. Images failed the same way in silence.
+   *
+   * Must end in `/`; a project-relative path is appended to it verbatim.
+   */
+  documentBaseUrl?: string;
   activate: (root?: string) => Promise<void>;
   openProject: () => Promise<{
     config: ProjectConfig;

--- a/packages/studio/tests/canvas-origin.test.ts
+++ b/packages/studio/tests/canvas-origin.test.ts
@@ -1,12 +1,12 @@
 import "./with-dom.js";
 import { afterEach, describe, expect, test } from "bun:test";
-import { canvasBaseOrigin, loopbackAssetSrc } from "../src/canvas/canvas-origin";
+import { canvasBaseOrigin, documentBase, loopbackAssetSrc } from "../src/canvas/canvas-origin";
 
 const { happyDOM } = globalThis as unknown as { happyDOM: { setURL: (u: string) => void } };
 happyDOM.setURL("http://localhost:3000/");
 
 interface PlatformGlobal {
-  __jxPlatform?: { canvasUrl?: string } | undefined;
+  __jxPlatform?: { canvasUrl?: string; documentBaseUrl?: string } | undefined;
 }
 const g = globalThis as unknown as PlatformGlobal;
 
@@ -64,5 +64,47 @@ describe("loopbackAssetSrc", () => {
     expect(loopbackAssetSrc("blob:http://x/abc")).toBe("blob:http://x/abc");
     expect(loopbackAssetSrc("http://example.com/pic.png")).toBe("http://example.com/pic.png");
     expect(loopbackAssetSrc("views://studio/pic.png")).toBe("views://studio/pic.png");
+  });
+});
+
+/**
+ * Where the canvas fetches project files from.
+ *
+ * The renderer resolves a component `$ref` with `fetch(url).then(r => r.json())` from inside the
+ * iframe, so a project file has to exist at a URL — `readFile` is not reachable from there. Hosts
+ * that serve the tree from their web root need no declaration; a host whose `projectRoot` is an
+ * identifier rather than a path must make one, or every `$ref` addresses nothing.
+ */
+describe("documentBase", () => {
+  test("defaults to the canvas origin plus the project root", () => {
+    g.__jxPlatform = {};
+    expect(documentBase("examples/site-demo")).toBe(`${location.origin}/examples/site-demo/`);
+  });
+
+  test("omits the root segment when there is no root", () => {
+    g.__jxPlatform = {};
+    expect(documentBase("")).toBe(`${location.origin}/`);
+    expect(documentBase()).toBe(`${location.origin}/`);
+  });
+
+  test("a declared base wins, and the project root is NOT appended to it", () => {
+    /* The declared base already addresses one project — Jx Cloud's is
+       /api/v1/p/:owner/:repo/:branch/studio/raw/ — so appending the root key on top of it would
+       address a directory named "owner/repo@branch" inside that project. */
+    g.__jxPlatform = { documentBaseUrl: "/api/v1/p/acme/site/main/studio/raw/" };
+    expect(documentBase("acme/site@main")).toBe("/api/v1/p/acme/site/main/studio/raw/");
+  });
+
+  test("a declared base missing its trailing slash still composes", () => {
+    // `new URL("pages/index.json", ".../raw")` would drop the last segment; the slash is load-bearing.
+    g.__jxPlatform = { documentBaseUrl: "/api/v1/p/acme/site/main/studio/raw" };
+    expect(new URL("pages/index.json", `http://x${documentBase("")}`).pathname).toBe(
+      "/api/v1/p/acme/site/main/studio/raw/pages/index.json",
+    );
+  });
+
+  test("an unregistered platform does not throw — gates render before registration", () => {
+    g.__jxPlatform = undefined;
+    expect(documentBase("root")).toBe(`${location.origin}/root/`);
   });
 });

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,9 +2,9 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.3.19-draft
+**Version:** 0.3.20-draft
 **Status:** Pending
-**Updated:** 2026-08-22
+**Updated:** 2026-08-23
 **License:** MIT
 
 ---
@@ -90,6 +90,16 @@ The canonical `StudioPlatform` interface is `packages/studio/src/types.ts` — r
 | **Publish / identity**   | `getUser?`, `getAccountStatus?`, `listRepos?`, `importProject?`, `cfConnection?`, `cfConnect?`, `cfApi?`                                                                                                                       |
 | **Code services / AI**   | `codeService` (§5.3), `resolveClass?`, `aiChatUrl`                                                                                                                                                                             |
 | **Multi-window / shell** | `openProjectInNewWindow?`, `pickProject?`, `newWindow?`, `setWindowProject?`, `getProjectRoot?`, `getAppInfo?`, backend-persisted settings                                                                                     |
+| **Canvas**               | `canvasUrl?`, `canvasUrlDeferred?`, `documentBaseUrl?`                                                                                                                                                                         |
+
+**The canvas needs project files at a URL, not behind `readFile`.** It renders in an iframe, and the
+renderer resolves a component `$ref` by fetching it, so a platform must be able to say where the
+project tree is served. `documentBaseUrl` is that declaration. It defaults to
+`<canvas origin>/<projectRoot>/`, which is already right for any backend serving the tree from its
+web root — the dev server and the desktop loopback both do — and **MUST** be set by a platform whose
+`projectRoot` is an identifier rather than a served path. A host that answers a missing file with a
+single-page fallback compounds a wrong base rather than exposing it: the shell arrives at HTTP 200,
+so the fetch succeeds and the failure surfaces from the JSON parser instead.
 
 **Core vs. optional, and degradation.** Required members are the minimal backend every platform implements. Optional members (marked `?` in the interface) each back an optional protocol route; Studio feature-detects them and degrades gracefully when they are absent — hiding the corresponding UI or falling back to a client-side path. Each optional route's `degradation` note in `STUDIO_ROUTES` records exactly what turns off (e.g. no `collab` → Studio edits solo with file-level saves; no `importSite` → the New Project modal hides its Import tab).
 
@@ -1154,6 +1164,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.3.20-draft** (2026-08-23) — 3.1 adds the Canvas member family and states that the canvas needs project files at a URL rather than behind readFile: documentBaseUrl defaults to the canvas origin plus projectRoot and must be set by a platform whose root is an identifier rather than a served path.
 - **0.3.19-draft** (2026-08-22) — 10 SaaS/Cloud is Partial rather than Future: the adapter shipped and is deployed (10.1 Implemented, with what it implements and what it deliberately omits), collaboration shipped as a CRDT rather than the sketched lock model (10.3), and 10.2's storage table is marked Pending because the deployed backend is git-backed.
 - **0.3.18-draft** (2026-08-22) — 3.3 the init bundle loads through a declared boot slot rather than an exact-string replace on the shipped document.
 - **0.3.17-draft** (2026-08-22) — §9.2: the session watches a project or nothing — a root with no project.json is declined rather than scanned recursively.
@@ -1192,4 +1203,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.3.19-draft_
+_Jx Studio Desktop Architecture Specification v0.3.20-draft_


### PR DESCRIPTION
Studio half of the canvas fix. Backend half is in the platform repo (`GET <session>/raw/<path>`); **both are needed**.

## What was wrong

The cloud canvas has **never** been able to fetch project files.

It renders in an iframe, and `@jxsuite/runtime` resolves a component `$ref` with `fetch(url).then(r => r.json())` — `readFile` is not reachable from that realm — against a base of `<canvas origin>/<projectRoot>/`. That is a real URL on the dev server and the desktop loopback, which both serve the project tree by path. On Jx Cloud `projectRoot` is the **identifier** `owner/repo@branch`, so the base addressed nothing.

And nothing said so, because the host answers a missing path with its app shell at **HTTP 200**. `res.ok` passed and the failure surfaced from the JSON parser:

```
iframe canvas: failed to register element {"$ref":"../components/co-nav.json"}
SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
```

Components were the loud casualty — a barebones template renders with no nav and no footer. **Images resolve through the same base and failed identically, in silence.**

## The fix

`documentBaseUrl` — the declaration a platform makes when its project tree is not at `<origin>/<projectRoot>/`.

- The **default is unchanged**, so dev server, chromium and electrobun are byte-identical.
- The cloud adapter points it at the session's `/raw` mount.
- It is deliberately **not** composed with `projectRoot`. The declared base already addresses one project; appending the root key would look for a directory named `owner/repo@branch` inside it. There is a test for that, because it is the obvious wrong thing to do later.
- It is only set once a project is bound — `"/raw/"` on its own would be a confident wrong answer, which is worse than the default's visible failure.

## The other half of the fix

`resolve()` in `@jxsuite/runtime` now rejects a `text/html` body outright:

> `Jx: … returned HTML, not a document — the host answered a missing file with its app shell (a single-page fallback), so this path is not served.`

That sentence is actionable; `Unexpected token '<'` is not. This matters beyond Jx Cloud — **any** static host with an SPA fallback turns a 404 into a parser error, and the parser error names the wrong culprit.

Checked on the content type rather than by sniffing, and optional-chained: a response carrying no headers is one we have **no evidence** about, and guessing is worse than proceeding. Both behaviours are pinned.

## Verification

9132 studio tests and 608 runtime tests pass, 0 fail. `canvas-origin.ts` 100% lines / 100% functions. Lint, both typechecks, type-aware lint, and every docs gate (`check`, `status`, `standards`, `markdown`, `claims`) clean.

## Docs & spec

`specs/desktop.md` §3.1 gains a **Canvas** member family and states the rule normatively — the canvas needs project files at a URL, not behind `readFile`, and a platform whose root is an identifier **MUST** declare where they are. `docs/extending/embedding/platform-adapter.md` documents it for adapter authors, with a warning about the SPA-fallback trap, since that is what makes a wrong base fail confusingly rather than cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
