### PR TITLE
fix(runtime): a reflected property name no longer clobbers a declared default

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -26,7 +26,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `schema.md`               | 0.4.8-draft  | Partial     | 2026-08-16 |
 | `server.md`               | 0.2.11       | Implemented | 2026-08-22 |
 | `site-architecture.md`    | 0.5.16-draft | Partial     | 2026-08-19 |
-| `spec.md`                 | 0.5.4-draft  | Partial     | 2026-08-18 |
+| `spec.md`                 | 0.5.5-draft  | Partial     | 2026-08-24 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |
 | `studio-ui-guidelines.md` | 0.3.14       | Implemented | 2026-08-22 |
 | `studio.md`               | 0.9.40-draft | Partial     | 2026-08-24 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -317,6 +317,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `spec.md`
 
+- **0.5.5-draft** (2026-08-24) — 13.2 states that the runtime takes a prop from an instance only where the instance genuinely carries one — an own property or an attribute — because a state key colliding with a reflected DOM property otherwise reports an empty string and beats the component's declared default.
 - **0.5.4-draft** (2026-08-18) — §21.5: Trusted Types enforcement is declined rather than deferred — the observation run answered its question and was removed with its header; no innerHTML write remains in code Jx ships.
 - **0.5.3-draft** (2026-08-18) — §5.6: both tiers refuse a $props write against a private key, and a private entry gets no property accessor.
 - **0.5.2-draft** (2026-08-18) — §21.5: ship the Trusted Types observation stage, and correct two claims its first boot disproved.

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -2193,6 +2193,39 @@ const _privatePropWarned = new Set<string>();
  * @param {string} [where] - The site refusing it, for a message that points somewhere
  * @returns {boolean} True when the key is private and the caller must skip it
  */
