### PR TITLE
fix(canvas): the document base is absolute, so the canvas mounts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
     },
     "extensions/parser": {
       "name": "@jxsuite/parser",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@jxsuite/markup": "workspace:^",
         "@jxsuite/schema": "workspace:^",
@@ -121,7 +121,7 @@
     },
     "packages/ai": {
       "name": "@jxsuite/ai",
-      "version": "0.36.1",
+      "version": "0.36.2",
       "dependencies": {
         "@jxsuite/protocol": "workspace:^",
         "@vue/reactivity": "3.5.41",
@@ -142,7 +142,7 @@
     },
     "packages/compiler": {
       "name": "@jxsuite/compiler",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "bin": {
         "jx": "./bin/jx.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/create": {
       "name": "@jxsuite/create",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "bin": {
         "create-jxsuite": "./index.ts",
       },
@@ -175,7 +175,7 @@
     },
     "packages/desktop": {
       "name": "@jxsuite/desktop",
-      "version": "2.2.1",
+      "version": "2.3.2",
       "dependencies": {
         "@jxsuite/compiler": "workspace:^",
         "@jxsuite/create": "workspace:^",
@@ -200,7 +200,7 @@
     },
     "packages/formulas": {
       "name": "@jxsuite/formulas",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
       },
@@ -210,7 +210,7 @@
     },
     "packages/import": {
       "name": "@jxsuite/import",
-      "version": "0.39.2",
+      "version": "0.39.4",
       "bin": {
         "jx-import": "./src/cli.ts",
       },
@@ -250,14 +250,14 @@
     },
     "packages/protocol": {
       "name": "@jxsuite/protocol",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
       },
     },
     "packages/runtime": {
       "name": "@jxsuite/runtime",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
         "@vue/reactivity": "3.5.41",
@@ -282,7 +282,7 @@
     },
     "packages/server": {
       "name": "@jxsuite/server",
-      "version": "2.2.1",
+      "version": "2.2.4",
       "dependencies": {
         "@jxsuite/collab": "workspace:^",
         "@jxsuite/compiler": "workspace:^",
@@ -304,7 +304,7 @@
     },
     "packages/starters": {
       "name": "@jxsuite/starters",
-      "version": "1.5.0",
+      "version": "1.6.1",
       "devDependencies": {
         "@jxsuite/parser": "workspace:^",
         "@jxsuite/runtime": "workspace:^",
@@ -315,7 +315,7 @@
     },
     "packages/studio": {
       "name": "@jxsuite/studio",
-      "version": "2.2.1",
+      "version": "2.4.0",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^3.0.0",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.1.0",

--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,7 +17,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.8-draft  | Partial     | 2026-08-23 |
 | `collab.md`               | 0.2.5-draft  | Partial     | 2026-08-20 |
 | `compiler.md`             | 0.3.1-draft  | Partial     | 2026-08-18 |
-| `desktop.md`              | 0.3.20-draft | Pending     | 2026-08-23 |
+| `desktop.md`              | 0.3.21-draft | Pending     | 2026-08-24 |
 | `extensions.md`           | 0.3.10-draft | Partial     | 2026-08-20 |
 | `imports.md`              | 0.1.9-draft  | Partial     | 2026-08-15 |
 | `jx-markdown.md`          | 0.1.8-draft  | Partial     | 2026-08-15 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -73,6 +73,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.3.21-draft** (2026-08-24) — 3.1 states that documentBaseUrl may be absolute or root-relative, and that a root-relative value is resolved against the canvas origin because the canvas composes it as new URL(path, base) — a relative base throws and fails the whole canvas mount.
 - **0.3.20-draft** (2026-08-23) — 3.1 adds the Canvas member family and states that the canvas needs project files at a URL rather than behind readFile: documentBaseUrl defaults to the canvas origin plus projectRoot and must be set by a platform whose root is an identifier rather than a served path.
 - **0.3.19-draft** (2026-08-22) — 10 SaaS/Cloud is Partial rather than Future: the adapter shipped and is deployed (10.1 Implemented, with what it implements and what it deliberately omits), collaboration shipped as a CRDT rather than the sketched lock model (10.3), and 10.2's storage table is marked Pending because the deployed backend is git-backed.
 - **0.3.18-draft** (2026-08-22) — 3.3 the init bundle loads through a declared boot slot rather than an exact-string replace on the shipped document.

--- a/packages/studio/src/canvas/canvas-origin.ts
+++ b/packages/studio/src/canvas/canvas-origin.ts
@@ -42,12 +42,24 @@ export function canvasBaseOrigin(): string {
  * @returns {string} A base URL ending in `/`, safe to pass to `new URL(relativePath, base)`.
  */
 export function documentBase(projectRoot?: string): string {
+  const origin = canvasBaseOrigin();
   const declared = hasPlatform() ? getPlatform().documentBaseUrl : undefined;
   if (declared) {
-    return declared.endsWith("/") ? declared : `${declared}/`;
+    const withSlash = declared.endsWith("/") ? declared : `${declared}/`;
+    /*
+     * ABSOLUTE, ALWAYS. The caller uses this as `new URL(documentPath, base)`, and a `base` that is
+     * itself relative throws `Failed to construct 'URL': Invalid base URL` — which is not a failed
+     * fetch but a failed MOUNT: the canvas renders nothing at all.
+     *
+     * Jx Cloud declares a root-relative base (`/api/v1/p/:owner/:repo/:branch/studio/raw/`), which
+     * is the natural thing to declare and must keep working. Resolving it against the canvas origin
+     * here means a platform may declare either shape. An already-absolute URL passes through
+     * unchanged, because that is what `new URL` does with one.
+     */
+    return new URL(withSlash, `${origin}/`).href;
   }
   const root = projectRoot || "";
-  return `${canvasBaseOrigin()}/${root ? `${root}/` : ""}`;
+  return `${origin}/${root ? `${root}/` : ""}`;
 }
 
 /**

--- a/packages/studio/src/types.ts
+++ b/packages/studio/src/types.ts
@@ -195,7 +195,9 @@ export interface StudioPlatform {
    * every `$ref` fetch landed on the SPA fallback — which answers HTML at **200**, so `res.ok`
    * passed and the parse died on `Unexpected token '<'`. Images failed the same way in silence.
    *
-   * Must end in `/`; a project-relative path is appended to it verbatim.
+   * May be absolute or root-relative — a root-relative value is resolved against the canvas origin,
+   * because the canvas uses this as `new URL(path, base)` and a relative BASE throws. A missing
+   * trailing `/` is added: without it `new URL` drops the last segment.
    */
   documentBaseUrl?: string;
   activate: (root?: string) => Promise<void>;

--- a/packages/studio/tests/canvas-origin.test.ts
+++ b/packages/studio/tests/canvas-origin.test.ts
@@ -87,19 +87,58 @@ describe("documentBase", () => {
     expect(documentBase()).toBe(`${location.origin}/`);
   });
 
-  test("a declared base wins, and the project root is NOT appended to it", () => {
-    /* The declared base already addresses one project — Jx Cloud's is
-       /api/v1/p/:owner/:repo/:branch/studio/raw/ — so appending the root key on top of it would
-       address a directory named "owner/repo@branch" inside that project. */
+  /**
+   * The result must be usable as `new URL(path, base)`, which is the ONLY thing the caller does
+   * with it. Asserting the returned string instead is what let a root-relative base ship: the
+   * caller threw `Failed to construct 'URL': Invalid base URL` and the canvas did not mount at all
+   * — not a failed fetch, a blank canvas with an error card.
+   *
+   * The other test here made it worse by prefixing `http://x` to the result by hand, writing the
+   * missing absolutisation into the test and hiding the very defect it was covering. So every case
+   * below composes a real path through the real API.
+   */
+  const compose = (path: string) => new URL(path, documentBase("acme/site@main")).href;
+
+  test("a ROOT-RELATIVE declared base is absolutised — the shape Jx Cloud declares", () => {
     g.__jxPlatform = { documentBaseUrl: "/api/v1/p/acme/site/main/studio/raw/" };
-    expect(documentBase("acme/site@main")).toBe("/api/v1/p/acme/site/main/studio/raw/");
+    expect(compose("pages/index.md")).toBe(
+      `${location.origin}/api/v1/p/acme/site/main/studio/raw/pages/index.md`,
+    );
+  });
+
+  test("and a component $ref resolves off it, which is what the canvas actually fetches", () => {
+    g.__jxPlatform = { documentBaseUrl: "/api/v1/p/acme/site/main/studio/raw/" };
+    const doc = new URL("pages/index.md", documentBase("acme/site@main"));
+    expect(new URL("../components/co-nav.json", doc).href).toBe(
+      `${location.origin}/api/v1/p/acme/site/main/studio/raw/components/co-nav.json`,
+    );
+  });
+
+  test("the project root is NOT appended to a declared base", () => {
+    /* The declared base already addresses one project, so appending the root key on top of it
+       would address a directory named "acme/site@main" inside that project. */
+    g.__jxPlatform = { documentBaseUrl: "/api/v1/p/acme/site/main/studio/raw/" };
+    expect(compose("pages/index.md")).not.toContain("acme/site@main");
+  });
+
+  test("an ALREADY-ABSOLUTE declared base passes through", () => {
+    // A platform may serve project files from another origin entirely.
+    g.__jxPlatform = { documentBaseUrl: "https://files.example.com/proj/" };
+    expect(compose("pages/index.md")).toBe("https://files.example.com/proj/pages/index.md");
   });
 
   test("a declared base missing its trailing slash still composes", () => {
-    // `new URL("pages/index.json", ".../raw")` would drop the last segment; the slash is load-bearing.
+    // Without the slash `new URL` drops the last segment, so "raw" would be lost.
     g.__jxPlatform = { documentBaseUrl: "/api/v1/p/acme/site/main/studio/raw" };
-    expect(new URL("pages/index.json", `http://x${documentBase("")}`).pathname).toBe(
-      "/api/v1/p/acme/site/main/studio/raw/pages/index.json",
+    expect(compose("pages/index.md")).toBe(
+      `${location.origin}/api/v1/p/acme/site/main/studio/raw/pages/index.md`,
+    );
+  });
+
+  test("the DEFAULT base composes too — it is used the same way", () => {
+    g.__jxPlatform = {};
+    expect(new URL("pages/index.md", documentBase("examples/site-demo")).href).toBe(
+      `${location.origin}/examples/site-demo/pages/index.md`,
     );
   });
 

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,9 +2,9 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.3.20-draft
+**Version:** 0.3.21-draft
 **Status:** Pending
-**Updated:** 2026-08-23
+**Updated:** 2026-08-24
 **License:** MIT
 
 ---
@@ -97,7 +97,10 @@ renderer resolves a component `$ref` by fetching it, so a platform must be able 
 project tree is served. `documentBaseUrl` is that declaration. It defaults to
 `<canvas origin>/<projectRoot>/`, which is already right for any backend serving the tree from its
 web root — the dev server and the desktop loopback both do — and **MUST** be set by a platform whose
-`projectRoot` is an identifier rather than a served path. A host that answers a missing file with a
+`projectRoot` is an identifier rather than a served path. It may be absolute or root-relative; a
+root-relative value is resolved against the canvas origin, because the canvas composes it as
+`new URL(path, base)` and a relative base throws rather than resolving — which fails the whole
+canvas MOUNT, not one fetch. A host that answers a missing file with a
 single-page fallback compounds a wrong base rather than exposing it: the shell arrives at HTTP 200,
 so the fetch succeeds and the failure surfaces from the JSON parser instead.
 
@@ -1164,6 +1167,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.3.21-draft** (2026-08-24) — 3.1 states that documentBaseUrl may be absolute or root-relative, and that a root-relative value is resolved against the canvas origin because the canvas composes it as new URL(path, base) — a relative base throws and fails the whole canvas mount.
 - **0.3.20-draft** (2026-08-23) — 3.1 adds the Canvas member family and states that the canvas needs project files at a URL rather than behind readFile: documentBaseUrl defaults to the canvas origin plus projectRoot and must be set by a platform whose root is an identifier rather than a served path.
 - **0.3.19-draft** (2026-08-22) — 10 SaaS/Cloud is Partial rather than Future: the adapter shipped and is deployed (10.1 Implemented, with what it implements and what it deliberately omits), collaboration shipped as a CRDT rather than the sketched lock model (10.3), and 10.2's storage table is marked Pending because the deployed backend is git-backed.
 - **0.3.18-draft** (2026-08-22) — 3.3 the init bundle loads through a declared boot slot rather than an exact-string replace on the shipped document.
@@ -1203,4 +1207,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.3.20-draft_
+_Jx Studio Desktop Architecture Specification v0.3.21-draft_


### PR DESCRIPTION
```
The canvas could not be mounted.
Failed to construct 'URL': Invalid base URL
```

**My regression, and it takes the whole canvas** — not one fetch, the mount.

## Cause

`documentBase()` returned a platform's declared `documentBaseUrl` verbatim, and the caller composes it as `new URL(documentPath, base)`. Jx Cloud declares a **root-relative** base — `/api/v1/p/:owner/:repo/:branch/studio/raw/` — and a relative base does not resolve, it throws:

```js
new URL("pages/index.md", "/api/v1/p/acme/site/main/studio/raw/")
//                        → Invalid URL
new URL("pages/index.md", "https://studio.jxsuite.com/api/v1/…/raw/")
//                        → …/raw/pages/index.md
```

A declared base is now resolved against the canvas origin, so a platform may declare either shape. An already-absolute URL passes through — that's what `new URL` does with one anyway.

## The tests passed while this shipped

That's the part worth fixing properly, and it's the same mistake twice in this area.

- One asserted the returned **string** equalled the relative input. True, and useless: the only thing the caller does with the value is use it as a `new URL` base.
- The other was worse — it prefixed `http://x` to the result **by hand** to make the composition work, writing the missing absolutisation into the test and hiding the exact defect it was covering.

Every case now composes a real path through the real API:

| case | asserts |
| --- | --- |
| root-relative declared base | resolves against the canvas origin |
| a component `$ref` off that base | `…/raw/components/co-nav.json` — what the canvas actually fetches |
| already-absolute declared base | passes through to another origin |
| declared base missing its `/` | last segment isn't dropped |
| the **default** base | composes the same way |
| project root vs declared base | the root key is not appended on top |

Verified by restoring the shipped behaviour: **four of them fail.**

## Contract

The PAL member and `specs/desktop.md` §3.1 now say which shapes are accepted and why. "Must end in `/`" was the only stated constraint, and it wasn't the one that broke.

## Suites

9182 studio tests pass. Lint, both typechecks, type-aware lint and every docs gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
