### PR TITLE
fix: the last two Windows-only test failures

### DIFF
--- a/extensions/connector/src/dialects/bun-sqlite.ts
+++ b/extensions/connector/src/dialects/bun-sqlite.ts
@@ -23,7 +23,8 @@ export interface BunSqliteStatementLike {
 /** The subset of `bun:sqlite`'s Database the driver uses. */
 export interface BunSqliteDatabaseLike {
   prepare: (sql: string) => BunSqliteStatementLike;
-  close?: () => void;
+  /** `throwOnError` forces the close instead of deferring it — see {@link createDriver}'s destroy. */
+  close?: (throwOnError?: boolean) => void;
 }
 
 export interface BunSqliteDialectConfig {
@@ -113,7 +114,14 @@ function createDriver(config: BunSqliteDialectConfig): Driver {
     },
     destroy: async () => {
       if (owned) {
-        db?.close?.();
+        /* `close(true)`, not `close()`. bun:sqlite defers a bare close while prepared statements
+           are outstanding, and `executeQuery` above prepares one per query and finalizes none, so
+           the bare form returns without releasing the file. Measured directly: open a database,
+           prepare three statements, then `close()` — the file cannot be deleted (EBUSY on
+           Windows); `close(true)`, or finalizing each statement first, releases it. POSIX hides
+           the difference because a file can be unlinked while open, but the handle leaks on every
+           platform, once per connection the driver believes it has closed. */
+        db?.close?.(true);
       }
       db = null;
     },

--- a/extensions/connector/tests/bun-sqlite.test.ts
+++ b/extensions/connector/tests/bun-sqlite.test.ts
@@ -68,3 +68,28 @@ describe("createBunSqliteDialect", () => {
     await driver.destroy();
   });
 });
+
+describe("destroy releases the database file", () => {
+  /*
+   * A driver that reports itself destroyed while still holding the file is the failure this pins.
+   * `executeQuery` prepares a statement per query and finalizes none, and bun:sqlite DEFERS a bare
+   * `close()` while statements are outstanding — so the obvious spelling returns without releasing
+   * anything. POSIX cannot see it (an open file still unlinks); Windows answers EBUSY, which is
+   * where it surfaced. Deleting the directory is the assertion because that is the consequence
+   * anyone actually meets: a temp fixture that will not clean up, or a project directory a desktop
+   * window has quietly pinned.
+   */
+  test("the file can be deleted after destroy, having been queried through", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bun-sqlite-release-"));
+    const db = new Kysely<DynamicDatabase>({
+      dialect: createBunSqliteDialect({ url: join(dir, "held.sqlite") }),
+    });
+    await sql`create table t (a integer)`.execute(db);
+    await sql`insert into t (a) values (1)`.execute(db);
+    await sql`select * from t`.execute(db);
+    await db.destroy();
+
+    expect(() => rmSync(dir, { recursive: true })).not.toThrow();
+    expect(existsSync(dir)).toBe(false);
+  });
+});

--- a/packages/studio/tests/reachability.ts
+++ b/packages/studio/tests/reachability.ts
@@ -85,16 +85,38 @@ export interface ReachabilityReport {
 }
 
 /**
- * A path in TypeScript's spelling: absolute, forward-slashed.
+ * A path in this harness's one spelling: absolute, forward-slashed, drive letter upper-cased.
  *
- * Every path this harness compares comes from the TS API — `configFileName`, the program's file
- * names — and TypeScript normalises those to `/` on every platform. `resolve`/`join` do not: on
- * Windows they yield `C:\\…`, so `p.configFileName === TSCONFIG` was never true, `configured` was
- * silently undefined behind its `!`, and the run died on `p.program` — while the `SRC`-prefixed
- * filters quietly matched nothing.
+ * Two normalisations, because Windows offers the same file under several names and this harness
+ * keys maps by it.
+ *
+ * Separators: every path it compares against comes from the TS API, which uses `/` on every
+ * platform. `resolve`/`join` do not — they yield `C:\\…`, so `p.configFileName === TSCONFIG` was
+ * never true, `configured` was silently undefined behind its `!`, and the run died on `p.program`,
+ * while the `SRC`-prefixed filters quietly matched nothing.
+ *
+ * Drive-letter case: TypeScript is not self-consistent here. A file inside the configured program
+ * comes back `C:/…`; the same file opened by name comes back `c:/…`. Windows means one file by
+ * either, so an `owner` lookup keyed on one spelling missed the entry stored under the other and
+ * the walk died on a second `!` that had never been true.
  */
