### PR TITLE
fix(ci): the cache verifier was reading its own log output as a store path

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -339,10 +339,33 @@ jobs:
           for system in x86_64-linux aarch64-linux; do
             # Not `out=$(...)` bare: under `set -e` a failed eval would kill the script before it
             # could report anything, turning "the cache is broken" into a silent red X.
-            if ! out="$(nix eval --raw "${ref}#packages.${system}.default.outPath" 2>&1)"; then
-              problems="${problems}- evaluating the $system package failed: \`$out\`"$'\n'
+            #
+            # And NOT `2>&1`, which is how it was written for five releases. `nix eval` prints its
+            # fetch progress and its evaluation warnings to STDERR, so merging the streams put
+            # `unpacking 'github:jxsuite/jx/…' into the Git cache`, seven `copying path` lines and
+            # a `stdenv.isLinux is deprecated` warning INSIDE `$out`. `nix path-info` was then
+            # handed that blob in place of a store path and failed with
+            # `getting status of "…": No such file or directory` — the SAME message a genuinely
+            # absent path produces, which is why nothing looked wrong. This job filed
+            # "Binary cache does not serve <tag>" five times running against a cache that was
+            # serving every one of those paths (#161, #169, #172, #178, #190).
+            #
+            # stderr is still captured, because the diagnostic it carries is why it was merged in
+            # the first place — just not into the value.
+            err="$(mktemp)"
+            if ! out="$(nix eval --raw "${ref}#packages.${system}.default.outPath" 2>"$err")"; then
+              problems="${problems}- evaluating the $system package failed: \`$(tail -n 3 "$err")\`"$'\n'
               continue
             fi
+            # A check whose input is unvalidated cannot tell "the cache is empty" from "I did not
+            # understand the answer", and reports the first for both. Say which one it is.
+            case "$out" in
+              /nix/store/?*) ;;
+              *)
+                problems="${problems}- the $system evaluation did not return a store path, so the cache was never asked: \`$out\`"$'\n'
+                continue
+                ;;
+            esac
             echo "$system -> $out"
             if nix path-info --store "$cache" "$out" >/dev/null 2>&1; then
               echo "::notice::$cache holds $out"

--- a/scripts/release-config.test.ts
+++ b/scripts/release-config.test.ts
@@ -16,6 +16,8 @@
  * matrix.
  */
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, test } from "bun:test";
 
 import { readWorkspaces } from "./lib/workspaces.ts";
