### PR TITLE
fix(canvas): keystrokes land in a component slot, not just the caret

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -29,7 +29,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `spec.md`                 | 0.5.4-draft  | Partial     | 2026-08-18 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |
 | `studio-ui-guidelines.md` | 0.3.14       | Implemented | 2026-08-22 |
-| `studio.md`               | 0.9.38-draft | Partial     | 2026-08-24 |
+| `studio.md`               | 0.9.39-draft | Partial     | 2026-08-24 |
 
 ## Sections not yet implemented
 

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -425,6 +425,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `studio.md`
 
+- **0.9.39-draft** (2026-08-24) — 8.2.1 records that a prop-bound host is classified before positions are resolved: it has no document path, so the unresolvable-position rule would otherwise reject every keystroke in it, and only the paragraph split and line break are prevented there.
 - **0.9.38-draft** (2026-08-24) — 8.2 states that a component island covers the component's internals and never the document slotted into it: a child with a stamped path is re-opened, a nested instance stays frozen, and connectedCallback internals are never re-opened.
 - **0.9.37-draft** (2026-08-22) — 11.2 Hosting the Studio: the asset manifest, the two layout modes, generated documents, the boot slot and the layering rule; 11.1 states the entry-rooted asset rule; 3.4's stale member names and file extensions corrected.
 - **0.9.36-draft** (2026-08-21) — Preferences → Appearance states what the theme repaints: the chrome, the overlays and an open code view, with the canvas a light document in both.

--- a/packages/studio/src/canvas/editable-actions.ts
+++ b/packages/studio/src/canvas/editable-actions.ts
@@ -49,6 +49,15 @@ export interface BeforeInputContext {
   atBlockEnd: boolean;
   /** The event's `data` (inserted text), empty for deletions. */
   data: string;
+  /**
+   * The caret is in a PROP-BOUND nested host — text inside a component instance that is an
+   * invertible prop binding (studio.md §8.2.5), not a block of the page document.
+   *
+   * Such a host has no `data-jx-path` of its own, so `from`/`to` are always null for it. Without
+   * this flag the null-position rule below rejected every keystroke: the caret appeared, and
+   * nothing typed into a component slot ever landed.
+   */
+  inPropHost: boolean;
 }
 
 /**
@@ -92,6 +101,20 @@ const INSERT_TEXT = new Set([
 const NATIVE_FORMAT_PREFIX = "format";
 
 /**
+ * Intents refused inside a prop-bound host, because a prop value is ONE PLAIN STRING.
+ *
+ * `docs/studio/editing/writing.md` puts it as "paragraph splits are off": there is no second block
+ * for Enter to make, and a `<br>` would serialise into a value that is supposed to be a single
+ * line. Everything else — insert, delete, paste, cut, IME — is ordinary text editing on a
+ * `plaintext-only` host and runs natively.
+ *
+ * These are refused rather than re-expressed: Enter FINISHES the edit (handled as a keystroke by
+ * the editing engine, not as an input event), so the chokepoint's only job is to stop the browser
+ * inserting the newline first.
+ */
+const PROP_STRUCTURAL = new Set(["insertParagraph", "insertLineBreak"]);
+
+/**
  * Classify one `beforeinput`.
  *
  * The order of the checks is the contract: 1. composition is untouchable (preventing it breaks IME
@@ -124,7 +147,20 @@ export function classifyBeforeInput(ctx: BeforeInputContext): EditAction {
     return { kind: "reject" };
   }
 
-  // 2. No resolvable position means the caret is in canvas chrome or a `contenteditable="false"`
+  /*
+   * 2. A prop-bound host is editable text with NO document path — it is written back as a prop
+   * value by its own commit (`editCommitProp`), not as a block. It must be judged before the
+   * null-position rule below, which would otherwise reject it for having no path: that is exactly
+   * what made a component slot show a caret and swallow every keystroke.
+   *
+   * Nothing here is structural, so nothing is re-expressed; the browser edits the text and the
+   * session commits the string.
+   */
+  if (ctx.inPropHost) {
+    return PROP_STRUCTURAL.has(inputType) ? { kind: "reject" } : { kind: "native" };
+  }
+
+  // 3. No resolvable position means the caret is in canvas chrome or a `contenteditable="false"`
   // Island — there is no document node to write to.
   if (!from || !to) {
     return { kind: "reject" };

--- a/packages/studio/src/canvas/iframe-editable-root.ts
+++ b/packages/studio/src/canvas/iframe-editable-root.ts
@@ -358,6 +358,9 @@ export function startEditableRoot(
       atBlockStart: resolved ? isAtBlockStart(resolved.from) : false,
       data: e.data ?? "",
       from: resolved?.from ?? null,
+      /* An adopted element with no path IS the prop-bound host — `onPointerDownCapture` sets
+         exactly that pair, and `syncActiveBlock` preserves it while the caret stays inside. */
+      inPropHost: activeEl !== null && activeKey === null,
       inputType: e.inputType,
       to: resolved?.to ?? null,
     });