+function canonical(file: string): string {
+  const slashed = file.replaceAll("\\", "/");
+  return /^[a-z]:\//.test(slashed) ? slashed[0]!.toUpperCase() + slashed.slice(1) : slashed;
+}
+
+/**
+ * A path relative to `src/`, forward-slashed — the spelling every reported key and allow-list entry
+ * uses. `relative()` alone yields `canvas\iframe-position.ts` on Windows, so no allow-list entry
+ * matched and all 1322 declarations were reported dead.
+ */
+function srcRelative(file: string): string {
+  return relative(SRC, file).replaceAll("\\", "/");
+}
+
+/** {@link canonical}, applied to path parts this harness resolves for itself. */
 function tsPath(...parts: string[]): string {
-  return resolve(...parts).replaceAll("\\", "/");
+  return canonical(resolve(...parts));
 }
 
 const STUDIO_DIR = tsPath(import.meta.dir, "..");
@@ -227,7 +249,8 @@ async function run(api: API): Promise<ReachabilityReport> {
   // `packages/desktop` are outside it, and they hold real callers, so they are opened alongside.
   const first = await api.updateSnapshot({ openProjects: [TSCONFIG] });
   const main = first.getProjects()[0]!;
-  const inProgram = new Set(await main.program.getSourceFileNames());
+  const programFiles = await main.program.getSourceFileNames();
+  const inProgram = new Set(programFiles.map((file) => canonical(file)));
   const extra = callerFiles(REPO).filter((f) => !inProgram.has(f) && namesStudio(f));
 
   const snapshot = await api.updateSnapshot({ openProjects: [TSCONFIG], openFiles: extra });
@@ -280,7 +303,7 @@ async function run(api: API): Promise<ReachabilityReport> {
     decls.set(id, {
       id,
       name,
-      file: sf.fileName,
+      file: canonical(sf.fileName),
       line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
       isFunction: fn,
       isExported: exported,
@@ -422,7 +445,9 @@ async function run(api: API): Promise<ReachabilityReport> {
 
   const shorthandValues = await Promise.all(
     shorthands.map((h) =>
-      owner.get(h.node.getSourceFile().fileName)!.checker.getShorthandAssignmentValueSymbol(h.node),
+      owner
+        .get(canonical(h.node.getSourceFile().fileName))!
+        .checker.getShorthandAssignmentValueSymbol(h.node),
     ),
   );
   const shorthandTargets = await followAliases(configured, shorthandValues);
@@ -432,7 +457,7 @@ async function run(api: API): Promise<ReachabilityReport> {
 
   const patternTypes = await Promise.all(
     patterns.map((p) =>
-      owner.get(p.node.getSourceFile().fileName)!.checker.getTypeAtLocation(p.node),
+      owner.get(canonical(p.node.getSourceFile().fileName))!.checker.getTypeAtLocation(p.node),
     ),
   );
   const wanted: {
@@ -446,7 +471,7 @@ async function run(api: API): Promise<ReachabilityReport> {
     if (!type) {
       continue;
     }
-    const project = owner.get(p.node.getSourceFile().fileName)!;
+    const project = owner.get(canonical(p.node.getSourceFile().fileName))!;
     for (const element of p.node.elements as AnyNode[]) {
       const name: string | undefined = element.propertyName?.text ?? element.name?.text;
       if (name !== undefined) {
@@ -467,7 +492,10 @@ async function run(api: API): Promise<ReachabilityReport> {
     if (!spec.startsWith(".")) {
       return undefined;
     }
-    const base = join(dirname(from), spec.replace(/\.js$/, ""));
+    /* The canonical spelling, not join: `sources` is keyed that way and join() hands back
+       `C:\…\x` on Windows, so no relative import resolved at all — `importsOf` was empty for every
+       file and 289 of 308 modules were reported unreachable. */
+    const base = tsPath(dirname(from), spec.replace(/\.js$/, ""));
     for (const candidate of [base, `${base}.ts`, `${base}/index.ts`]) {
       if (sources.has(candidate)) {
         return candidate;
@@ -500,10 +528,10 @@ async function run(api: API): Promise<ReachabilityReport> {
      export does not have to be added here. */
   const published = Object.values(manifest.exports)
     .filter((p) => p.endsWith(".ts"))
-    .map((p) => join(STUDIO_DIR, p));
+    .map((p) => tsPath(STUDIO_DIR, p));
   const bundleSource = readFileSync(join(STUDIO_DIR, "scripts", "build-config.ts"), "utf8");
   const bundled = [...bundleSource.matchAll(/"(\.\/src\/[\w./-]+\.ts)"/g)].map((m) =>
-    join(STUDIO_DIR, m[1]!),
+    tsPath(STUDIO_DIR, m[1]!),
   );
   if (bundled.length === 0) {
     throw new Error("no STUDIO_ENTRYPOINTS found in scripts/build-config.ts — the roots moved");
@@ -554,19 +582,19 @@ async function run(api: API): Promise<ReachabilityReport> {
   }
 
   const functions = [...decls.values()].filter((d) => d.isFunction);
-  const key = (d: Decl) => `${relative(SRC, d.file)}:${d.name}`;
+  const key = (d: Decl) => `${srcRelative(d.file)}:${d.name}`;
   const dead = functions
     .filter((d) => !live.has(d.id))
     .map((d) => ({
       name: d.name,
-      file: relative(SRC, d.file),
+      file: srcRelative(d.file),
       line: d.line,
       key: key(d),
     }));
 
   return {
     dead,
-    deadModules: studioFiles.filter((f) => !liveModules.has(f)).map((f) => relative(SRC, f)),
+    deadModules: studioFiles.filter((f) => !liveModules.has(f)).map((f) => srcRelative(f)),
     allFunctions: new Set(functions.map((d) => key(d))),
     functionCount: functions.length,
     moduleCount: studioFiles.length,


### PR DESCRIPTION
Two Windows-only failures left over from #193, both pre-existing on `main` and both invisible on CI's Linux. Neither is Electrobun.

## `bun:sqlite` was never actually closed

`extensions/connector`'s driver prepares a statement per query and finalizes none, then calls a bare `db.close()`. `bun:sqlite` **defers** that close while statements are outstanding — so `destroy()` returned having released nothing, while reporting the database closed.

Measured directly rather than inferred:

| | result |
| --- | --- |
| prepare 3 statements → `close()` | file cannot be deleted (EBUSY) |
| prepare 3 statements → `close(true)` | released |
| finalize each → `close()` | released |

POSIX hides it, because an open file still unlinks. Windows does not, and three tests in this package were already failing there:

```
createBunSqliteDialect > opens a file database, ... and closes it on destroy
Sqlite provider > deploySchema + testConnection run real SQL against the file
node-side resolution > TableQuery/TableEntry resolve against a real local sqlite
```

The package goes from 92 pass / 3 fail to 96 pass / 0 fail. The added test asserts the *consequence* rather than the call — after querying through a file database and destroying it, the directory can be removed — because that is what anyone actually meets: a fixture that will not clean up, or a project directory a long-lived host has quietly pinned. It fails without the one-character change.

## The reachability gate could not run on Windows at all

Five path assumptions, each hiding the next:

1. `p.configFileName === TSCONFIG` was never true — the constant came from `join`/`resolve` (`C:\…`), TypeScript reports `C:/…`. `configured` was silently `undefined` behind its `!` and the run died on `p.program`.
2. TypeScript is not self-consistent about the drive letter: a file **inside** the configured program comes back `C:/…`, the **same file opened by name** comes back `c:/…`. `owner` was keyed by one and read by the other.
3. `relative(SRC, file)` yields `canvas\iframe-position.ts`, matching no allow-list entry — all **1322** declarations reported dead.
4. `resolveSpecifier` built candidates with `join`, so none matched a `sources` key: no relative import resolved, and **289 of 308 modules** were reported unreachable.
5. The declared entry points were built the same way and failed their own "entry point is not in the program" check.

One `canonical()` — absolute, forward-slashed, drive letter upper-cased — now applies to paths the harness resolves *and* to every path arriving from the TS API. Nothing changes on POSIX, where it is the identity for these paths.

The gate now agrees with Linux: **0 dead modules**, and the same dead-function set the allow-list already describes.

## Verification

`packages/studio` 9180 pass / 2 skip / 0 fail · `extensions/connector` 96/0 · `packages/desktop` 690/0 · `scripts` 475 pass / 2 skip / 0 fail · lint, format, both typechecks, type-aware lint, and the docs gates all green.

## Still open

The desktop `data-session` fixture still leaves `.jx/data/main.sqlite` locked on Windows, so its cleanup stays best-effort (the suite is green either way). The connector fix above does **not** resolve it, and I could not explain why: instrumenting `openDatabase` in the dialect produced no output on that path even though the file is created and locked, and there is only one `@jxsuite/connector` on disk — a workspace symlink — and no other `bun:sqlite` opener in the tree. That contradiction deserves a debugger rather than more probes, so I have left it rather than guess. It is not a regression and it does not fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