+/**
+ * Whether the instance genuinely CARRIES `key`, rather than the prototype merely having an accessor
+ * for it.
+ *
+ * `key in el` cannot tell those apart, and for a REFLECTED DOM property — `title`, `role`, `id`,
+ * `lang`, `dir`, `slot`, `hidden` — the accessor answers `""` when nothing is set. `"" !==
+ * undefined`, so a component declaring `state.title` never rendered its own default: the empty
+ * string won. `quote` next to it kept its default, which is what made the bug look like bad
+ * content.
+ *
+ * The test is NOT `Object.hasOwn` alone, and that distinction is the whole subtlety. Assigning a
+ * reflected name goes through the prototype accessor and creates no own property, so a legitimate
+ * `$props.title` would be discarded by an own-property test — silently, for every component that
+ * declares one. What the accessor DOES do is write the attribute, so the attribute is the evidence
+ * that somebody set it, whether that was `$props` before connection or the author in the document.
+ *
+ * @param {HTMLElement} el - The instance being connected.
+ * @param {string} key - A state key declared by the component definition.
+ * @returns {boolean}
+ */
+function instanceSupplies(el: HTMLElement, key: string): boolean {
+  if (Object.hasOwn(el, key)) {
+    return true;
+  }
+  if (el.hasAttribute(key)) {
+    return true;
+  }
+  // ARIA-style reflections carry a kebab attribute for a camelCase property (`ariaLabel` →
+  // `aria-label`), so the direct name lookup above would miss a value that really was set.
+  const kebab = key.replaceAll(/[A-Z]/gu, (c) => `-${c.toLowerCase()}`);
+  return kebab !== key && el.hasAttribute(kebab);
+}
+
 function refusePrivateProp(key: string, where?: string): boolean {
   if (!isPrivateStateKey(key)) {
     return false;
@@ -2530,7 +2563,11 @@ export async function defineElement(source: string | JxDocument, baseUrl?: strin
         if (isPrivateStateKey(key)) {
           continue;
         }
-        if (key in this && (this as Record<string, unknown>)[key] !== undefined) {
+        if (
+          key in this &&
+          (this as Record<string, unknown>)[key] !== undefined &&
+          instanceSupplies(this, key)
+        ) {
           state[key] = (this as Record<string, unknown>)[key];
         }
       }

--- a/packages/runtime/tests/custom-elements.test.ts
+++ b/packages/runtime/tests/custom-elements.test.ts
@@ -444,3 +444,72 @@ describe("prop-binding markers (setStampPropBindings)", () => {
     el.remove();
   });
 });
+
+/**
+ * A state key that collides with a REFLECTED DOM property.
+ *
+ * `connectedCallback` merges instance values with `key in this && this[key] !== undefined`. For a
+ * reflected name — `title`, `role`, `id`, `lang`, `dir`, `slot`, `hidden` — the accessor exists on
+ * the prototype and answers `""` when nothing is set, and `"" !== undefined`, so the empty string
+ * won and the component's own default never rendered. A plain key beside it kept its default, which
+ * is what made this look like broken content rather than a runtime bug. 41 shipped starter
+ * components declare `title` or `role` as state.
+ */
+describe("a reflected property name does not clobber the declared default", () => {
+  /** Render one instance of a definition declaring a reflected key and a plain one. */
+  async function render(instance: Record<string, unknown>) {
+    const tag = uniqueTag();
+    await defineElement({
+      children: [
+        { tagName: "h3", textContent: "${state.title}" },
+        { tagName: "p", textContent: "${state.quote}" },
+      ],
+      state: { quote: "DEFAULT QUOTE", title: "DEFAULT TITLE" },
+      tagName: tag,
+    } as never);
+    const el = renderNode({ tagName: tag, ...instance }, {}, {});
+    document.body.append(el);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    return {
+      quote: el.querySelector("p")?.textContent,
+      title: el.querySelector("h3")?.textContent,
+    };
+  }
+
+  test("with nothing supplied, BOTH defaults render", async () => {
+    // The regression, stated once: `title` rendered "" while `quote` rendered its default.
+    expect(await render({})).toEqual({ quote: "DEFAULT QUOTE", title: "DEFAULT TITLE" });
+  });
+
+  test("$props on a reflected name still wins", async () => {
+    /* The trap in the fix. Assigning a reflected name goes through the prototype accessor and
+       creates NO own property, so an `Object.hasOwn` test would discard this silently — for every
+       component that declares one. The accessor writes the attribute, and that is the evidence. */
+    const r = await render({ $props: { title: "FROM PROPS" } });
+    expect(r.title).toBe("FROM PROPS");
+  });
+
+  test("an explicitly EMPTY $props value is honoured, not replaced by the default", async () => {
+    // "" is a value an author may mean. It must not be read as "nothing was supplied".
+    const rendered = await render({ $props: { title: "" } });
+    expect(rendered.title).toBe("");
+  });
+
+  test("$props on a plain name still wins", async () => {
+    const rendered = await render({ $props: { quote: "FROM PROPS" } });
+    expect(rendered.quote).toBe("FROM PROPS");
+  });
+
+  test("a literal attribute of the same name still wins", async () => {
+    // Unchanged behaviour: the attribute is how a reflected value arrives, so it still supplies.
+    const rendered = await render({ attributes: { title: "FROM ATTR" } });
+    expect(rendered.title).toBe("FROM ATTR");
+  });
+
+  test("a props.* attribute still wins", async () => {
+    const r = await render({ attributes: { "props.title": "FROM PROPS-ATTR" } });
+    expect(r.title).toBe("FROM PROPS-ATTR");
+  });
+});

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -2,9 +2,9 @@
 
 ## Declarative Document Object Model — JSON Edition
 
-**Version:** 0.5.4-draft
+**Version:** 0.5.5-draft
 **Status:** Partial
-**Updated:** 2026-08-18
+**Updated:** 2026-08-24
 **License:** MIT
 
 ---
@@ -1361,6 +1361,16 @@ Props are passed via `$props` on the instance node. This is the only mechanism f
 }
 ```
 
+**An instance supplies a prop, or it does not.** The runtime takes a value from the instance only
+where the instance genuinely carries one — an own JS property, or an attribute of that name. Probing
+the element for the key alone is not enough, because a state key that collides with a **reflected**
+DOM property (`title`, `role`, `id`, `lang`, `dir`, `slot`, `hidden`) always answers: the accessor
+lives on the prototype and reports `""` when nothing is set, which would otherwise beat the
+component's declared default and render blank. Testing for an own property alone is equally wrong in
+the other direction — assigning a reflected name goes through that same accessor and creates no own
+property, so a real `$props.title` would be discarded. The attribute the accessor writes is what
+distinguishes the two.
+
 ### 13.3 Signal Forwarding
 
 When a `$props` value is a `$ref` to a signal, the child receives the same reactive reference — writes in either scope trigger effects in both.
@@ -2477,6 +2487,7 @@ This rewrites the mutating handlers of Appendix A's idiom using `$expression`, l
 
 ## Changelog
 
+- **0.5.5-draft** (2026-08-24) — 13.2 states that the runtime takes a prop from an instance only where the instance genuinely carries one — an own property or an attribute — because a state key colliding with a reflected DOM property otherwise reports an empty string and beats the component's declared default.
 - **0.5.4-draft** (2026-08-18) — §21.5: Trusted Types enforcement is declined rather than deferred — the observation run answered its question and was removed with its header; no innerHTML write remains in code Jx ships.
 - **0.5.3-draft** (2026-08-18) — §5.6: both tiers refuse a $props write against a private key, and a private entry gets no property accessor.
 - **0.5.2-draft** (2026-08-18) — §21.5: ship the Trusted Types observation stage, and correct two claims its first boot disproved.
@@ -2535,4 +2546,4 @@ This rewrites the mutating handlers of Appendix A's idiom using `$expression`, l
 
 ---
 
-_Jx Specification v0.5.4-draft — subject to revision_
+_Jx Specification v0.5.5-draft — subject to revision_


### PR DESCRIPTION
Closes #186.

## The bug

A component whose state key collides with a **reflected** DOM property — `title`, `role`, `id`, `lang`, `dir`, `slot`, `hidden` — never rendered its own default. Measured against the real runtime before touching anything:

```
definition state: { title: "DEFAULT TITLE", quote: "DEFAULT QUOTE" }
instance:         { tagName: "…" }        // nothing supplied