--- a/packages/studio/tests/editable-actions.test.ts
+++ b/packages/studio/tests/editable-actions.test.ts
@@ -21,6 +21,7 @@ function at(
     atBlockStart: flags.atBlockStart ?? false,
     data: flags.data ?? "",
     from: pos,
+    inPropHost: false,
     inputType,
     to: pos,
   };
@@ -38,6 +39,7 @@ function span(
     atBlockStart: flags.atBlockStart ?? false,
     data: flags.data ?? "",
     from,
+    inPropHost: false,
     inputType,
     to,
   };
@@ -82,6 +84,7 @@ describe("classifyBeforeInput — rejected", () => {
         atBlockStart: false,
         data: "x",
         from: null,
+        inPropHost: false,
         inputType: "insertText",
         to: null,
       }),
@@ -92,6 +95,7 @@ describe("classifyBeforeInput — rejected", () => {
         atBlockStart: false,
         data: "x",
         from: P0_MID,
+        inPropHost: false,
         inputType: "insertText",
         to: null,
       }),
@@ -263,5 +267,117 @@ describe("classifyBeforeInput — single-block natives", () => {
     // New engine behaviours are far more often ordinary text editing than structural surgery; the
     // MutationObserver net is what catches the exceptions.
     expect(classifyBeforeInput(at("insertSomethingNewIn2027", P0_MID))).toEqual({ kind: "native" });
+  });
+});
+
+/**
+ * A prop-bound host — text inside a component instance that is an invertible prop binding.
+ *
+ * It is editable text with NO document path, because it is written back as a prop VALUE
+ * (`editCommitProp`) rather than as a block. `from`/`to` are therefore always null for it, which
+ * put it straight into the null-position rule: every keystroke was rejected. Measured in Chrome —
+ * `beforeinput` fired `insertText "Q"` on the heading and arrived at the container already
+ * `defaultPrevented`, and the text never changed. The caret was visible the whole time, which is
+ * what made it look like an editing bug rather than a suppression one.
+ */
+describe("a prop-bound host has no path, and is still editable", () => {
+  /** A caret in a prop-bound host: no resolvable position, by construction. */
+  function inProp(inputType: string, data = ""): BeforeInputContext {
+    return {
+      atBlockEnd: false,
+      atBlockStart: false,
+      data,
+      from: null,
+      inPropHost: true,
+      inputType,
+      to: null,
+    };
+  }
+
+  test("typing runs natively — the regression, stated once", () => {
+    expect(classifyBeforeInput(inProp("insertText", "Q"))).toEqual({ kind: "native" });
+  });
+
+  test("every ordinary text edit runs natively despite the null position", () => {
+    for (const inputType of [
+      "insertText",
+      "insertReplacementText",
+      "insertFromPaste",
+      "insertFromYank",
+      "insertTranspose",
+      "deleteContentBackward",
+      "deleteContentForward",
+      "deleteWordBackward",
+      "deleteWordForward",
+      "deleteSoftLineBackward",
+      "deleteByCut",
+    ]) {
+      expect({ action: classifyBeforeInput(inProp(inputType, "x")), inputType }).toEqual({
+        action: { kind: "native" },
+        inputType,
+      });
+    }
+  });
+
+  test("a paragraph split is refused — a prop is ONE plain string", () => {
+    /* The writing docs put it as "paragraph splits are off", and Enter FINISHES the edit.
+       The chokepoint's job is only to stop the browser inserting the newline first; committing and
+       leaving is the editing engine's keystroke handling, not an input event. */
+    expect(classifyBeforeInput(inProp("insertParagraph"))).toEqual({ kind: "reject" });
+    expect(classifyBeforeInput(inProp("insertLineBreak"))).toEqual({ kind: "reject" });
+  });
+
+  test("it is never re-expressed as a document mutation", () => {
+    // A prop host has no path, so a split/merge/replaceRange would carry a null target. The
+    // Classifier must only ever answer native or reject here.
+    for (const inputType of [
+      "insertText",
+      "insertParagraph",
+      "deleteContentBackward",
+      "deleteContentForward",
+      "insertFromPaste",
+    ]) {
+      expect(["native", "reject"]).toContain(classifyBeforeInput(inProp(inputType)).kind);
+    }
+  });
+
+  test("composition still wins, so IME into a component slot is untouched", () => {
+    // Ordered before the prop branch on purpose: preventing composition strands the candidate
+    // Window mid-word, and that is true in a prop host as much as anywhere else.
+    expect(classifyBeforeInput(inProp("insertCompositionText"))).toEqual({ kind: "native" });
+  });
+
+  test("the universally-refused intents stay refused in a prop host", () => {
+    // Native formatting, native history and text drag are wrong everywhere; the prop branch must
+    // Not have re-admitted them by sitting too early.
+    for (const inputType of [
+      "formatBold",
+      "formatItalic",
+      "historyUndo",
+      "historyRedo",
+      "insertFromDrop",
+      "deleteByDrag",
+    ]) {
+      expect({ action: classifyBeforeInput(inProp(inputType)), inputType }).toEqual({
+        action: { kind: "reject" },
+        inputType,
+      });
+    }
+  });
+
+  test("a null position OUTSIDE a prop host is still refused", () => {
+    // The rule the prop branch steps in front of must keep working: canvas chrome and component
+    // Internals still have nowhere to write.
+    expect(
+      classifyBeforeInput({
+        atBlockEnd: false,
+        atBlockStart: false,
+        data: "x",
+        from: null,
+        inPropHost: false,
+        inputType: "insertText",
+        to: null,
+      }),
+    ).toEqual({ kind: "reject" });
   });
 });

