### PR TITLE
fix(cloud): discover components by reading them, so the canvas can register any

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -17,7 +17,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `ai.md`                   | 0.1.8-draft  | Partial     | 2026-08-23 |
 | `collab.md`               | 0.2.5-draft  | Partial     | 2026-08-20 |
 | `compiler.md`             | 0.3.1-draft  | Partial     | 2026-08-18 |
-| `desktop.md`              | 0.3.22-draft | Pending     | 2026-08-24 |
+| `desktop.md`              | 0.3.23-draft | Pending     | 2026-08-25 |
 | `extensions.md`           | 0.3.10-draft | Partial     | 2026-08-20 |
 | `imports.md`              | 0.1.9-draft  | Partial     | 2026-08-15 |
 | `jx-markdown.md`          | 0.1.8-draft  | Partial     | 2026-08-15 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -73,6 +73,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `desktop.md`
 
+- **0.3.23-draft** (2026-08-25) — 10.1 removes discoverComponents from the cloud adapter's omissions: deriving component metadata from a JSON document executes nothing, and returning an empty registry left the canvas unable to register or fetch any component at all.
 - **0.3.22-draft** (2026-08-24) — §7 records the ElectroBun 2 toolchain boundary: the electrobun npm devDependency selects Hutch, Cottontail and ElectroBun together (no machine-wide install and no release pin in hutch.config.ts), the SDK is projected into .hutch/devkit, the main process is pinned to bun explicitly, and stable installers drop the channel prefix that the updater feed keeps.
 - **0.3.21-draft** (2026-08-24) — 3.1 states that documentBaseUrl may be absolute or root-relative, and that a root-relative value is resolved against the canvas origin because the canvas composes it as new URL(path, base) — a relative base throws and fails the whole canvas mount.
 - **0.3.20-draft** (2026-08-23) — 3.1 adds the Canvas member family and states that the canvas needs project files at a URL rather than behind readFile: documentBaseUrl defaults to the canvas origin plus projectRoot and must be set by a platform whose root is an identifier rather than a served path.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -10,6 +10,7 @@
   "exports": {
     ".": "./src/schema.ts",
     "./asset-paths": "./src/asset-paths.ts",
+    "./component-meta": "./src/component-meta.ts",
     "./extension-registry": "./src/extension-registry.ts",
     "./format-registry": "./src/format-registry.ts",
     "./project-schemas": "./src/project-schemas.ts",

--- a/packages/schema/src/component-meta.ts
+++ b/packages/schema/src/component-meta.ts
@@ -1,0 +1,143 @@
+/**
+ * Component metadata, derived from a parsed component document.
+ *
+ * Discovery — "what components does this project have, and what props do they take" — is a pure
+ * function of the document. It reads `tagName`, `state` and any `<slot>` in the tree; it executes
+ * nothing. That distinction is what lets a backend with a no-project-JS posture discover JSON
+ * components safely, which Jx Cloud could not do while this logic lived inside two Bun servers.
+ *
+ * It lives here because THREE backends need the same answer and two of them had already written it
+ * twice: `packages/server/src/studio-api.ts` (the dev server's `/__studio/components`) and
+ * `packages/desktop/src/project-session.ts`. A third copy in the cloud adapter would have made
+ * "which entries in `state` count as props" a question with three answers.
+ *
+ * @license MIT
+ */
+
+import type { JsonValue } from "../types";
+
+/** One `<slot>` found in a component's tree. */
+export interface ComponentSlotDef {
+  /** The slot's name; `""` for the unnamed slot. */
+  name: string;
+  /** Fallback children rendered when nothing is slotted in. */
+  fallback?: unknown[];
+}
+
+/** One editable prop, derived from a `state` entry. */
+export interface ComponentPropDef {
+  name: string;
+  type?: unknown;
+  default?: JsonValue;
+  format?: unknown;
+}
+
+/** What discovery reports for one component document. */
+export interface ComponentMetaOut {
+  tagName: string;
+  $id: string | null;
+  path: string;
+  props: ComponentPropDef[];
+  slots?: ComponentSlotDef[];
+  hasElements: boolean;
+}
+
+/**
+ * Collect slot definitions from a parsed component tree.
+ *
+ * Whitespace-only names count as unnamed (`""`), and only static `children` arrays are walked — a
+ * slot produced by a `$map` or a `$switch` has no fixed identity to report.
+ *
+ * @param {unknown} node - A node of the component document.
+ * @param {ComponentSlotDef[]} [out] - Accumulator, for the recursive walk.
+ * @returns {ComponentSlotDef[]}
+ */
+export function collectSlotDefs(node: unknown, out: ComponentSlotDef[] = []): ComponentSlotDef[] {
+  if (!node || typeof node !== "object" || Array.isArray(node)) {
+    return out;
+  }
+  const el = node as Record<string, unknown>;
+  if (el.tagName === "slot") {
+    const attrs = el.attributes as Record<string, unknown> | undefined;
+    const rawName = attrs?.name;
+    const name = typeof rawName === "string" ? rawName.trim() : "";
+    const { children } = el;
+    out.push({
+      name,
+      ...(Array.isArray(children) && children.length > 0 ? { fallback: children } : {}),
+    });
+  }
+  if (Array.isArray(el.children)) {
+    for (const c of el.children) {
+      collectSlotDefs(c, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * Whether a `state` entry is an editable prop.
+ *
+ * The shorthand form (`"title": "Hello"`) always is. The full form is one only when it is plain
+ * data: a computed value, a handler or a prototype entry is machinery the author does not type
+ * into, and offering it as a prop would put a text box in front of a function.
+ *
+ * @param {unknown} def - The `state` entry.
+ * @returns {boolean}
+ */
+function isPropEntry(def: unknown): boolean {
+  if (def == null) {
+    return false;
+  }
+  if (typeof def !== "object") {
+    return true;
+  }
+  const obj = def as Record<string, unknown>;
+  return !obj.$prototype && !obj.$handler && !obj.$compute;
+}
+
+/**
+ * Metadata for one component document, or null when the document is not a component.
+ *
+ * A component is a document whose `tagName` is a valid custom-element name — it must contain a
+ * hyphen. That single test is what keeps a page or a data file from being reported as a component
+ * when a whole project tree is scanned.
+ *
+ * @param {unknown} doc - The parsed document.
+ * @param {string} path - Project-relative path, reported verbatim.
+ * @returns {ComponentMetaOut | null}
+ */
+export function componentMetaFrom(doc: unknown, path: string): ComponentMetaOut | null {
+  if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
+    return null;
+  }
+  const content = doc as Record<string, unknown>;
+  const { tagName } = content;
+  if (typeof tagName !== "string" || !tagName.includes("-")) {
+    return null;
+  }
+  const slots = collectSlotDefs(content);
+  const state = (content.state ?? {}) as Record<string, unknown>;
+  return {
+    $id: typeof content.$id === "string" && content.$id ? content.$id : null,
+    hasElements: Array.isArray(content.$elements) && content.$elements.length > 0,
+    path,
+    props: Object.entries(state)
+      .filter(([, def]) => isPropEntry(def))
+      .map(([name, def]) => {
+        if (typeof def !== "object" || def === null) {
+          // Shorthand: the value IS the default, and its runtime type is the only type on offer.
+          return { default: def as JsonValue, name, type: typeof def };
+        }
+        const obj = def as Record<string, unknown>;
+        return {
+          default: obj.default as JsonValue,
+          format: obj.format,
+          name,
+          type: obj.type,
+        };
+      }),
+    ...(slots.length > 0 ? { slots } : {}),
+    tagName,
+  };
+}

--- a/packages/schema/tests/component-meta.test.ts
+++ b/packages/schema/tests/component-meta.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Component metadata, derived rather than executed.
+ *
+ * This module exists because three backends need the same answer and two had already written it
+ * twice — and the third could not write it at all: Jx Cloud refused component discovery under a "no
+ * execution of project JS" posture, when for a JSON component discovery is a file read and a
+ * property lookup. The cost was not the loss of a feature list. The canvas injects the `$elements`
+ * a document's tags need only when the registry is non-empty, so an empty registry meant no
+ * component was ever registered or fetched, and every instance rendered as an unregistered custom
+ * element — an empty inline box where the component should be.
+ */
+import { describe, expect, test } from "bun:test";
+import { collectSlotDefs, componentMetaFrom } from "../src/component-meta";
+
+describe("componentMetaFrom", () => {
+  test("a hyphenated tagName is a component; anything else is not", () => {
+    // The single test that keeps a whole-project scan from reporting pages and data files as
+    // Components: every backend globs the whole tree for JSON, so most of what it reads is not one.
+    expect(componentMetaFrom({ tagName: "my-card" }, "c.json")?.tagName).toBe("my-card");
+    expect(componentMetaFrom({ tagName: "div" }, "p.json")).toBeNull();
+    expect(componentMetaFrom({ children: [] }, "p.json")).toBeNull();
+  });
+
+  test("non-objects and arrays are refused rather than throwing", () => {
+    // A scan reads whatever JSON it finds, including `[]` and `"text"`.
+    for (const doc of [null, undefined, 42, "str", [], true]) {
+      expect(componentMetaFrom(doc, "x.json")).toBeNull();
+    }
+  });
+
+  test("the path is reported verbatim — the caller owns its shape", () => {
+    // One backend globs from the project root, another walks a session tree; normalising here
+    // Would fight whichever one already had it right.
+    expect(componentMetaFrom({ tagName: "a-b" }, "components/deep/a.json")?.path).toBe(
+      "components/deep/a.json",
+    );
+  });
+
+  describe("which state entries are props", () => {
+    test("shorthand entries are props, and the value is both default and type", () => {
+      const meta = componentMetaFrom(
+        { state: { count: 3, title: "Hi" }, tagName: "a-b" },
+        "a.json",
+      );
+      expect(meta?.props).toEqual([
+        { default: 3, name: "count", type: "number" },
+        { default: "Hi", name: "title", type: "string" },
+      ]);
+    });
+
+    test("machinery is NOT a prop — computed, handler and prototype entries", () => {
+      /* Offering these would put a text box in front of a function. This is the rule the two
+         copies stated in different words, which is the drift this module ends. */
+      const meta = componentMetaFrom(
+        {
+          state: {
+            items: { $prototype: "Array" },
+            onClick: { $handler: "x" },
+            plain: { default: "d", type: "string" },
+            total: { $compute: "a+b" },
+          },
+          tagName: "a-b",
+        },
+        "a.json",
+      );
+      expect(meta?.props.map((p) => p.name)).toEqual(["plain"]);
+    });
+
+    test("a null entry is not a prop", () => {
+      expect(componentMetaFrom({ state: { x: null }, tagName: "a-b" }, "a.json")?.props).toEqual(
+        [],
+      );
+    });
+
+    test("the full form carries default, type and format through", () => {
+      const meta = componentMetaFrom(
+        { state: { img: { default: "/a.png", format: "media", type: "string" } }, tagName: "a-b" },
+        "a.json",
+      );
+      expect(meta?.props).toEqual([
+        { default: "/a.png", format: "media", name: "img", type: "string" },
+      ]);
+    });
+
+    test("no state at all yields no props, not a throw", () => {
+      expect(componentMetaFrom({ tagName: "a-b" }, "a.json")?.props).toEqual([]);
+    });
+  });
+
+  describe("slots", () => {
+    test("an unnamed slot, and a whitespace-only name, are both the unnamed slot", () => {
+      const meta = componentMetaFrom(
+        {
+          children: [
+            { tagName: "slot" },
+            { attributes: { name: "   " }, tagName: "slot" },
+            { attributes: { name: "footer" }, tagName: "slot" },
+          ],
+          tagName: "a-b",
+        },
+        "a.json",
+      );
+      expect(meta?.slots?.map((s) => s.name)).toEqual(["", "", "footer"]);
+    });
+
+    test("a slot's children are its fallback; an empty slot has none", () => {
+      const meta = componentMetaFrom(
+        { children: [{ children: ["Nothing here"], tagName: "slot" }], tagName: "a-b" },
+        "a.json",
+      );
+      expect(meta?.slots?.[0]?.fallback).toEqual(["Nothing here"]);
+      const bare = componentMetaFrom({ children: [{ tagName: "slot" }], tagName: "a-b" }, "a.json");
+      expect(bare?.slots?.[0]).toEqual({ name: "" });
+    });
+
+    test("slots are found at any depth", () => {
+      const meta = componentMetaFrom(
+        {
+          children: [
+            { children: [{ children: [{ tagName: "slot" }], tagName: "div" }], tagName: "section" },
+          ],
+          tagName: "a-b",
+        },
+        "a.json",
+      );
+      expect(meta?.slots).toHaveLength(1);
+    });
+
+    test("the key is omitted entirely when there are no slots", () => {
+      // Rather than an empty array, so a component with no slots serialises without the key.
+      expect(componentMetaFrom({ tagName: "a-b" }, "a.json")).not.toHaveProperty("slots");
+    });
+  });
+
+  test("hasElements reports a NON-EMPTY $elements only", () => {
+    // It answers "does this component bring its own dependencies", so an empty array is a no.
+    expect(
+      componentMetaFrom({ $elements: [{ $ref: "./x.json" }], tagName: "a-b" }, "a")?.hasElements,
+    ).toBe(true);
+    expect(componentMetaFrom({ $elements: [], tagName: "a-b" }, "a")?.hasElements).toBe(false);
+    expect(componentMetaFrom({ tagName: "a-b" }, "a")?.hasElements).toBe(false);
+  });
+
+  test("$id is null rather than absent or empty", () => {
+    expect(componentMetaFrom({ $id: "c-1", tagName: "a-b" }, "a")?.$id).toBe("c-1");
+    expect(componentMetaFrom({ $id: "", tagName: "a-b" }, "a")?.$id).toBeNull();
+    expect(componentMetaFrom({ tagName: "a-b" }, "a")?.$id).toBeNull();
+  });
+});
+
+describe("collectSlotDefs", () => {
+  test("only static children arrays are walked", () => {
+    /* A slot produced by a `$map` or a `$switch` has no fixed identity to report, so it is not a
+       slot the studio can offer to fill. */
+    expect(collectSlotDefs({ children: { $prototype: "Array" }, tagName: "div" })).toEqual([]);
+  });
+
+  test("a non-object is not walked", () => {
+    expect(collectSlotDefs(null)).toEqual([]);
+    expect(collectSlotDefs(["slot"])).toEqual([]);
+  });
+});

--- a/packages/server/src/studio-api.ts
+++ b/packages/server/src/studio-api.ts
@@ -8,6 +8,7 @@
  */
 
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { componentMetaFrom } from "@jxsuite/schema/component-meta";
 import { errorMessage } from "@jxsuite/schema/parse";
 import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync, statSync, unlinkSync } from "node:fs";
@@ -91,38 +92,6 @@ interface ComponentDoc {
   $elements?: unknown[];
   state?: Record<string, unknown>;
   [key: string]: unknown;
-}
-
-interface SlotDef {
-  name: string;
-  fallback?: unknown[];
-}
-
-/**
- * Collect slot definitions (name + fallback children) from a parsed component tree. Whitespace-only
- * names count as unnamed (""). Only static children arrays are walked.
- */
-function collectSlotDefs(node: unknown, out: SlotDef[] = []): SlotDef[] {
-  if (!node || typeof node !== "object" || Array.isArray(node)) {
-    return out;
-  }
-  const el = node as Record<string, unknown>;
-  if (el.tagName === "slot") {
-    const attrs = el.attributes as Record<string, unknown> | undefined;
-    const rawName = attrs?.name;
-    const name = typeof rawName === "string" ? rawName.trim() : "";
-    const { children } = el;
-    out.push({
-      name,
-      ...(Array.isArray(children) && children.length > 0 ? { fallback: children } : {}),
-    });
-  }
-  if (Array.isArray(el.children)) {
-    for (const c of el.children) {
-      collectSlotDefs(c, out);
-    }
-  }
-  return out;
 }
 
 // ─── Extension registry (per project root, invalidated on project.json change) ──
@@ -792,42 +761,14 @@ export async function handleStudioApi(
             const source = await readFile(fp, "utf8");
             content = (await entry.call("parse", source)) as ComponentDoc;
           }
-          if (content.tagName && content.tagName.includes("-")) {
-            const slotDefs = collectSlotDefs(content);
-            components.push({
-              $id: content.$id || null,
-              hasElements: Array.isArray(content.$elements) && content.$elements.length > 0,
-              path: fwd(match),
-              props: Object.entries(content.state || {})
-                .filter(([, d]) => {
-                  if (d == null) {
-                    return false;
-                  }
-                  // Shorthand: "key": "value" or "key": 0 etc.
-                  if (typeof d !== "object") {
-                    return true;
-                  }
-                  // Full form: skip computed/handler/prototype entries
-                  const obj = d as Record<string, unknown>;
-                  return !obj.$prototype && !obj.$handler && !obj.$compute;
-                })
-                .map(([name, d]) => {
-                  if (typeof d !== "object" || d === null) {
-                    // Shorthand: infer type from value
-                    return { default: d, name, type: typeof d };
-                  }
-                  const obj = d as Record<string, unknown>;
-                  return {
-                    default: obj.default,
-                    format: obj.format,
-                    name,
-                    type: obj.type,
-                  };
-                }),
-              ...(slotDefs.length > 0 ? { slots: slotDefs } : {}),
-              source: "jx",
-              tagName: content.tagName,
-            });
+          /* The metadata rules live in @jxsuite/schema/component-meta because THREE backends need
+             the same answer — this one, the desktop session, and now the cloud adapter, which can
+             discover JSON components precisely because deriving them executes nothing. Two copies
+             had already drifted apart in wording; a third would have made "which state entries are
+             props" a question with three answers. */
+          const meta = componentMetaFrom(content, fwd(match));
+          if (meta) {
+            components.push({ ...meta, source: "jx" });
           }
         } catch {} // Skip non-JSON or parse errors
       }

--- a/packages/studio/src/platforms/cloud.ts
+++ b/packages/studio/src/platforms/cloud.ts
@@ -15,8 +15,10 @@ import { negotiateCollab } from "@jxsuite/collab/negotiate";
 import type { CollabNegotiation } from "@jxsuite/collab/negotiate";
 import type { WsCollabConnection } from "@jxsuite/collab/client";
 import type { ProjectConfig } from "@jxsuite/schema/types";
+import { componentMetaFrom } from "@jxsuite/schema/component-meta";
 import type {
   AccountStatus,
+  ComponentMeta,
   CreateProjectDestination,
   DirEntry,
   ExtensionsInfo,
@@ -518,9 +520,66 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
 
     // ─── Components / code services (cloud: static-only posture) ──────────
 
+    /**
+     * Component discovery, by READING rather than executing.
+     *
+     * This returned `[]` under "no execution of project JS in the cloud", and the cost was not the
+     * loss of discovery — it was the canvas. `canvas-live-render` injects the `$elements` a
+     * document's tags need only when the registry is non-empty, so an empty registry meant nothing
+     * was ever registered, no component was ever fetched, and every component instance rendered as
+     * an unregistered custom element: an empty inline box. A page built from components came up as
+     * blank space between the layout's chrome.
+     *
+     * Discovery does not need to execute anything. For a JSON component it is a file read and a
+     * property lookup — `componentMetaFrom` is that function, shared with the two Bun backends so
+     * "which `state` entries are props" has one answer. Non-JSON component formats DO need a
+     * project-supplied parser, and those stay out: the posture is kept where it actually applies
+     * rather than across the whole feature.
+     *
+     * Bounded rather than unbounded: the walk skips the directories a scan has no business in and
+     * stops at a depth and a file count, because this runs against a remote session over HTTP and a
+     * pathological tree must not turn opening a project into thousands of requests.
+     */
     async discoverComponents() {
-      // No execution of project JS in the cloud (MVP security posture).
-      return [];
+      const SKIP = new Set(["node_modules", "dist", ".git", ".claude", ".obsidian", "build"]);
+      const MAX_FILES = 400;
+      const MAX_DEPTH = 6;
+      const jsonPaths: string[] = [];
+
+      const walk = async (dir: string, depth: number): Promise<void> => {
+        if (depth > MAX_DEPTH || jsonPaths.length >= MAX_FILES) {
+          return;
+        }
+        let entries: DirEntry[];
+        try {
+          entries = await platform.listDirectory(dir);
+        } catch {
+          return; // A directory that vanished mid-walk is not a discovery failure.
+        }
+        const dirs: string[] = [];
+        for (const entry of entries) {
+          if (entry.type === "directory") {
+            if (!SKIP.has(entry.name) && !entry.name.startsWith(".")) {
+              dirs.push(entry.path);
+            }
+          } else if (entry.name.endsWith(".json") && jsonPaths.length < MAX_FILES) {
+            jsonPaths.push(entry.path);
+          }
+        }
+        await Promise.all(dirs.map(async (d) => walk(d, depth + 1)));
+      };
+      await walk("", 0);
+
+      const metas = await Promise.all(
+        jsonPaths.map(async (path) => {
+          try {
+            return componentMetaFrom(JSON.parse(await platform.readFile(path)), path);
+          } catch {
+            return null; // Not JSON, not readable, or not a component — all the same answer here.
+          }
+        }),
+      );
+      return metas.filter((m): m is NonNullable<typeof m> => m !== null) as ComponentMeta[];
     },
 
     async codeService() {

--- a/packages/studio/tests/cloud-platform.test.ts
+++ b/packages/studio/tests/cloud-platform.test.ts
@@ -907,10 +907,9 @@ describe("formats (session backend registry)", () => {
 });
 
 describe("static-posture members", () => {
-  test("component discovery and code services are inert", async () => {
+  test("code services stay inert — those DO need project JS", async () => {
     mockFetch({});
     const p = createCloudPlatform(PROJECT);
-    expect(await p.discoverComponents()).toEqual([]);
     expect(await p.codeService("lint", {})).toBeNull();
     expect(await p.fetchPluginSchema("src")).toBeNull();
     expect(p.aiChatUrl()).toBe("/api/v1/ai/chat");
@@ -1035,5 +1034,129 @@ describe("collab capability", () => {
     } finally {
       console.warn = realWarn;
     }
+  });
+});
+
+/**
+ * Component discovery, by reading rather than executing.
+ *
+ * This returned `[]` under a blanket "no execution of project JS" posture, and the canvas paid for
+ * it: `canvas-live-render` injects the `$elements` a document's tags need only when the registry is
+ * non-empty, so nothing was ever registered, no component was ever fetched, and every instance
+ * rendered as an unregistered custom element — blank space where the component should be.
+ */
+describe("discoverComponents", () => {
+  /** A session whose tree is `dirs` and whose files answer with `files`. */
+  function session(dirs: Record<string, unknown[]>, files: Record<string, unknown>) {
+    globalThis.fetch = ((url: string) => {
+      const listed = /\/files\?dir=([^&]*)/u.exec(url);
+      if (listed) {
+        return Promise.resolve(Response.json(dirs[decodeURIComponent(listed[1] ?? "")] ?? []));
+      }
+      const read = /\/file\?path=([^&]*)/u.exec(url);
+      if (read) {
+        const path = decodeURIComponent(read[1] ?? "");
+        return path in files
+          ? Promise.resolve(Response.json({ content: JSON.stringify(files[path]) }))
+          : Promise.resolve(Response.json({ error: "gone" }, { status: 404 }));
+      }
+      return Promise.resolve(Response.json({}));
+    }) as unknown as typeof fetch;
+  }
+
+  const dir = (name: string, path: string) => ({ name, path, type: "directory" });
+  const file = (name: string, path: string) => ({ name, path, type: "file" });
+
+  test("finds a component nested in the tree, and reports its props", async () => {
+    session(
+      {
+        "": [dir("components", "components"), file("package.json", "package.json")],
+        components: [file("card.json", "components/card.json")],
+      },
+      {
+        "components/card.json": { state: { title: "Hi" }, tagName: "my-card" },
+        "package.json": { name: "site" },
+      },
+    );
+    const found = await createCloudPlatform(PROJECT).discoverComponents();
+    expect(found).toEqual([
+      {
+        $id: null,
+        hasElements: false,
+        path: "components/card.json",
+        props: [{ default: "Hi", name: "title", type: "string" }],
+        tagName: "my-card",
+      },
+    ]);
+  });
+
+  test("a JSON file that is not a component is not reported", async () => {
+    // Most of what a whole-tree scan reads is pages and data. The hyphen test is what separates
+    // Them, and it lives in the shared extractor rather than here.
+    session(
+      { "": [file("index.json", "pages/index.json")] },
+      { "pages/index.json": { children: [], tagName: "main" } },
+    );
+    expect(await createCloudPlatform(PROJECT).discoverComponents()).toEqual([]);
+  });
+
+  test("unreadable or non-JSON files are skipped, not fatal", async () => {
+    // A scan reads whatever it finds; one bad file must not lose every other component.
+    session(
+      {
+        "": [file("broken.json", "broken.json"), file("ok.json", "ok.json")],
+      },
+      { "ok.json": { tagName: "a-b" } },
+    );
+    const found = await createCloudPlatform(PROJECT).discoverComponents();
+    expect(found.map((c) => c.tagName)).toEqual(["a-b"]);
+  });
+
+  test("node_modules and build output are never walked", async () => {
+    /* Not a nicety: a session tree with node_modules in it would turn opening a project into
+       thousands of HTTP reads against a remote Durable Object. */
+    const calls: string[] = [];
+    session(
+      {
+        "": [dir("node_modules", "node_modules"), dir("dist", "dist"), dir("src", "src")],
+        dist: [file("a.json", "dist/a.json")],
+        node_modules: [file("b.json", "node_modules/b.json")],
+        src: [],
+      },
+      {},
+    );
+    const inner = globalThis.fetch;
+    globalThis.fetch = ((url: string, init?: RequestInit) => {
+      calls.push(url);
+      return (inner as (u: string, i?: RequestInit) => Promise<Response>)(url, init);
+    }) as unknown as typeof fetch;
+
+    await createCloudPlatform(PROJECT).discoverComponents();
+    expect(calls.some((u) => u.includes("node_modules"))).toBe(false);
+    expect(calls.some((u) => u.includes("dist"))).toBe(false);
+  });
+
+  test("a dot-directory is skipped too", async () => {
+    const calls: string[] = [];
+    session({ "": [dir(".git", ".git"), dir(".claude", ".claude")] }, {});
+    const inner = globalThis.fetch;
+    globalThis.fetch = ((url: string, init?: RequestInit) => {
+      calls.push(url);
+      return (inner as (u: string, i?: RequestInit) => Promise<Response>)(url, init);
+    }) as unknown as typeof fetch;
+    await createCloudPlatform(PROJECT).discoverComponents();
+    expect(calls.some((u) => u.includes(".git") || u.includes(".claude"))).toBe(false);
+  });
+
+  test("a directory that fails to list does not abort the walk", async () => {
+    session({ "": [dir("components", "components")] }, {});
+    const inner = globalThis.fetch;
+    globalThis.fetch = ((url: string, init?: RequestInit) => {
+      if (url.includes("dir=components")) {
+        return Promise.resolve(Response.json({ error: "gone" }, { status: 500 }));
+      }
+      return (inner as (u: string, i?: RequestInit) => Promise<Response>)(url, init);
+    }) as unknown as typeof fetch;
+    expect(await createCloudPlatform(PROJECT).discoverComponents()).toEqual([]);
   });
 });

--- a/specs/desktop.md
+++ b/specs/desktop.md
@@ -2,9 +2,9 @@
 
 ## Platform Abstraction, Project Loading, and Component Scoping
 
-**Version:** 0.3.22-draft
+**Version:** 0.3.23-draft
 **Status:** Pending
-**Updated:** 2026-08-24
+**Updated:** 2026-08-25
 **License:** MIT
 
 ---
@@ -1050,9 +1050,18 @@ path. It reports `id: "cloud"`, `canvasUrl: "/canvas.html"` and `openProjectPick
 that last one routes New Project through Studio's own repository picker over `listRepos` +
 `importProject`, so `openProject()` is never called (§3.4). It implements the full git family, the
 identity and publish members, `subscribeFileEvents` over SSE, and `collab`. It deliberately omits
-`pickDirectory`, `importSite`, the package install family, `gitClone`, `resolveClass`,
-`discoverComponents` and `codeService`; each degrades exactly as its protocol route's `degradation`
-field describes, which is what makes an omission a documented state rather than a break.
+`pickDirectory`, `importSite`, the package install family, `gitClone`, `resolveClass` and
+`codeService`; each degrades exactly as its protocol route's `degradation` field describes, which is
+what makes an omission a documented state rather than a break.
+
+**`discoverComponents` is NOT among them, and the reason it once was is worth keeping.** It returned
+nothing under a blanket "no execution of project JS" posture — but for a JSON component, discovery
+is a file read and a property lookup, and executes nothing. The posture belongs to the formats that
+genuinely need a project-supplied parser, not to the whole feature. Omitting it did not cost a
+feature list: the canvas injects the `$elements` a document's tags need only when the component
+registry is non-empty, so an empty registry meant no component was ever registered or fetched, and
+every instance rendered as an unregistered custom element — blank space where the component should
+be. An omission is only a documented state when something actually degrades gracefully.
 
 Because a cloud project _is_ a repository, the adapter sets `createDestination: "repo"` and the New Project modal collects a repository location — owner (personal account or organization), repository name, and visibility — instead of a folder (§4.5). The adapter forwards all three to the API, which resolves the owner against the session login to choose between the personal and organization creation endpoints. Nothing about the destination is defaulted server-side.
 
@@ -1176,6 +1185,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.3.23-draft** (2026-08-25) — 10.1 removes discoverComponents from the cloud adapter's omissions: deriving component metadata from a JSON document executes nothing, and returning an empty registry left the canvas unable to register or fetch any component at all.
 - **0.3.22-draft** (2026-08-24) — §7 records the ElectroBun 2 toolchain boundary: the electrobun npm devDependency selects Hutch, Cottontail and ElectroBun together (no machine-wide install and no release pin in hutch.config.ts), the SDK is projected into .hutch/devkit, the main process is pinned to bun explicitly, and stable installers drop the channel prefix that the updater feed keeps.
 - **0.3.21-draft** (2026-08-24) — 3.1 states that documentBaseUrl may be absolute or root-relative, and that a root-relative value is resolved against the canvas origin because the canvas composes it as new URL(path, base) — a relative base throws and fails the whole canvas mount.
 - **0.3.20-draft** (2026-08-23) — 3.1 adds the Canvas member family and states that the canvas needs project files at a URL rather than behind readFile: documentBaseUrl defaults to the canvas origin plus projectRoot and must be set by a platform whose root is an identifier rather than a served path.
@@ -1217,4 +1227,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_Jx Studio Desktop Architecture Specification v0.3.22-draft_
+_Jx Studio Desktop Architecture Specification v0.3.23-draft_


### PR DESCRIPTION
Components render as **blank space** on Jx Cloud. This is the actual cause — not a URL problem.

## What the log showed

Your invocation log has the session fetch `pages/index.md`, POST `/format`, read `layouts/base.json` — and then **no component read of any kind**. Not through `/raw`, not through `/file`. The canvas never asks for one.

```ts
async discoverComponents() {
  // No execution of project JS in the cloud (MVP security posture).
  return [];
}
```

`canvas-live-render` injects the `$elements` a document's tags need **only when the component registry is non-empty**. Empty registry → nothing registered → nothing fetched → every instance renders as an unregistered custom element, which is an empty inline box.

The `/raw` mount (platform#29) and `documentBaseUrl` (#176) were both necessary and **neither was sufficient**: they fix the fetch, and there was no fetch.

## The posture was applied too broadly

For a **JSON** component, discovery is a file read and a property lookup. It executes nothing. The formats that genuinely need a project-supplied parser stay out — the rule now sits where it actually applies rather than across the whole feature.

## One derivation, not three

`componentMetaFrom` lands in `@jxsuite/schema` because three backends need the same answer and two had already written it twice — and they had **already drifted**: the desktop copy omits `type`/`format` when null while the dev server emits them as undefined keys. That's the kind of difference that surfaces as a studio behaving differently on two backends.

The dev server now uses the shared one. **The desktop copy is deliberately left** for its own change: that file's program doesn't currently typecheck cleanly in my environment, and a mechanical edit there isn't worth bundling into a fix. Filed as a follow-up.

## The walk is bounded

Depth, file count, and a skip list — because this runs against a remote Durable Object over HTTP, and a session tree containing `node_modules` would turn opening a project into thousands of reads. Tests cover the skip list, the bound, a directory that fails to list mid-walk, a file that isn't JSON, and a JSON file that isn't a component — that last being most of what a whole-tree scan reads.

## Verification

Restoring the empty implementation makes the discovery tests fail. schema **379**, server **822**, studio **9196** pass. `component-meta.ts` at **100%** lines and functions. Lint, typecheck, dep-rules, studio-package and every docs gate clean.

## Spec

`specs/desktop.md` §10.1 no longer lists `discoverComponents` among the cloud adapter's deliberate omissions, and says why it shouldn't have been: **an omission is only a documented state when something actually degrades gracefully.** This one didn't — it silently emptied the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
