### PR TITLE
fix(create): scaffold writable projects from read-only template stores

### DIFF
--- a/docs/framework/build/cli.md
+++ b/docs/framework/build/cli.md
@@ -43,6 +43,10 @@ A blank scaffold produces:
 
 Choosing a starter instead copies the starter site verbatim (minus build artifacts), then re-stamps `project.json` with your name, URL, description, and adapter, and rebuilds `package.json` with current dependency ranges.
 
+The new project is always writable, whatever permissions the templates themselves carry. Templates are copied from wherever `@jxsuite/create` and `@jxsuite/starters` are installed, and a read-only install — every path under `/nix/store` is read-only by construction — would otherwise hand you a project you could not edit, install into, or build.
+
+A scaffold that fails partway cleans up after itself, so a retry sees the destination it expects rather than the debris of the previous attempt. Only what the scaffolder wrote is removed: a directory it created is deleted, a directory that already existed is emptied, and a destination that already had content is refused before anything is written at all.
+
 ## `jx build`
 
 Build the site to the configured `outDir` (default `dist/`). See [How compilation works](/docs/framework/build) for what happens inside.

--- a/packages/create/generate.ts
+++ b/packages/create/generate.ts
@@ -1,6 +1,6 @@
 /** Shared project generation logic. Used by both the CLI scaffolder and the Studio server endpoint. */
 
-import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, cp, lstat, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { adapterNeedsWrangler, buildWranglerJsonc } from "./scaffold";
 import { basename, join, relative, sep } from "node:path";
 
