### PR TITLE
fix(server)!: public/ resolves before the project root, as a build does

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -24,7 +24,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `parser.md`               | 0.2.9-draft  | Partial     | 2026-08-16 |
 | `relationships.md`        | 0.1.4-draft  | Partial     | 2026-08-15 |
 | `schema.md`               | 0.4.8-draft  | Partial     | 2026-08-16 |
-| `server.md`               | 0.2.11       | Implemented | 2026-08-22 |
+| `server.md`               | 0.2.12       | Implemented | 2026-08-25 |
 | `site-architecture.md`    | 0.5.17-draft | Partial     | 2026-08-25 |
 | `spec.md`                 | 0.5.5-draft  | Partial     | 2026-08-24 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -223,6 +223,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `server.md`
 
+- **0.2.12** (2026-08-25) — §3: the static-file order now matches a build — public/ precedes the project root, which survives as a compatibility lane that warns.
 - **0.2.11** (2026-08-22) — §3.1: watch-policy.ts — watchers watch only directories and regular files, and contain symlinks to the root, so a socket cannot throw and a link out cannot walk the filesystem.
 - **0.2.10** (2026-08-20) — The loopback project server's RPC socket carries server-initiated frames (ProjectServerHandle.push) — the loopback twin of the dev server's named fs SSE event, and the channel a desktop launcher raises a window over (§4.2).
 - **0.2.9** (2026-08-18) — §4.2: the Studio shell's report-only Trusted Types header is removed — see spec.md §21.5.

