### PR TITLE
fix(canvas): prose slotted into a component is editable again

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -29,7 +29,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `spec.md`                 | 0.5.4-draft  | Partial     | 2026-08-18 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |
 | `studio-ui-guidelines.md` | 0.3.14       | Implemented | 2026-08-22 |
-| `studio.md`               | 0.9.37-draft | Partial     | 2026-08-22 |
+| `studio.md`               | 0.9.38-draft | Partial     | 2026-08-24 |
 
 ## Sections not yet implemented
 

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -425,6 +425,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `studio.md`
 
+- **0.9.38-draft** (2026-08-24) — 8.2 states that a component island covers the component's internals and never the document slotted into it: a child with a stamped path is re-opened, a nested instance stays frozen, and connectedCallback internals are never re-opened.
 - **0.9.37-draft** (2026-08-22) — 11.2 Hosting the Studio: the asset manifest, the two layout modes, generated documents, the boot slot and the layering rule; 11.1 states the entry-rooted asset rule; 3.4's stale member names and file extensions corrected.
 - **0.9.36-draft** (2026-08-21) — Preferences → Appearance states what the theme repaints: the chrome, the overlays and an open code view, with the canvas a light document in both.
 - **0.9.35-draft** (2026-08-20) — Declare the Monaco editor feature set in monaco-setup (one register import per capability, and the measured caveat that 0.56.0's contrib graph does not yet honour the exclusions); drop the Monaco de-duplication plugin now that the first-party collab binding leaves one importer.

--- a/packages/studio/src/canvas/iframe-render.ts
+++ b/packages/studio/src/canvas/iframe-render.ts
@@ -480,6 +480,17 @@ export function injectHead(doc: JxDocument): void {
  * + `data-jx-layout-file` (layout-originated nodes) on rendered nodes.
  */
 export function makeStamper(ctx: PathMapCtx) {
+  /*
+   * Paths of the component instances frozen below. Nodes arrive parent-first and `onNodeCreated`
+   * fires straight after `createElement`, BEFORE the node is attached — so there is no ancestor to
+   * walk at stamp time, and the path is the only way to know a node landed inside an island.
+   */
+  const islands: (string | number)[][] = [];
+  const insideIsland = (path: (string | number)[]): boolean =>
+    islands.some(
+      (island) => path.length > island.length && island.every((seg, i) => path[i] === seg),
+    );
+
   return (created: Node, path: (string | number)[], def: unknown) => {
     if (!(created instanceof HTMLElement)) {
       return;
@@ -503,8 +514,11 @@ export function makeStamper(ctx: PathMapCtx) {
     //
     // The opened document's own root is excluded: when a component definition is the file being
     // Edited, its subtree IS the document and must stay editable.
-    if (!isDefinitionRoot && created.tagName.includes("-") && isEditableMode(ctx.canvasMode)) {
+    const isIsland =
+      !isDefinitionRoot && created.tagName.includes("-") && isEditableMode(ctx.canvasMode);
+    if (isIsland) {
       created.contentEditable = "false";
+      islands.push(path);
     }
     const classified = classifyRenderNode(path, def, ctx);
     if (classified.kind === "layout") {
@@ -530,6 +544,29 @@ export function makeStamper(ctx: PathMapCtx) {
       return;
     }
     created.dataset.jxPath = serializeJxPath(classified.path);
+    /*
+     * SLOTTED PAGE CONTENT IS NOT COMPONENT INTERNALS.
+     *
+     * The island above exists to keep the caret out of what a component renders for itself. But a
+     * component's CHILDREN are the author's own document — in jx-markdown,
+     *
+     *     :::eer-intro
+     *     If you need reliable rental equipment fast, request a quote today!
+     *     :::
+     *
+     * is a paragraph the author typed, stamped here with its own `data-jx-path`. Inheriting the
+     * island's `contenteditable="false"` made every such paragraph uneditable: on a page written
+     * this way — which is most component-using pages — the caret could not be placed anywhere at
+     * all, and the only route to the text was the properties sidebar.
+     *
+     * Re-opening on the STAMPED node alone is what keeps the distinction. Component internals are
+     * created by the component's own `connectedCallback` in another document and never pass through
+     * this stamper, so they stay frozen; prop-bound internals keep their nested-host activation
+     * (see iframe-editable-root's `onPointerDownCapture`).
+     */
+    if (!isIsland && isEditableMode(ctx.canvasMode) && insideIsland(path)) {
+      created.contentEditable = "true";
+    }
   };
 }
 

--- a/packages/studio/tests/iframe-render.test.ts
+++ b/packages/studio/tests/iframe-render.test.ts
@@ -21,6 +21,7 @@ import {
   syncStylebookCss,
 } from "../src/canvas/iframe-render";
 import type { PathMapCtx } from "../src/canvas/path-mapping";
+import { serializeJxPath } from "../src/canvas/path-mapping";
 
 const ctx: PathMapCtx = {
   arrayPaths: new Set(),
@@ -862,5 +863,128 @@ describe("syncStylebookCss", () => {
     expect(sheet()).toBeTruthy();
     expect(document.head.querySelector(`#${EDIT_PLACEHOLDER_STYLE_ID}`)).toBeNull();
     handle.dispose();
+  });
+});
+
+/**
+ * Slotted page content stays editable inside a component island.
+ *
+ * The island (`contenteditable="false"` on a component instance) exists so a caret cannot wander
+ * into what a component renders for ITSELF. But a component's children are the author's own
+ * document. In jx-markdown,
+ *
+ *     :::eer-intro
+ *     If you need reliable rental equipment fast, request a quote today!
+ *     :::
+ *
+ * That paragraph is page content with its own `data-jx-path`, and inheriting the island's `false`
+ * made it uneditable. On a page written this way — most component-using pages — the caret could not
+ * be placed ANYWHERE, and the only route to the text was the properties sidebar. Measured in Chrome
+ * on a real project: 23 stamped blocks, 0 of them editable.
+ */
+describe("component islands and the document inside them", () => {
+  const editable: PathMapCtx = { ...ctx, canvasMode: "edit" };
+
+  /** Stamp a component instance at `path`, then a child of it, and report the child. */
+  function stampChild(
+    componentPath: (string | number)[],
+    childPath: (string | number)[],
+    childTag = "p",
+  ): HTMLElement {
+    const stamp = makeStamper(editable);
+    const host = document.createElement("eer-intro");
+    stamp(host, componentPath, { tagName: "eer-intro" });
+    const child = document.createElement(childTag);
+    stamp(child, childPath, { tagName: childTag });
+    return child;
+  }
+
+  test("the component instance itself is frozen — it is selected whole, not typed into", () => {
+    const stamp = makeStamper(editable);
+    const host = document.createElement("eer-intro");
+    stamp(host, ["children", 1], { tagName: "eer-intro" });
+    expect(host.getAttribute("contenteditable")).toBe("false");
+  });
+
+  test("a stamped child of that instance is re-opened", () => {
+    const child = stampChild(["children", 1], ["children", 1, "children", 0]);
+    expect(child.getAttribute("contenteditable")).toBe("true");
+  });
+
+  test("it re-opens at any depth, not just direct children", () => {
+    // `:::eer-steps` wrapping `:::eer-step` wrapping a paragraph — three levels, all authored.
+    const child = stampChild(["children", 4], ["children", 4, "children", 2, "children", 0]);
+    expect(child.getAttribute("contenteditable")).toBe("true");
+  });
+
+  test("a SIBLING of the island is left alone — it was never blocked", () => {
+    // Path ["children", 2] is not inside ["children", 1]; a prefix test that compared strings
+    // Rather than segments would wrongly treat ["children", 10] as inside ["children", 1].
+    const child = stampChild(["children", 1], ["children", 2]);
+    expect(child.getAttribute("contenteditable")).toBeNull();
+  });
+
+  test("a path that merely SHARES A PREFIX DIGIT is not inside the island", () => {
+    const child = stampChild(["children", 1], ["children", 10, "children", 0]);
+    expect(child.getAttribute("contenteditable")).toBeNull();
+  });
+
+  test("top-level page content outside any component is untouched", () => {
+    const stamp = makeStamper(editable);
+    const el = document.createElement("p");
+    stamp(el, ["children", 0], { tagName: "p" });
+    // The container is the editing host; a plain block needs no attribute of its own.
+    expect(el.getAttribute("contenteditable")).toBeNull();
+    expect(el.dataset.jxPath).toBe(serializeJxPath(["children", 0]));
+  });
+
+  test("nothing is re-opened in a non-editable mode", () => {
+    // Preview and stylebook renders have no editing host at all, so an island is never created and
+    // There is nothing to re-open. A stray `true` here would make preview text typable.
+    const stamp = makeStamper({ ...ctx, canvasMode: "preview" });
+    const host = document.createElement("eer-intro");
+    stamp(host, ["children", 1], { tagName: "eer-intro" });
+    const child = document.createElement("p");
+    stamp(child, ["children", 1, "children", 0], { tagName: "p" });
+    expect(host.getAttribute("contenteditable")).toBeNull();
+    expect(child.getAttribute("contenteditable")).toBeNull();
+  });
+
+  test("a NESTED component instance stays frozen — it is an island, not slotted prose", () => {
+    /* The trap in the re-opening rule, and it is not hypothetical: a nested instance is BOTH an
+       island and a stamped descendant of one. Re-opening it unconditionally overrode its own
+       freeze, which put a caret directly into a nested component's internals — measured in Chrome,
+       16 prop-bound internals became typable that should only be reachable through the nested-host
+       activation. `:::eer-categories` wrapping `::eer-category` is the shape. */
+    const stamp = makeStamper(editable);
+    const outer = document.createElement("eer-categories");
+    stamp(outer, ["children", 2], { tagName: "eer-categories" });
+    const inner = document.createElement("eer-category");
+    stamp(inner, ["children", 2, "children", 0], { tagName: "eer-category" });
+    expect(inner.getAttribute("contenteditable")).toBe("false");
+  });
+
+  test("but prose slotted into that NESTED instance is still editable", () => {
+    // Two components deep, then the author's paragraph. `:::eer-steps` → `:::eer-step` → text.
+    const stamp = makeStamper(editable);
+    stamp(document.createElement("eer-steps"), ["children", 4], { tagName: "eer-steps" });
+    const step = document.createElement("eer-step");
+    stamp(step, ["children", 4, "children", 0], { tagName: "eer-step" });
+    const prose = document.createElement("p");
+    stamp(prose, ["children", 4, "children", 0, "children", 0], { tagName: "p" });
+    expect(step.getAttribute("contenteditable")).toBe("false");
+    expect(prose.getAttribute("contenteditable")).toBe("true");
+  });
+
+  test("the opened document's own root is not an island, so its subtree stays plain", () => {
+    // Editing a component DEFINITION: the subtree IS the document. It must not be frozen, and its
+    // Children must not be re-opened as though they were escaping one.
+    const stamp = makeStamper(editable);
+    const root = document.createElement("eer-cta");
+    stamp(root, [], { tagName: "eer-cta" });
+    const child = document.createElement("p");
+    stamp(child, ["children", 0], { tagName: "p" });
+    expect(root.getAttribute("contenteditable")).toBeNull();
+    expect(child.getAttribute("contenteditable")).toBeNull();
   });
 });

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -2,9 +2,9 @@
 
 ## Visual Builder for Jx Documents
 
-**Version:** 0.9.37-draft
+**Version:** 0.9.38-draft
 **Status:** Partial
-**Updated:** 2026-08-22
+**Updated:** 2026-08-24
 **License:** MIT
 
 ---
@@ -964,6 +964,14 @@ none of which the studio implements.
 
 Component instances are `contenteditable="false"` islands: the caret treats each as one atomic unit
 and never enters its internals. Prop-bound text inside a component (§8.2.5) is the exception.
+
+**An island covers a component's internals, never the document slotted into it.** A component's
+children are page content — in a markdown class-directive page they are the author's own prose, and
+as §4.1 notes those pages place _every_ editable block inside a component. Each such block is
+stamped with its own `data-jx-path` and re-opened with `contenteditable="true"`, so the island
+freezes only what the component renders for itself. A **nested** component instance is an island in
+its own right and stays frozen, even though it is also a child of one; internals rendered by a
+component's own `connectedCallback` never carry a stamped path, so they are never re-opened.
 
 Text reaches the document on a **~500 ms typing pause** and whenever the caret leaves a block. Any
 operation that reads the document as authoritative — chiefly saving — first flushes what the caret
@@ -2373,6 +2381,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.9.38-draft** (2026-08-24) — 8.2 states that a component island covers the component's internals and never the document slotted into it: a child with a stamped path is re-opened, a nested instance stays frozen, and connectedCallback internals are never re-opened.
 - **0.9.37-draft** (2026-08-22) — 11.2 Hosting the Studio: the asset manifest, the two layout modes, generated documents, the boot slot and the layering rule; 11.1 states the entry-rooted asset rule; 3.4's stale member names and file extensions corrected.
 - **0.9.36-draft** (2026-08-21) — Preferences → Appearance states what the theme repaints: the chrome, the overlays and an open code view, with the canvas a light document in both.
 - **0.9.35-draft** (2026-08-20) — Declare the Monaco editor feature set in monaco-setup (one register import per capability, and the measured caveat that 0.56.0's contrib graph does not yet honour the exclusions); drop the Monaco de-duplication plugin now that the first-party collab binding leaves one importer.
@@ -2465,4 +2474,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_`@jxsuite/studio` Specification v0.9.37-draft_
+_`@jxsuite/studio` Specification v0.9.38-draft_


### PR DESCRIPTION
Inline editing was dead on any page written with markdown class directives — which `specs/studio.md` §4.1 already notes is most of them: *"markdown class-directive pages place every editable block inside a component."*

## The bug

A component instance is a `contenteditable="false"` island so the caret cannot wander into what the component renders for itself. But the island covers the whole subtree, and **a component's children are not its internals** — they are the author's own document:

```markdown
:::eer-intro
If you need reliable rental equipment fast, request a quote today!
:::
```

That paragraph is stamped with its own `data-jx-path` and must be typable. It inherited the island's `false`.

Measured in Chrome on the reported project:

| | before | after |
| --- | --- | --- |
| stamped page blocks editable | **0 / 23** | 5 / 5 prose |
| component instances frozen | 8 (top level only) | **18 / 18** incl. nested |
| prop-bound internals frozen | 26 / 26 | **26 / 26** (unchanged) |

Only prop-bound text kept a caret, through its nested-host activation — which is exactly the reported symptom: **a cursor in the hero and none in the paragraph below it.**

## The fix

A stamped node inside an island is re-opened with `contenteditable="true"`.

Nodes arrive parent-first and `onNodeCreated` fires *before* the node is attached, so there is no ancestor to walk at stamp time. The island's **path** is recorded instead and descendants are matched **segment-wise** — a string-prefix test would read `["children", 10]` as inside `["children", 1]`, and there is a test for that.

### The trap, which I fell into first

A nested instance is **both** an island and a stamped descendant of one. Re-opening it unconditionally overrode its own freeze: the first version of this fix put a caret directly into nested component internals — 16 prop-bound elements that should only be reachable through the nested-host activation. Caught by re-measuring in the browser, not by the tests, so it now has its own test.

`:::eer-categories` → `::eer-category` is the shape; the inner instance stays frozen while prose slotted into *it* stays editable.

## Verification

Real keystrokes in Chrome against the reported repro, not just unit tests:

- caret places in a slotted paragraph
- a character insert lands at the caret (`If yo**Z**u need reliable…`)
- Backspace removes it again
- the document goes dirty (`beforeunload` arms), so the edit reaches the model

The scratch edit was never saved — `pages/index.md` is untouched on disk.

Unit side: **9142 studio tests pass**, `iframe-render.ts` at 96.43% functions / 99.13% lines. The two tests that fail with the fix reverted are the two that describe it — verified by reverting.

## Spec

§8.2 now states which side slotted content falls on; "island" alone did not say. The three-way boundary is written down: a stamped child is re-opened, a nested instance stays frozen, and `connectedCallback` internals never carry a stamped path so are never re-opened.

## Note on cause

This is not from the packaging refactor. `git log -L` puts the island on `6a4b4702 feat(studio): give the canvas a document-wide caret` (2026-07-25) — the caret redesign introduced the island without carving out slotted content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