renders:  <h3>…</h3>   → ""              ← the declared default is gone
          <p>…</p>     → "DEFAULT QUOTE" ← a plain key beside it is fine
```

That asymmetry is why this read as broken content rather than a runtime bug.

`connectedCallback` merged instance values with `key in this && this[key] !== undefined`. For a reflected name the accessor lives on the **prototype** and answers `""` when nothing is set — and `""` is not `undefined`, so the empty string won.

**41 shipped starter components** declare `title` or `role` as state.

## The fix, and the trap

The merge now asks whether the instance genuinely **carries** the key: an own JS property, or an attribute of that name.

`Object.hasOwn` alone is the trap the issue warned about, and it is a real one — assigning a reflected name goes through that same prototype accessor and creates **no own property**, so a legitimate `$props.title` would be discarded silently for every component that declares one. What the accessor *does* do is write the attribute, and that is the evidence somebody set it — whether `$props` before connection or the author in the document.

ARIA-style reflections are handled too: `ariaLabel` carries `aria-label`, so the direct name lookup would miss a value that really was set.

## Every legitimate route is pinned

The fix is only safe if none of them regressed, so all five are tests:

| route | still wins |
| --- | --- |
| `$props` on a **reflected** name | ✅ the trap case |
| `$props` on a plain name | ✅ |
| an explicitly **empty** `$props` value | ✅ must not read as "nothing supplied" |
| a literal attribute of the same name | ✅ unchanged behaviour |
| a `props.*` attribute | ✅ |

## Verified in both directions

- **Remove the guard** → the bug returns (2 failures, including "with nothing supplied, BOTH defaults render").
- **Substitute `Object.hasOwn`** → 4 failures, one of them an *existing* test (`stamps component internals rendered by connectedCallback`). That's the trap breaking real behaviour, not just my new cases — which is the protection #186 asked for.

## Suites

runtime 616, compiler 1360, studio 9169 — all pass. `runtime.ts` coverage 97.50 functions / 99.53 lines (bar 0.97/0.95). Lint, both typechecks, type-aware lint and every docs gate clean.

## Spec

`spec.md` §13.2 states the rule, because "probe the element for the key" and "test for an own property" are each wrong in a *different* direction and the next reader will reach for one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