--- a/packages/server/src/net-guard.ts
+++ b/packages/server/src/net-guard.ts
@@ -308,12 +308,81 @@ export async function serveContained(absPath: string, root: string): Promise<Res
 }
 
 /**
+ * Extensions a BUILD publishes as static assets, so a page may reference one by site URL.
+ *
+ * Deliberately excludes `.json`, `.md` and every other document extension: `serveProjectFile`
+ * serves two URL spaces at once — the SITE's, and the project tree's, which is how the Studio
+ * canvas fetches a component `$ref` — and only the site's is what {@link BUILD_LANES} defines. A
+ * `/components/x-card.json` answered from the project root is Studio's own protocol working
+ * correctly; a `/hero.jpg` answered from the project root is a preview telling a lie.
+ */
+const SITE_ASSET_EXTENSIONS = new Set([
+  ".apng",
+  ".avif",
+  ".bmp",
+  ".css",
+  ".gif",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".mp3",
+  ".mp4",
+  ".oga",
+  ".ogg",
+  ".ogv",
+  ".otf",
+  ".pdf",
+  ".png",
+  ".svg",
+  ".ttf",
+  ".txt",
+  ".wav",
+  ".webm",
+  ".webmanifest",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".xml",
+]);
+
+/** Paths already warned about, so a page that loads one image fifty times says it once. */
+const rootLaneWarned = new Set<string>();
+
+/**
+ * Say once, per path, that a file resolves here and will not resolve on the built site.
+ *
+ * @param {string} decodedPath - The site URL that matched the compatibility lane
+ */
+function warnRootLane(decodedPath: string): void {
+  const dot = decodedPath.lastIndexOf(".");
+  const ext = dot === -1 ? "" : decodedPath.slice(dot).toLowerCase();
+  if (!SITE_ASSET_EXTENSIONS.has(ext) || rootLaneWarned.has(decodedPath)) {
+    return;
+  }
+  rootLaneWarned.add(decodedPath);
+  console.warn(
+    `${decodedPath} resolves from the project root, which a BUILD does not do: it publishes ` +
+      `public/ at the site root and nothing else (site-architecture.md §9.3). This file loads in ` +
+      `the preview and 404s on the deployed site — move it into public/ to fix it. This ` +
+      `compatibility lane is going away.`,
+  );
+}
+
+/**
  * Try to serve a project file at its natural URL: an extension asset mount, then
- * absolute-under-root, then root-relative, then public/. Each candidate goes through containedPath
- * (realpath). `decodedPath` is the once-decoded URL pathname (leading slash, forward slashes).
+ * absolute-under-root, then `public/`, then the project root. Each candidate goes through
+ * containedPath (realpath). `decodedPath` is the once-decoded URL pathname (leading slash, forward
+ * slashes).
  *
  * Mounts come first and are contained against their own directory rather than the project root:
  * they exist precisely to publish directories that may sit outside it (extensions.md §8.5).
+ *
+ * **`public/` precedes the project root, which is the order a BUILD resolves in.** It did not: the
+ * root came first, so a file at `<root>/hero.jpg` loaded at `/hero.jpg` here and 404'd in
+ * production — a preview that lies in the one direction that matters, and one the spec never
+ * described (`site-architecture.md` §9.3 has always matched the compiler). The root lane survives
+ * as a COMPATIBILITY lane that warns, and is going away; it also still answers the project tree's
+ * own URL space, which is how the Studio canvas fetches a component `$ref`.
  *
  * The project's BUILT OUTPUT is deliberately NOT here, nor anywhere else in an editing server's
  * chain: these paths mean the project's SOURCES, and a built page addresses the same paths meaning
@@ -342,7 +411,8 @@ export async function serveProjectFile(
     ? decodedPath.slice(1)
     : decodedPath.replace(/^\/([A-Za-z]:)/, "$1");
 
-  // 1. Absolute path that falls under the project root.
+  /* 1. Absolute path that falls under the project root. Not a site URL at all — it is how Studio
+        addresses a file it already holds an absolute path for, so it stays ahead of both lanes. */
   if (normalizeForCompare(fsPath).startsWith(normalizeForCompare(root))) {
     const res = await serveContained(fsPath, root);
     if (res) {
@@ -350,19 +420,25 @@ export async function serveProjectFile(
     }
   }
 
-  // 2. Root-relative.
-  const relRes = await serveContained(resolve(root, `.${decodedPath}`), root);
-  if (relRes) {
-    return relRes;
-  }
-
-  // 3. public/ subdirectory.
+  // 2. public/ — the site's own URL space, and the only one a build publishes.
   const pubRes = await serveContained(resolve(root, "public", `.${decodedPath}`), root);
   if (pubRes) {
     return pubRes;
   }
 
+  // 3. The project root — the project tree's URL space, and a compatibility lane for site URLs.
+  const relRes = await serveContained(resolve(root, `.${decodedPath}`), root);
+  if (relRes) {
+    warnRootLane(decodedPath);
+    return relRes;
+  }
+
   return null;
+}
+
+/** Forget which paths have been warned about — for tests, which assert the warning fires. */
+export function resetRootLaneWarnings(): void {
+  rootLaneWarned.clear();
 }
 
 /** Result of decoding a URL pathname: the safe decoded/normalized path, or a rejection Response. */

--- a/packages/server/tests/net-guard.test.ts
+++ b/packages/server/tests/net-guard.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
@@ -13,6 +13,7 @@ import {
   originIsLoopbackOrAbsent,
   presentedToken,
   secretsMatch,
+  resetRootLaneWarnings,
   serveContained,
   serveProjectFile,
 } from "../src/net-guard.ts";
@@ -161,10 +162,72 @@ describe("serveProjectFile", () => {
     expect(res).not.toBeNull();
     expect(await res!.text()).toContain("in-root");
   });