@@ -217,5 +219,73 @@ describe("release-please config", () => {
     }
 
     expect(cycles).toEqual([]);
+  });
+});
+
+/**
+ * The binary-cache verifier in .github/workflows/release-please.yml.
+ *
+ * It filed "Binary cache does not serve <tag>" against five consecutive releases — #161, #169,
+ * #172, #178, #190 — while https://jxsuite.cachix.org was serving every single one of those store
+ * paths on both architectures. The cause was one redirection: `out="$(nix eval --raw … 2>&1)"`.
+ * `nix eval` writes its fetch progress and its evaluation warnings to stderr, so `$out` held eight
+ * lines of `copying path '/nix/store/…' from 'https://nix-community.cachix.org'` and a
+ * `stdenv.isLinux is deprecated` warning with the real path on the end.
+ *
+ * What made it invisible for five releases is that `nix path-info` answers a malformed argument and
+ * a genuinely absent path with the SAME message — `getting status of "…": No such file or
+ * directory`, exit 1 — so the job's own logs looked exactly like a cache that was empty.
+ *
+ * Neither assertion below can be made from the YAML's meaning, only from its text; that is the
+ * price of a check that lives in a shell script inside a workflow. They are cheap and they name the
+ * failure, which is more than the five issues managed between them.
+ */
+describe("the release workflow's binary-cache verifier", () => {
+  const workflow = readFileSync(".github/workflows/release-please.yml", "utf8");
+
+  /** Every `nix eval` invocation captured into a shell variable. */
+  const captures = [...workflow.matchAll(/^\s*(?:if !\s*)?\w+="\$\(nix eval[^\n]*$/gm)].map((m) =>
+    m[0].trim(),
+  );
+
+  test("captures a `nix eval` result at all — the anchor these tests depend on", () => {
+    expect(captures.length).toBeGreaterThan(0);
+  });
+
+  test("never merges stderr into the value it captures", () => {
+    // `2>&1` here is not a style question. It puts progress output inside a store path, and the
+    // Resulting lookup fails in a way indistinguishable from an empty cache.
+    for (const line of captures) {
+      expect(
+        line,
+        `${line}\n  -> redirect stderr to a file, not into the captured value`,
+      ).not.toContain("2>&1");
+    }
+  });
+
+  test("keeps stderr, because the diagnostic is the reason it was captured", () => {
+    // The original `2>&1` existed so a failed evaluation could be reported rather than vanishing.
+    // Dropping stderr entirely would fix the bug and lose that, so the fix must redirect it
+    // Somewhere the failure branch can still read.
+    for (const line of captures) {
+      expect(
+        line,
+        `${line}\n  -> send stderr to a file so the failure branch can quote it`,
+      ).toMatch(/2>"?\$/);
+    }
+  });
+
+  test("checks that what it got is a store path before asking the cache", () => {
+    // Without this the job reports "the cache does not hold X" both when the cache is empty and
+    // When it never understood X in the first place. Those need different words.
+    //
+    // Asserted against the extracted guard rather than the whole file, so a failure prints four
+    // Lines instead of the entire workflow.
+    const guard = /case\s+"\$out"\s+in\b([\s\S]*?)esac/.exec(workflow)?.[1];
+    expect(guard, 'no `case "$out"` guard in the cache verifier').toBeDefined();
+    expect(
+      guard,
+      "the guard must require a /nix/store path, not merely something under /nix",
+    ).toContain("/nix/store/?*)");
   });
 });


### PR DESCRIPTION
**The binary cache is fine, and has been for all five releases it was reported broken on.** The verifier was wrong.

## Ground truth first

```
$ curl -o /dev/null -w '%{http_code}' https://jxsuite.cachix.org/fzrgqy3ymr3y5n8kpj293hfkak51jwc0.narinfo
200                      # desktop-v2.3.3, x86_64-linux
$ curl -o /dev/null -w '%{http_code}' https://jxsuite.cachix.org/86mvnjs6fb1sswh42qrz8jgha6klyg2m.narinfo
200                      # desktop-v2.3.3, aarch64-linux
$ nix path-info --store https://jxsuite.cachix.org /nix/store/fzrgqy3ymr3y5n8kpj293hfkak51jwc0-jx-studio-2.3.3
/nix/store/fzrgqy3ymr3y5n8kpj293hfkak51jwc0-jx-studio-2.3.3
```

Both architectures, served, today. Cachix has the paths.

## What actually broke

One redirection in `verify-cache`:

```bash
out="$(nix eval --raw "${ref}#packages.${system}.default.outPath" 2>&1)"
```

`nix eval` writes fetch progress and evaluation warnings to **stderr**. Merging the streams put this inside `$out`:

```
unpacking 'github:jxsuite/jx/eb4fe5dc…' into the Git cache...
copying path '/nix/store/lrxvs4l9…-source' from 'https://nix-community.cachix.org'...
…five more copying lines…
evaluation warning: stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead
/nix/store/fzrgqy3ymr3y5n8kpj293hfkak51jwc0-jx-studio-2.3.3
```

`nix path-info` was then handed that blob instead of a store path. **What made it invisible for five releases is that it fails with the same message a genuinely absent path does:**

```
$ nix path-info --store https://jxsuite.cachix.org "$blob"
error: getting status of "…/evaluation warning: …\n/nix/store/fzrg…": No such file or directory   # exit 1

$ nix path-info --store https://jxsuite.cachix.org /nix/store/0000…-jx-studio-9.9.9
error: getting status of "/nix/store/0000…-jx-studio-9.9.9": No such file or directory            # exit 1
```

Same error, same exit code. The job's own logs read exactly like an empty cache.

The tell was in the issues all along: the third assertion in that job — `nix build github:jxsuite/jx/release --max-jobs 0`, i.e. *substitute or fail* — **passed every time**, and is absent from all five issue bodies. A consumer really was downloading the whole closure while the job insisted they were building from source.

## The fix

- stderr goes to a temp file instead of into the value. It is still captured, because reporting a failed evaluation is why it was merged in the first place — the failure branch quotes `tail -n 3` of it.
- The result is checked for `/nix/store/*` before the cache is asked, so the check can no longer answer *"the cache is empty"* when it means *"I did not understand the answer"*. That distinction is the actual lesson here.

Run verbatim against production before and after:

```
x86_64-linux  -> /nix/store/fzrgqy3ymr3y5n8kpj293hfkak51jwc0-jx-studio-2.3.3
  ::notice:: https://jxsuite.cachix.org holds …
aarch64-linux -> /nix/store/86mvnjs6fb1sswh42qrz8jgha6klyg2m-jx-studio-2.3.3
  ::notice:: https://jxsuite.cachix.org holds …

VERDICT: cache serves the release on both architectures — no issue filed.
```

## Regression guard

Four tests in `scripts/release-config.test.ts`, each **verified to fail against the code it forbids** rather than merely passing today:

| Mutant | Result |
|---|---|
| `2>&1` put back | 2 tests red |
| stderr dropped entirely (fixes the bug, loses the diagnostic) | 1 test red |
| store-path check weakened to `/nix/*` | 1 test red |
| restored | 12 pass |

These assert on the workflow's *text*, which is the price of a check that lives in a shell script inside YAML — but they name the failure, which is more than the five issues managed between them.

## Not covered by this

- **#168** (`desktop-v2.3.0` missing assets) was real, not a false alarm — that release has zero assets attached. It has since resolved on its own: `desktop-v2.3.3` carries all 15 expected assets and is not marked pre-release. Left open for you to close or investigate.
- **#177** (released versions that never shipped) is the separate `verify-release-integrity` lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