--- a/packages/studio/tests/iframe-editable-root.test.ts
+++ b/packages/studio/tests/iframe-editable-root.test.ts
@@ -203,6 +203,49 @@ describe("prop-bound nested hosts", () => {
     expect(rec.props).toEqual([]);
   });
 
+  /*
+   * The wiring, dispatched for real rather than reasoned about.
+   *
+   * `inPropHost` is computed in this module (`activeEl !== null && activeKey === null`) and only
+   * consumed by the pure classifier, so a classifier test alone cannot tell the flag apart from a
+   * hardcoded `false` — which is exactly what it effectively WAS: a prop host has no path, so the
+   * unresolvable-position rule rejected every keystroke and typing into a component slot did
+   * nothing while showing a caret. These dispatch `beforeinput` at the marker.
+   */
+  test("typing in an adopted prop host is NOT prevented", () => {
+    const { container } = mount(WITH_PROP, { onPropActivate: () => true });
+    const marker = container.querySelector("[data-jx-bound-prop]") as HTMLElement;
+    marker.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    expect(beforeInput(marker, "insertText", "x")).toBe(false);
+  });
+
+  test("a paragraph split in a prop host IS prevented — one plain string", () => {
+    const { container } = mount(WITH_PROP, { onPropActivate: () => true });
+    const marker = container.querySelector("[data-jx-bound-prop]") as HTMLElement;
+    marker.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    expect(beforeInput(marker, "insertParagraph")).toBe(true);
+  });
+
+  test("without adoption the same keystroke is still refused", () => {
+    /* The other half of the flag. A REFUSED marker is not a prop host, so the position stays
+       unresolvable and the keystroke must not slip through — this is what proves the guard is the
+       adoption state and not merely "the target has data-jx-bound-prop". */
+    const { container } = mount(WITH_PROP, { onPropActivate: () => false });
+    const marker = container.querySelector("[data-jx-bound-prop]") as HTMLElement;
+    marker.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    expect(beforeInput(marker, "insertText", "x")).toBe(true);
+  });
+
+  test("after leaving for a page block, the prop exemption is gone", () => {
+    // The flag must not outlive the session: once a real block is active, `activeKey` is set again
+    // And the chokepoint judges by position as usual.
+    const { container } = mount(WITH_PROP, { onPropActivate: () => true });
+    const marker = container.querySelector("[data-jx-bound-prop]") as HTMLElement;
+    marker.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    caretInto(container.querySelector("p") as HTMLElement, 1);
+    expect(beforeInput(marker, "insertParagraph")).toBe(true);
+  });
+
   test("leaving the nested host for a page block releases it", () => {
     const { container, rec } = mount(WITH_PROP, { onPropActivate: () => true });
     const marker = container.querySelector("[data-jx-bound-prop]") as HTMLElement;

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -2,7 +2,7 @@
 
 ## Visual Builder for Jx Documents
 
-**Version:** 0.9.38-draft
+**Version:** 0.9.39-draft
 **Status:** Partial
 **Updated:** 2026-08-24
 **License:** MIT
@@ -989,6 +989,15 @@ The browser may edit text; it may not restructure the document. Every `beforeinp
 | Backspace at a block start, Delete at a block end | Prevented; block merge (§8.2.3)      |
 | Any edit spanning two blocks                      | Prevented; range collapse (§8.2.3)   |
 | Native formatting, native history, text drag      | Prevented; the studio owns these     |
+| Any edit in a prop-bound host (§8.2.5)            | Applied natively; splits prevented   |
+
+**A prop-bound host is classified before positions are resolved.** It is editable text with no
+document path of its own — it commits as a prop VALUE, not as a block — so its position always
+resolves to nothing, and the rule that suppresses an unresolvable position would otherwise reject
+every keystroke in it. That is not hypothetical: it is what made a component slot show a caret and
+silently swallow everything typed into it. Nothing in such a host is structural, so nothing is
+re-expressed; the only intents prevented are the paragraph split and the line break, because a prop
+is one plain string.
 
 A structural intent with no handler is **suppressed**, never delegated back to the browser: an
 unimplemented operation must leave the document untouched rather than let the engine restructure the
@@ -2381,6 +2390,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.9.39-draft** (2026-08-24) — 8.2.1 records that a prop-bound host is classified before positions are resolved: it has no document path, so the unresolvable-position rule would otherwise reject every keystroke in it, and only the paragraph split and line break are prevented there.
 - **0.9.38-draft** (2026-08-24) — 8.2 states that a component island covers the component's internals and never the document slotted into it: a child with a stamped path is re-opened, a nested instance stays frozen, and connectedCallback internals are never re-opened.
 - **0.9.37-draft** (2026-08-22) — 11.2 Hosting the Studio: the asset manifest, the two layout modes, generated documents, the boot slot and the layering rule; 11.1 states the entry-rooted asset rule; 3.4's stale member names and file extensions corrected.
 - **0.9.36-draft** (2026-08-21) — Preferences → Appearance states what the theme repaints: the chrome, the overlays and an open code view, with the canvas a light document in both.
@@ -2474,4 +2484,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_`@jxsuite/studio` Specification v0.9.38-draft_
+_`@jxsuite/studio` Specification v0.9.39-draft_


### PR DESCRIPTION
Follow-up to #179. That fixed slotted prose (ordinary HTML in a component's children); this fixes the other half you reported — **prop-bound component slots showed a caret and dropped every keystroke.**

## The bug

Measured in Chrome: `beforeinput` fired `insertText "Q"` on the hero heading and arrived at the container **already `defaultPrevented`**. The text never changed.

The chokepoint rejected it. A prop-bound host has no `data-jx-path` of its own — it commits as a prop **value** via `editCommitProp`, not as a block — so its position always resolves to `null`, and rule 2 (*"no resolvable position means the caret is in canvas chrome or an island"*) suppressed everything. The rule is right; a prop host simply isn't what it's about.

That is also why the two symptoms differed: activation, caret and `contenteditable="plaintext-only"` all worked, so it looked like an editing bug rather than a suppression one.

## The fix

`classifyBeforeInput` takes `inPropHost` and answers **before** positions are resolved. Nothing in such a host is structural, so nothing is re-expressed — text edits run natively, and only the paragraph split and line break are prevented, which is what the writing docs already promise (*"paragraph splits are off"*, Enter finishes the edit).

Ordering is deliberate: the branch sits **after** composition (IME must never be intercepted) and after native formatting / native history / text drag, so those stay refused in a prop host too. Both are pinned.

## Verified end to end, not just as classifier data

In Chrome against your repro:

```
beforeinput  capture: insertText "Q"
beforeinput  bubble:  prevented: false     ← was true
input        insertText
text:        "DepeQndable Equipment Rental In Manheim, PA"
commit:      { kind: "editCommitProp", prop: "heading", value: "…", inPlace: true }
```

Caret placed, keystroke landed at the caret, Backspace removed it, and the idle tick posted the commit — so the value reaches the document. I undid the scratch edits; the project file is untouched on disk.

## The test gap this had

The flag is computed in `iframe-editable-root` and consumed by the pure classifier, so **classifier tests alone cannot tell it from a hardcoded `false`** — which is effectively what it was. Four tests dispatch a real `beforeinput` at the marker instead: adoption, refusal, the split, and the flag not outliving the session. Verified by hardcoding `false` and watching them go red.

9153 studio tests pass; `editable-actions.ts` 100/100, `iframe-editable-root.ts` 100/98.78.

## This does not make component-slot editing healthy

I audited the rest of the path with a fan-out of agents and adversarial verification — **16 findings survived refutation**. None is caused by this change, and the single finding that named it was refuted (the stale-state path is unreachable: acquiring a caret always clears the pair before any `beforeinput`).

The ones that matter most, all pre-existing:

| | defect |
| --- | --- |
| **data** | a bare click on an **unset** prop bakes the definition default into `$props` — no typing required |
| **data** | **Esc writes** rather than cancels on an unset prop, so "cancel" dirties the document |
| **data** | numeric and boolean props are committed as **strings** |
| **loss** | the slash menu opens in a plain session; picking an item releases **without committing**, discarding the edit |
| **loss** | ⌘B/⌘I/⌘K are forwarded out of the frame and applied back into the plaintext-only host |
| **state** | Enter/Esc end the engine's session without telling the editing host, so the next click on the same text does nothing |
| **state** | the release commit no-ops after an idle tick, so the instance is never re-rendered and canvas and document disagree |

Full list and evidence in the thread. Happy to take the next cluster — the three data-integrity ones look like the right first batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