-  test("falls back to public/", async () => {
+  test("serves from public/", async () => {
     const res = await serveProjectFile("/style.css", PROJECT);
     expect(res).not.toBeNull();
     expect(await res!.text()).toContain("body{}");
+  });
+
+  /**
+   * The lane order, and the one place a preview used to lie.
+   *
+   * A BUILD resolves `/x` to `public/x` and nowhere else (`site-architecture.md` §9.3, and
+   * `resolveImagePath` in the compiler). This server tried the project ROOT first, so a file at
+   * `<root>/hero.jpg` loaded at `/hero.jpg` here and 404'd on the deployed site — and when both
+   * copies existed, the preview showed the one production would never serve.
+   */
+  describe("the lane order matches a build", () => {
+    const both = join(PROJECT, "collide.png");
+    const pub = join(PROJECT, "public", "collide.png");
+
+    beforeEach(() => {
+      resetRootLaneWarnings();
+      writeFileSync(both, "root-copy");
+      writeFileSync(pub, "public-copy");
+    });
+
+    test("public/ wins when a file exists in both — that is what production serves", async () => {
+      const res = await serveProjectFile("/collide.png", PROJECT);
+      expect(await res!.text()).toBe("public-copy");
+    });
+
+    test("the project root still answers, and says the preview is lying", async () => {
+      rmSync(pub);
+      const warn = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const res = await serveProjectFile("/collide.png", PROJECT);
+        expect(await res!.text()).toBe("root-copy");
+        expect(warn.mock.calls[0]?.[0]).toContain("move it into public/");
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    test("it says so ONCE, not once per request", async () => {
+      rmSync(pub);
+      const warn = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await serveProjectFile("/collide.png", PROJECT);
+        await serveProjectFile("/collide.png", PROJECT);
+        await serveProjectFile("/collide.png", PROJECT);
+        expect(warn.mock.calls).toHaveLength(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    /* The root lane serves TWO URL spaces: the site's, and the project tree's — which is how the
+       Studio canvas fetches a component `$ref`. Only the first is what a build defines, so a
+       document answered from the project root is the protocol working, not a preview lying. */
+    test("a project document answered from the root says nothing", async () => {
+      const warn = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        await serveProjectFile("/index.html", PROJECT);
+        expect(warn.mock.calls).toHaveLength(0);
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
   test("returns null for a missing file", async () => {
     expect(await serveProjectFile("/nope.html", PROJECT)).toBeNull();

--- a/specs/server.md
+++ b/specs/server.md
@@ -2,9 +2,9 @@
 
 ## Development Server with Live Reload, Proxy Resolution, and Studio API
 
-**Version:** 0.2.11
+**Version:** 0.2.12
 **Status:** Implemented
-**Updated:** 2026-08-22
+**Updated:** 2026-08-25
 **License:** MIT
 
 ---
@@ -68,7 +68,11 @@ The request path is matched in this order (`src/server.ts`):
 4. `/_jx/*` — extension server mounts
 5. `/__studio/*` — Studio API (collab WebSocket/probe, activate, AI proxy, site import, code services, then the main studio handler)
 6. Custom `middleware`
-7. Static files — the active project's extension asset mounts ([extensions.md §8.5](./extensions.md)), then the server root, then the active project root, then its `public/` (mirroring production), then npm bare specifiers resolved through `node_modules` and bundled on demand with `Bun.build`. Served HTML gets the live-reload client injected (except the Studio shell, which manages its own state); all responses carry `Cache-Control: no-cache`. Content types come from `Bun.file`'s own inference, corrected only where a registration disagrees with it — `.md` carries the `variant` that names its dialect and `.yaml` is `application/yaml` rather than the retired `text/yaml` (`MEDIA_TYPE_BY_EXTENSION` in `@jxsuite/schema/media-type`, shared with `jx preview`); every other extension keeps the inferred type.
+7. Static files — the active project's extension asset mounts ([extensions.md §8.5](./extensions.md)), then the server root, then the active project's `public/`, then the active project root, then npm bare specifiers resolved through `node_modules` and bundled on demand with `Bun.build`. Served HTML gets the live-reload client injected (except the Studio shell, which manages its own state); all responses carry `Cache-Control: no-cache`. Content types come from `Bun.file`'s own inference, corrected only where a registration disagrees with it — `.md` carries the `variant` that names its dialect and `.yaml` is `application/yaml` rather than the retired `text/yaml` (`MEDIA_TYPE_BY_EXTENSION` in `@jxsuite/schema/media-type`, shared with `jx preview`); every other extension keeps the inferred type.
+
+**`public/` precedes the project root, and the project root is a compatibility lane.** The order above is the order a BUILD resolves in ([site-architecture.md §9.3](./site-architecture.md)): a site-absolute `/x` names `public/x` and nothing else. This server also serves the PROJECT TREE's own URL space at the same paths — that is how a Studio canvas fetches a component `$ref` — so the project root still answers, and the two spaces collide wherever a file exists in both.
+
+The order used to be the other way round, which made the preview lie in the one direction that matters: a file at `<root>/hero.jpg` loaded at `/hero.jpg` here and 404'd on the deployed site, and where both copies existed the preview showed the one production would never serve. Serving from the root a site URL that a build would not publish is now a diagnostic naming the file and the fix (move it into `public/`), and the lane is scheduled for removal. The diagnostic is scoped to extensions a build publishes as static assets, so a project document answered from the root — the canvas doing its job — says nothing.
 
 **Asset mounts.** A mount publishes a directory that may sit outside the project root — a content collection's co-located images — at the same site URL the built site will use, so a dev preview and a production page render identically. Each candidate is contained against the mount's own directory (lexical + realpath), and the URL→path mapping refuses `.`/`..`, empty segments, and still-encoded dots or slashes. Mounts come from the section owner's `assets` capability via the per-project context cache, so they refresh when `project.json` changes on disk. The desktop loopback server (`project-server.ts`) resolves them through the same `serveProjectFile` path.
 
@@ -330,6 +334,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.2.12** (2026-08-25) — §3: the static-file order now matches a build — public/ precedes the project root, which survives as a compatibility lane that warns.
 - **0.2.11** (2026-08-22) — §3.1: watch-policy.ts — watchers watch only directories and regular files, and contain symlinks to the root, so a socket cannot throw and a link out cannot walk the filesystem.
 - **0.2.10** (2026-08-20) — The loopback project server's RPC socket carries server-initiated frames (ProjectServerHandle.push) — the loopback twin of the dev server's named fs SSE event, and the channel a desktop launcher raises a window over (§4.2).
 - **0.2.9** (2026-08-18) — §4.2: the Studio shell's report-only Trusted Types header is removed — see spec.md §21.5.
@@ -355,4 +360,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_`@jxsuite/server` Specification v0.2.11_
+_`@jxsuite/server` Specification v0.2.12_


### PR DESCRIPTION
> ⚠️ **Do not merge with #206 or #207.** This ships **last and alone**, in a release of its own — an image fix must not be able to break a build. Stacked on #207 only because both regenerate `docs/extending/reference/spec-changelog.md`.

## The preview was lying, in the one direction that matters

The compiler resolves a site-absolute `/x` to `public/x` and **nowhere else** ([`image-transform.ts`](https://github.com/jxsuite/jx/blob/main/packages/compiler/src/site/image-transform.ts) `resolveImagePath`), and `site-architecture.md` §9.3 has always said so. The editing servers tried the project **root** first.

So a file at `<root>/hero.jpg` loaded at `/hero.jpg` in a dev preview and **404'd on the deployed site** — and where both copies existed, the preview showed the one production would never serve. `server.md` §3's "(mirroring production)" was simply false.

## BREAKING: a project relying on root-relative serving loses it

`public/` now precedes the project root. The root lane survives as a **compatibility lane that warns**, naming the file and the fix — *move it into `public/`* — once per path. It is scheduled for removal; **ship one minor with the warning before taking it out.**

## Why the lane cannot simply go

`serveProjectFile` serves **two URL spaces at the same paths**:

- the **site's**, which is what a build defines
- the **project tree's**, which is how the Studio canvas fetches a component `$ref`

Only the first is `BUILD_LANES`. So the diagnostic is scoped to extensions a build publishes as static assets: a `/components/x-card.json` answered from the project root is the canvas doing its job and says nothing, while a `/hero.jpg` answered from there is a preview telling a lie.

The absolute-under-root lane stays ahead of both — it is not a site URL at all, it is how Studio addresses a file it already holds an absolute path for.

## Tests

A `collide.png` in **both** places: `public/` wins, which is what production serves. Remove the `public/` copy and the root still answers — with the warning, once, not once per request. A `/index.html` answered from the root says nothing.

## Spec

`server.md` 0.2.11 → 0.2.12 (patch): §3's static-file order corrected, and the compatibility lane written down along with why the diagnostic is scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