@@ -64,12 +64,114 @@ const STARTER_EXCLUDE = new Set([
 ]);
 
 /**
+ * Add owner-write to every file and directory in a freshly copied tree.
+ *
+ * `fs.cp` reproduces the SOURCE's permission bits on the destination — correct for a backup, wrong
+ * for a scaffolder. When the templates ship from a read-only store the new project lands read-only:
+ * every path under /nix/store is 444/555 by construction, and a root-owned or content-addressed
+ * install can be too. The generator then fails on its own next write (the project.json re-stamp,
+ * EACCES), and had it not, the user's `bun install`, `jx build` and every later edit would fail the
+ * same way — the destination directory itself is writable only because `mkdir` created it.
+ *
+ * Bits are OR-ed rather than assigned, so a template that deliberately marks a file executable
+ * keeps it; only owner-write is forced on, plus owner-search on directories so the walk can enter
+ * them. Symlinks are skipped: `chmod` follows them, and a link pointing out of the tree must not
+ * have its target rewritten. A link's target inside the tree is normalized when the walk reaches it
+ * directly.
+ *
+ * @param {string} dir — absolute path to a directory that is already writable
+ */
+async function makeWritable(dir: string): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.isSymbolicLink()) {
+        return;
+      }
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const { mode } = await lstat(full);
+        // Widened before recursing: a directory lacking owner-search cannot be read into.
+        // oxlint-disable-next-line no-bitwise -- st_mode is a bitfield; OR-ing is how a bit is added
+        await chmod(full, mode | 0o700);
+        await makeWritable(full);
+        return;
+      }
+      if (entry.isFile()) {
+        const { mode } = await lstat(full);
+        // oxlint-disable-next-line no-bitwise -- st_mode is a bitfield; OR-ing is how a bit is added
+        await chmod(full, mode | 0o200);
+      }
+    }),
+  );
+}
+
+/**
+ * Remove the debris of a scaffold that threw partway through.
+ *
+ * The safety rule is that this may only delete what the generator itself wrote. `destPath` is
+ * removed outright ONLY when the generator created it; when the caller pointed at a directory that
+ * already existed, {@link generateProject} has just proved it was empty, so everything inside is
+ * ours and the directory the user made is left standing. Nothing that predates the call is
+ * reachable either way.
+ *
+ * @param {string} destPath — absolute path to the project directory
+ * @param {boolean} destExisted — whether destPath existed before the generator ran
+ */
+async function discardPartialScaffold(destPath: string, destExisted: boolean): Promise<void> {
+  try {
+    // The tree is very likely read-only: that is the failure this most often follows.
+    // Unlinking an entry needs write permission on the directory that holds it.
+    await makeWritable(destPath);
+    if (!destExisted) {
+      await rm(destPath, { force: true, recursive: true });
+      return;
+    }
+    const entries = await readdir(destPath);
+    await Promise.all(
+      entries.map(async (entry) => rm(join(destPath, entry), { force: true, recursive: true })),
+    );
+  } catch {
+    // Best-effort: the scaffold failure is the one worth reporting.
+    // A cleanup that cannot finish must not replace it with a second, less useful error.
+  }
+}
+
+/**
  * Generate a new Jx project at the given path.
  *
  * @param {string} destPath — absolute path to the project directory
  * @param {ProjectOptions} opts
  */
 export async function generateProject(destPath: string, opts: ProjectOptions) {
+  const destExisted = existsSync(destPath);
+  if (destExisted) {
+    const { readdirSync } = await import("node:fs");
+    if (readdirSync(destPath).length > 0) {
+      throw new Error(`Directory "${destPath}" is not empty`);
+    }
+  }
+
+  await mkdir(destPath, { recursive: true });
+
+  try {
+    await populateProject(destPath, opts);
+  } catch (error) {
+    // A half-written project is worse than no project: it is what turns the user's retry into
+    // `Directory "..." is not empty`, an error that describes the debris rather than the failure.
+    await discardPartialScaffold(destPath, destExisted);
+    throw error;
+  }
+}
+
+/**
+ * Write the project itself. Split out of {@link generateProject} so the destination guard, the
+ * directory creation and the rollback surround every write below without indenting them.
+ *
+ * @param {string} destPath — absolute path to the (existing, empty) project directory
+ * @param {ProjectOptions} opts
+ */
+async function populateProject(destPath: string, opts: ProjectOptions) {
   const {
     name,
     description = "",
@@ -79,15 +181,6 @@ export async function generateProject(destPath: string, opts: ProjectOptions) {
     template = "blank",
     design,
   } = opts;
-
-  if (existsSync(destPath)) {
-    const { readdirSync } = await import("node:fs");
-    if (readdirSync(destPath).length > 0) {
-      throw new Error(`Directory "${destPath}" is not empty`);
-    }
-  }
-
-  await mkdir(destPath, { recursive: true });
 
   if (starter && starter !== "blank") {
     await scaffoldFromStarter(destPath, starter, {
@@ -125,6 +218,10 @@ export async function generateProject(destPath: string, opts: ProjectOptions) {
 
   await Promise.all(writes);
 
+  // The .gitignore, layouts/ and pages/ above are copies too, carrying the template's modes.
+  // The overlay below would otherwise fail to `force` over a file that came across read-only.
+  await makeWritable(destPath);
+
   // The mobile-app variant overlays the shared skeleton with its app-shell layout and home page.
   // Sequenced after the base copies so the overlay files win.
   if (template === "mobile-app") {
@@ -132,6 +229,7 @@ export async function generateProject(destPath: string, opts: ProjectOptions) {
       force: true,
       recursive: true,
     });
+    await makeWritable(destPath);
   }
 
   if (design?.logo) {
@@ -174,6 +272,9 @@ async function scaffoldFromStarter(
       return rel === "" || !rel.split(sep).some((seg) => STARTER_EXCLUDE.has(seg));
     },
   });
+
+  // Before the re-stamp below, which writes straight back into the tree that was just copied.
+  await makeWritable(destPath);
 
   // Re-stamp project.json with the new project's identity, keeping the starter's design tokens,
   // Content types, image pipeline, and head.

--- a/packages/create/tests/generate-readonly.test.ts
+++ b/packages/create/tests/generate-readonly.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Regression coverage for scaffolding out of a READ-ONLY template store, and for the rollback that
+ * runs when a scaffold throws partway through.
+ *
+ * `fs.cp` reproduces the SOURCE's permission bits on the destination, so a starter shipped from a
+ * store where every path is 444/555 — which is what /nix/store is, by construction — produced a
+ * read-only project, and the generator then died on its own next write: `EACCES: permission denied,
+ * open '<dest>/project.json'`. The suites beside this one cannot see it: their fixtures are built
+ * by the test process at the default umask, so their sources are writable.
+ *
+ * The failure also left the half-written tree behind, which turned the user's retry into `Directory
+ * "<dest>" is not empty` — an error describing the debris rather than the cause.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const STAMP = Date.now();
+const FIXTURE = resolve(tmpdir(), `jx-readonly-fixture-${STAMP}`);
+const BROKEN = resolve(tmpdir(), `jx-readonly-broken-${STAMP}`);
+const OUTSIDE = resolve(tmpdir(), `jx-readonly-outside-${STAMP}`);
+const TMP = resolve(tmpdir(), `jx-create-readonly-test-${STAMP}`);
+
+// Stand in for @jxsuite/starters: "fixture" is a well-formed read-only starter; "broken" is one
+// Whose project.json cannot be parsed, which is how the rollback path is reached.
+void mock.module("@jxsuite/starters", () => ({
+  getStarterDir: (id: string) => {
+    if (id === "fixture") {
+      return FIXTURE;
+    }
+    if (id === "broken") {
+      return BROKEN;
+    }
+    throw new Error(`Unknown starter: "${id}"`);
+  },
+}));
+
+const { generateProject } = await import("../generate");
+
+/**
+ * Apply `dirMode`/`fileMode` to every directory and file under `dir`, depth-first so a directory is
+ * still searchable while its children are being walked. Symlinks are left alone — `chmodSync`
+ * follows them, and these fixtures point deliberately outside the tree.
+ */
+function chmodTree(dir: string, dirMode: number, fileMode: number) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      chmodTree(full, dirMode, fileMode);
+      chmodSync(full, dirMode);
+    } else {
+      chmodSync(full, fileMode);
+    }
+  }
+}
+
+/** Lock a fixture down to exactly what a store path looks like. */
+const lockdown = (dir: string) => {
+  chmodTree(dir, 0o555, 0o444);
+  chmodSync(dir, 0o555);
+};
+
+/**
+ * Widen a tree back to writable. Every teardown must run this BEFORE `rmSync`: unlinking an entry
+ * needs write permission on the directory holding it, so a 555 tree cannot be deleted and the test
+ * would otherwise leak a directory the runner itself cannot remove.
+ */
+const unlock = (dir: string) => {
+  if (!existsSync(dir)) {
+    return;
+  }
+  chmodSync(dir, 0o755);
+  chmodTree(dir, 0o755, 0o644);
+};
+
+/** The permission bits of `p`, following symlinks (nothing here is called on a link). */
+// oxlint-disable-next-line no-bitwise -- st_mode is a bitfield; masking is how permissions are read
+const permsOf = (p: string) => statSync(p).mode & 0o777;
+
+/** Whether `p` carries the owner-write bit — the one thing the fix is responsible for. */
+// oxlint-disable-next-line no-bitwise -- st_mode is a bitfield; masking is how a bit is tested
+const isWritable = (p: string) => (permsOf(p) & 0o200) !== 0;
+
+/**
+ * Every real (non-symlink) path under `dir`. Links are omitted because a symlink's own mode is
+ * meaningless on Linux — it is always 777 — and `statSync` on one reports its TARGET, which is the
+ * very file this fix must leave alone.
+ */
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    const full = join(dir, entry.name);
+    out.push(full);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    }
+  }
+  return out;
+}
+
+beforeAll(() => {
+  mkdirSync(join(FIXTURE, "pages"), { recursive: true });
+  mkdirSync(join(FIXTURE, "content", "posts"), { recursive: true });
+  writeFileSync(
+    join(FIXTURE, "project.json"),
+    JSON.stringify({ name: "Atrium", style: {}, url: "https://fixture.example" }),
+  );
+  writeFileSync(join(FIXTURE, "package.json"), JSON.stringify({ name: "atrium" }));
+  writeFileSync(join(FIXTURE, "pages", "index.md"), "# Home\n");
+  writeFileSync(join(FIXTURE, "content", "posts", "first.md"), "# First\n");
+  writeFileSync(join(FIXTURE, "setup.sh"), "#!/bin/sh\necho hi\n");
+
+  // A symlink pointing out of the starter tree. Chmod follows symlinks, so a walk that does not
+  // Skip them would widen a file the scaffolder has no business touching.
+  mkdirSync(OUTSIDE, { recursive: true });
+  writeFileSync(join(OUTSIDE, "secret.txt"), "not ours");
+  chmodSync(join(OUTSIDE, "secret.txt"), 0o444);
+  symlinkSync(join(OUTSIDE, "secret.txt"), join(FIXTURE, "link.txt"));
+
+  lockdown(FIXTURE);
+  // Stamped AFTER the lockdown, which flattens every file to 0o444: a template file that is
+  // Deliberately executable proves the fix ADDS owner-write rather than assigning a flat 0o644.
+  chmodSync(join(FIXTURE, "setup.sh"), 0o555);
+
+  mkdirSync(BROKEN, { recursive: true });
+  writeFileSync(join(BROKEN, "project.json"), "{ this is not json");
+  lockdown(BROKEN);
+});
+
+afterEach(() => {
+  unlock(TMP);
+  rmSync(TMP, { force: true, recursive: true });
+});
+
+afterAll(() => {
+  for (const dir of [FIXTURE, BROKEN, OUTSIDE]) {
+    unlock(dir);
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("generateProject — read-only template store", () => {
+  test("scaffolds from a read-only starter and re-stamps project.json", async () => {
+    await generateProject(TMP, { name: "Language Demo", starter: "fixture" });
+
+    // The regression itself: this write is the statement that threw EACCES, so the starter's own
+    // Name surviving is exactly the symptom the user saw.
+    const project = JSON.parse(readFileSync(join(TMP, "project.json"), "utf8"));
+    expect(project.name).toBe("Language Demo");
+    expect(project.name).not.toBe("Atrium");
+
+    // The rebuilt package.json is the write immediately after it.
+    const pkg = JSON.parse(readFileSync(join(TMP, "package.json"), "utf8"));
+    expect(pkg.name).toBe("language-demo");
+    expect(readFileSync(join(TMP, "content", "posts", "first.md"), "utf8")).toBe("# First\n");
+  });
+
+  test("leaves every file and directory in the new project writable", async () => {
+    await generateProject(TMP, { name: "Writable", starter: "fixture" });
+
+    const notWritable = walk(TMP).filter((p) => !isWritable(p));
+    expect(notWritable).toEqual([]);
+    // The scaffolded root is only writable because mkdir made it; the copied tree is the risk.
+    expect(permsOf(join(TMP, "content", "posts"))).toBe(0o755);
+  });
+
+  test("adds owner-write without dropping an executable bit", async () => {
+    await generateProject(TMP, { name: "Exec", starter: "fixture" });
+
+    expect(permsOf(join(TMP, "setup.sh"))).toBe(0o755);
+  });
+
+  test("does not follow a symlink pointing out of the tree", async () => {
+    await generateProject(TMP, { name: "Linked", starter: "fixture" });
+
+    expect(permsOf(join(OUTSIDE, "secret.txt"))).toBe(0o444);
+  });
+
+  test("produces a writable project on the blank path too", async () => {
+    await generateProject(TMP, { name: "Blank Writable" });
+
+    const notWritable = walk(TMP).filter((p) => !isWritable(p));
+    expect(notWritable).toEqual([]);
+  });
+});
+
+describe("generateProject — rollback on failure", () => {
+  test("removes the directory it created", async () => {
+    // oxlint-disable-next-line typescript/await-thenable -- Bun types `.rejects.toThrow` as void, but it resolves a Promise at runtime; the await is required.
+    await expect(generateProject(TMP, { name: "Doomed", starter: "broken" })).rejects.toThrow();
+
+    // Without the rollback this directory survives, and the retry the user reaches for reports
+    // `Directory "…" is not empty` instead of the real failure.
+    expect(existsSync(TMP)).toBe(false);
+  });
+
+  test("empties, but keeps, a directory that already existed", async () => {
+    mkdirSync(TMP, { recursive: true });
+
+    // oxlint-disable-next-line typescript/await-thenable -- Bun types `.rejects.toThrow` as void, but it resolves a Promise at runtime; the await is required.
+    await expect(generateProject(TMP, { name: "Doomed", starter: "broken" })).rejects.toThrow();
+
+    expect(existsSync(TMP)).toBe(true);
+    expect(readdirSync(TMP)).toEqual([]);
+  });
+
+  test("never deletes a directory that already had content", async () => {
+    mkdirSync(TMP, { recursive: true });
+    writeFileSync(join(TMP, "keep-me.txt"), "user data");
+
+    // oxlint-disable-next-line typescript/await-thenable -- Bun types `.rejects.toThrow` as void, but it resolves a Promise at runtime; the await is required.
+    await expect(generateProject(TMP, { name: "Doomed", starter: "broken" })).rejects.toThrow(
+      `Directory "${TMP}" is not empty`,
+    );
+
+    // The guard rejects before anything is created, so the rollback must never run here — this is
+    // The property that keeps an over-eager cleanup away from a user's files.
+    expect(readFileSync(join(TMP, "keep-me.txt"), "utf8")).toBe("user data");
+  });
+});


### PR DESCRIPTION
Creating a project in Studio failed with `EACCES: permission denied, open '.../project.json'`, and the retry then reported that the directory was not empty.

## Root cause

`fs.cp` reproduces the **source's** permission bits on the destination — right for a backup, wrong for a scaffolder. Every path under `/nix/store` is 444/555 by construction, so a Studio installed from Nix copied the starter tree read-only, and the generator failed on its own next write: the `project.json` re-stamp two statements later.

The tell is that the scaffolded `project.json` came out byte-identical to the starter's, still carrying the starter's own `name` — the re-stamp never ran. Had it succeeded, the user's `bun install`, `jx build` and every later edit would have failed the same way. Only the top-level directory was writable, because `mkdir` created that one.

It is invisible in development: the workspace starters are 755/644, so only a packaged build reproduces it.

The second error was a consequence, not a separate bug. `generateProject()` had no rollback, so the first attempt left a partial tree and the second tripped the emptiness guard — an error describing the debris rather than the cause.

## The fix

**`makeWritable(dir)`** walks the copied tree and ORs in owner-write — `| 0o200` on files, `| 0o700` on directories, widened *before* recursing so an unsearchable directory can still be entered.

- OR-ing rather than assigning is deliberate: a template file that ships executable stays executable, which a flat `0o644` would have quietly broken.
- Symlinks are skipped. `chmod` follows them, and a link pointing out of the tree must not have its target rewritten; a link's target inside the tree is normalized when the walk reaches it directly.

**`discardPartialScaffold(destPath, destExisted)`** rolls back a scaffold that threw partway. The safety rule is that it may only ever delete what the generator itself wrote:

| Destination | On failure |
| --- | --- |
| Created by the generator | Removed |
| Existed, and the guard proved it empty | Emptied, directory kept |
| Existed with content | Never reached — refused before anything is written |

It normalizes modes first, because `rm` cannot unlink out of a 555 directory — the very failure it is cleaning up after. Cleanup is best-effort: the scaffold failure is the one worth reporting.

`generateProject()` keeps the guard, the `mkdir` and a `try/catch`, delegating the writes to a new `populateProject()` so the rollback surrounds every write without reindenting them.

The blank path is covered too: its `.gitignore`, `layouts/` and `pages/` are copies carrying the template's modes, and the `mobile-app` overlay would otherwise fail to `force` over a file that came across read-only.

## Tests

`packages/create/tests/generate-readonly.test.ts` — 8 tests against a fixture locked to 444/555, which is what no existing suite had: their fixtures are built by the test process at the default umask, so their sources are writable and the defect cannot appear.

Covers the re-stamp regression, whole-tree writability, the preserved executable bit, the symlink-not-followed case, the blank path, and all three rollback outcomes above.

The teardown widens modes before `rmSync`. That is not incidental — a 555 tree cannot be deleted, so without it the suite leaks a directory the runner itself cannot remove.

## Verification

Run end to end against the real read-only store path that broke: scaffolds clean, `project.json` re-stamped, all 58 files writable, the starter's i18n locales intact.

- `generate.ts` at **100% lines and functions**
- Suites: create 68, server 822, desktop 690, compiler 1360, studio 9196 — **0 failures**
- Green: `lint`, `typecheck`, coverage manifest, `docs:check`, `docs:sync`, `docs:verify`, `docs:markdown`, `docs:claims`, `docs:standards`, `schema:verify`

## Docs

`docs/framework/build/cli.md` gains the writability guarantee and the cleanup-on-failure behavior — the page already documents what a scaffold produces, and `packages/create/generate.ts` is already in its `code:` frontmatter.

No spec edit: the page's linked sections (`extensions.md` §5.2, §5.4) are schema composition and validation, and nothing in `/specs` owns scaffold permissions.

## Note for release

Users on an installed build only get this after that build is republished — the fix cannot reach an immutable store path already on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZQGhLYSvvoWL1PyrQdyAG
