### PR TITLE
refactor(commitlint): the config is TypeScript, and typechecked

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -425,7 +425,7 @@ jobs:
   #
   #   1. release-please skips a component whose changelog carries a raw `<tag>` — it logs
   #      "Pull request contains releases, but not for component: starters", creates the other 18,
-  #      and exits 0. The manifest still claims the version. (commitlint.config.js has the full
+  #      and exits 0. The manifest still claims the version. (commitlint.config.ts has the full
   #      mechanism; `checks` now blocks the commit subjects that cause it.)
   #   2. The `release-please` job dies PART WAY THROUGH after creating some releases — a GitHub 5xx
   #      during its commit-history walk, which is precisely what an un-tagged component provokes.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -368,7 +368,7 @@ jobs:
       # release-please DROP that package from its own release — silently, exit 0. That is how
       # `schema` and `starters` fell out of three consecutive releases and `npm i @jxsuite/create`
       # became unresolvable. `.husky/commit-msg` runs the same rule, but a hook is skippable with
-      # `--no-verify`, which is how the offending subject reached main. See commitlint.config.js.
+      # `--no-verify`, which is how the offending subject reached main. See commitlint.config.ts.
       #
       # Pull-request-only, and it names the two shas explicitly rather than using HEAD: `checks`
       # runs on the merge commit, whose own subject is not a conventional commit.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,7 +25,7 @@
     },
     {
       // Tool contracts (commitlint, electrobun, etc.) require default exports.
-      "files": ["**/*.config.*", "**/commitlint.config.js"],
+      "files": ["**/*.config.*", "**/commitlint.config.ts"],
       "rules": {
         "import/no-default-export": "off"
       }

--- a/.oxlintrc.typecheck.json
+++ b/.oxlintrc.typecheck.json
@@ -31,22 +31,26 @@
       // tsgolint sees error-types for their imports. The no-unsafe-* family is
       // therefore src-only; promise safety still applies everywhere.
       //
-      // The repo-root entrypoints are outside it for the same reason and were
-      // simply missed: tsconfig.json sets `allowJs: false` and its `include`
-      // starts at packages/ and extensions/, so a root-level `.js` file is in
-      // no project at all and EVERY expression in it types as `error`. That is
-      // not a latent bug the rule is catching — there is no annotation or
-      // rewrite that fixes it, because the file has no program. `server.js`
-      // proved it: adding `exampleRoutes()` in 7fb3669a turned three ordinary
-      // lines (`new Bun.Glob(...)`, the `const` that takes its result, and a
+      // `server.js` is outside it for the same reason and was simply missed:
+      // tsconfig.json sets `allowJs: false` and its `include` starts at
+      // packages/ and extensions/, so a root-level `.js` file is in no project
+      // at all and EVERY expression in it types as `error`. That is not a
+      // latent bug the rule is catching — there is no annotation or rewrite
+      // that fixes it, because the file has no program. `server.js` proved it:
+      // adding `exampleRoutes()` in 7fb3669a turned three ordinary lines
+      // (`new Bun.Glob(...)`, the `const` that takes its result, and a
       // `.length` on that) into three errors and reddened main.
+      //
+      // The waiver is for files with no program, NOT for root-level files:
+      // `commitlint.config.ts` was the other entry here and left this list by
+      // joining tsconfig.json's `include`, not by being exempted. A root file
+      // that can be typechecked should be, and then these rules apply to it.
       "files": [
         "**/tests/**/*.*",
         "**/*.test.*",
         "**/scripts/**/*.*",
         "**/bin/**/*.*",
-        "./server.js",
-        "./commitlint.config.js"
+        "./server.js"
       ],
       "rules": {
         "typescript/no-unsafe-assignment": "off",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ no tag, no GitHub release, no npm publish, green run.
 unresolvable. The bug is upstream and still present in release-please 17.11.1, so the defence is to
 keep the text out of the changelog. **Backticks do not help** — the escaping happens on raw text.
 
-- The rule and the full write-up live in `commitlint.config.js` (`changelog-safe-angle-brackets`).
+- The rule and the full write-up live in `commitlint.config.ts` (`changelog-safe-angle-brackets`).
 - `.husky/commit-msg` applies it as you commit; `checks` runs
   `bun scripts/check-changelog-safety.ts` over the pull request's commits, because a hook is
   skippable with `--no-verify` and that is how the subject landed.

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@commitlint/cli": "^21.2.2",
         "@commitlint/config-conventional": "^21.2.2",
+        "@commitlint/types": "^21.2.0",
         "@ttsc/graph": "^0.28.2",
         "@types/bun": "1.4.0",
         "bun-types": "^1.4.0",
@@ -43,7 +44,7 @@
     },
     "extensions/auth": {
       "name": "@jxsuite/auth",
-      "version": "0.5.2",
+      "version": "0.5.5",
       "dependencies": {
         "@jxsuite/connector": "workspace:^",
         "@jxsuite/schema": "workspace:^",
@@ -57,7 +58,7 @@
     },
     "extensions/connector": {
       "name": "@jxsuite/connector",
-      "version": "0.5.2",
+      "version": "0.5.5",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
         "kysely": "^0.29.5",
@@ -73,7 +74,7 @@
     },
     "extensions/feed": {
       "name": "@jxsuite/feed",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
       },
@@ -83,7 +84,7 @@
     },
     "extensions/parser": {
       "name": "@jxsuite/parser",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@jxsuite/markup": "workspace:^",
         "@jxsuite/schema": "workspace:^",
@@ -111,7 +112,7 @@
     },
     "extensions/search": {
       "name": "@jxsuite/search",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
         "minisearch": "^7.2.0",
@@ -122,7 +123,7 @@
     },
     "packages/ai": {
       "name": "@jxsuite/ai",
-      "version": "0.36.2",
+      "version": "0.36.4",
       "dependencies": {
         "@jxsuite/protocol": "workspace:^",
         "@vue/reactivity": "3.5.41",
@@ -133,7 +134,7 @@
     },
     "packages/collab": {
       "name": "@jxsuite/collab",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
         "lib0": "^0.2.117",
@@ -143,7 +144,7 @@
     },
     "packages/compiler": {
       "name": "@jxsuite/compiler",
-      "version": "2.0.5",
+      "version": "2.0.8",
       "bin": {
         "jx": "./bin/jx.js",
       },
@@ -166,7 +167,7 @@
     },
     "packages/create": {
       "name": "@jxsuite/create",
-      "version": "1.3.5",
+      "version": "1.3.7",
       "bin": {
         "create-jxsuite": "./index.ts",
       },
@@ -176,7 +177,7 @@
     },
     "packages/desktop": {
       "name": "@jxsuite/desktop",
-      "version": "2.3.3",
+      "version": "4.0.0",
       "dependencies": {
         "@jxsuite/compiler": "workspace:^",
         "@jxsuite/create": "workspace:^",
@@ -201,7 +202,7 @@
     },
     "packages/formulas": {
       "name": "@jxsuite/formulas",
-      "version": "0.0.11",
+      "version": "0.0.14",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
       },
@@ -211,7 +212,7 @@
     },
     "packages/import": {
       "name": "@jxsuite/import",
-      "version": "0.39.5",
+      "version": "0.39.8",
       "bin": {
         "jx-import": "./src/cli.ts",
       },
@@ -232,7 +233,7 @@
     },
     "packages/markup": {
       "name": "@jxsuite/markup",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
         "hast-util-from-html": "^2.0.3",
@@ -251,14 +252,14 @@
     },
     "packages/protocol": {
       "name": "@jxsuite/protocol",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
       },
     },
     "packages/runtime": {
       "name": "@jxsuite/runtime",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "dependencies": {
         "@jxsuite/schema": "workspace:^",
         "@vue/reactivity": "3.5.41",
@@ -269,7 +270,7 @@
     },
     "packages/schema": {
       "name": "@jxsuite/schema",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "@webref/css": "^8.7.2",
         "@webref/elements": "^2.7.1",
@@ -283,7 +284,7 @@
     },
     "packages/server": {
       "name": "@jxsuite/server",
-      "version": "2.2.5",
+      "version": "3.0.0",
       "dependencies": {
         "@jxsuite/collab": "workspace:^",
         "@jxsuite/compiler": "workspace:^",
@@ -305,7 +306,7 @@
     },
     "packages/starters": {
       "name": "@jxsuite/starters",
-      "version": "1.6.2",
+      "version": "1.6.4",
       "devDependencies": {
         "@jxsuite/parser": "workspace:^",
         "@jxsuite/runtime": "workspace:^",
@@ -316,7 +317,7 @@
     },
     "packages/studio": {
       "name": "@jxsuite/studio",
-      "version": "2.4.1",
+      "version": "3.0.0",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^3.0.0",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.1.0",
@@ -1929,7 +1930,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "meow": ["meow@8.1.2", "", { "dependencies": { "@types/minimist": "^1.2.0", "camelcase-keys": "^6.2.2", "decamelize-keys": "^1.1.0", "hard-rejection": "^2.1.0", "minimist-options": "4.1.0", "normalize-package-data": "^3.0.0", "read-pkg-up": "^7.0.1", "redent": "^3.0.0", "trim-newlines": "^3.0.0", "type-fest": "^0.18.0", "yargs-parser": "^20.2.3" } }, "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q=="],
+    "meow": ["meow@14.1.0", "", {}, "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
@@ -2619,9 +2620,9 @@
 
     "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "conventional-changelog-writer/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
+    "conventional-changelog-writer/meow": ["meow@8.1.2", "", { "dependencies": { "@types/minimist": "^1.2.0", "camelcase-keys": "^6.2.2", "decamelize-keys": "^1.1.0", "hard-rejection": "^2.1.0", "minimist-options": "4.1.0", "normalize-package-data": "^3.0.0", "read-pkg-up": "^7.0.1", "redent": "^3.0.0", "trim-newlines": "^3.0.0", "type-fest": "^0.18.0", "yargs-parser": "^20.2.3" } }, "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q=="],
 
-    "conventional-commits-parser/meow": ["meow@14.1.0", "", {}, "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw=="],
+    "conventional-changelog-writer/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -2718,10 +2719,6 @@
     "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "mdast-util-to-hast/@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
-
-    "meow/type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
-
-    "meow/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "minimist-options/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
 
@@ -2852,6 +2849,10 @@
     "class-utils/define-property/is-descriptor": ["is-descriptor@0.1.8", "", { "dependencies": { "is-accessor-descriptor": "^1.0.1", "is-data-descriptor": "^1.0.1" } }, "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "conventional-changelog-writer/meow/type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
+
+    "conventional-changelog-writer/meow/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "create-jest-runner/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -34,7 +34,15 @@
  * This file is the single definition. `scripts/check-changelog-safety.ts` imports `findAngleTags`
  * so the CI gate and the local commit hook can never disagree;
  * `scripts/check-changelog-safety.test.ts` tests it.
+ *
+ * Commitlint loads this file through `cosmiconfig-typescript-loader` (a jiti transpile), and
+ * `scripts/check-changelog-safety.ts` loads it through Bun. Neither transpiler typechecks, so the
+ * annotations below are proved by `bun run typecheck` — which is why `tsconfig.json` names this
+ * file in its `include`. Keep the imports TYPE-ONLY: both loaders would otherwise have to resolve
+ * `@commitlint/types` at runtime, and this module is deliberately runtime-dependency-free.
  */
+
+import type { SyncRule, UserConfig } from "@commitlint/types";
 
 /**
  * Anything a browser's HTML parser would treat as a tag: an element (`<picture>`, `</details>`,
@@ -43,13 +51,8 @@
  */
 const ANGLE_TAG = /<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>|<!--/g;
 
-/**
- * Every angle-bracket tag in `text`, in order, with duplicates collapsed.
- *
- * @param {string | null | undefined} text
- * @returns {string[]}
- */
-export function findAngleTags(text) {
+/** Every angle-bracket tag in `text`, in order, with duplicates collapsed. */
+export function findAngleTags(text: string | null | undefined): string[] {
   if (!text) {
     return [];
   }
@@ -58,16 +61,32 @@ export function findAngleTags(text) {
 }
 
 /**
+ * A part of a commit message by the name the reports print, since that name is what tells an author
+ * which line to amend. Both callers join these with " and ", so they read as prose.
+ */
+export type ChangelogPart = "subject" | "BREAKING CHANGE";
+
+/** One changelog-bound part of a commit message that carries at least one angle-bracket tag. */
+export interface ChangelogUnsafePart {
+  /** Where in the message the tags are. */
+  part: ChangelogPart;
+  /** Every distinct tag found in `text`, in order of first appearance. */
+  tags: string[];
+  /** The offending text, verbatim, for the report to quote. */
+  text: string;
+}
+
+/**
  * The parts of a commit message release-please copies into a changelog: the subject line, and the
  * text of any `BREAKING CHANGE:` note. The body is otherwise dropped, so it is not checked — a
  * commit may still explain itself with markup below the fold.
  *
- * @param {string} message A full commit message.
- * @returns {{ part: string; text: string; tags: string[] }[]} One entry per offending part.
+ * @param message A full commit message.
+ * @returns One entry per offending part.
  */
-export function findChangelogUnsafeParts(message) {
+export function findChangelogUnsafeParts(message: string): ChangelogUnsafePart[] {
   const lines = message.replaceAll("\r\n", "\n").split("\n");
-  const problems = [];
+  const problems: ChangelogUnsafePart[] = [];
 
   const subject = lines[0] ?? "";
   const subjectTags = findAngleTags(subject);
@@ -77,12 +96,16 @@ export function findChangelogUnsafeParts(message) {
 
   // A BREAKING CHANGE note runs to the next blank line; release-please reproduces all of it.
   for (let i = 1; i < lines.length; i++) {
-    if (!/^BREAKING[ -]CHANGE:/.test(lines[i])) {
+    if (!/^BREAKING[ -]CHANGE:/.test(lines[i] ?? "")) {
       continue;
     }
-    const note = [];
-    for (let j = i; j < lines.length && lines[j].trim() !== ""; j++) {
-      note.push(lines[j]);
+    const note: string[] = [];
+    for (let j = i; j < lines.length; j++) {
+      const line = lines[j] ?? "";
+      if (line.trim() === "") {
+        break;
+      }
+      note.push(line);
     }
     const text = note.join("\n");
     const tags = findAngleTags(text);
@@ -96,28 +119,34 @@ export function findChangelogUnsafeParts(message) {
 }
 
 /** The advice is the same wherever the check fires, so both callers read it from here. */
-export function changelogSafetyAdvice(problems) {
+export function changelogSafetyAdvice(problems: readonly ChangelogUnsafePart[]): string {
   const found = [...new Set(problems.flatMap((p) => p.tags))].join(", ");
   return (
     `contains ${found} — an angle-bracket tag here silently drops the package from its own ` +
-    "release (see the header of commitlint.config.js). Say it in prose, or use braces: " +
+    "release (see the header of commitlint.config.ts). Say it in prose, or use braces: " +
     "`ext/{name}/{kind}/v{n}`. Backticks do not help."
   );
 }
 
-const config = {
+/**
+ * `parsed.raw` is the whole message; `SyncRule` types it as `string | null | undefined` because
+ * `Commit` carries its non-standard fields through an index signature.
+ */
+const changelogSafeAngleBrackets: SyncRule = (parsed) => {
+  const problems = findChangelogUnsafeParts(parsed.raw ?? "");
+  if (problems.length === 0) {
+    return [true, ""];
+  }
+  const where = problems.map((p) => p.part).join(" and ");
+  return [false, `${where} ${changelogSafetyAdvice(problems)}`];
+};
+
+const config: UserConfig = {
   extends: ["@commitlint/config-conventional"],
   plugins: [
     {
       rules: {
-        "changelog-safe-angle-brackets": (parsed) => {
-          const problems = findChangelogUnsafeParts(parsed.raw ?? "");
-          if (problems.length === 0) {
-            return [true, ""];
-          }
-          const where = problems.map((p) => p.part).join(" and ");
-          return [false, `${where} ${changelogSafetyAdvice(problems)}`];
-        },
+        "changelog-safe-angle-brackets": changelogSafeAngleBrackets,
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
+    "@commitlint/types": "^21.2.0",
     "@ttsc/graph": "^0.28.2",
     "@types/bun": "1.4.0",
     "bun-types": "^1.4.0",

--- a/scripts/check-changelog-safety.test.ts
+++ b/scripts/check-changelog-safety.test.ts
@@ -3,12 +3,12 @@
  * REAL commits — the five in this repository's history that would each have deleted a package from
  * its own release, and the near-misses that must stay allowed.
  *
- * See `commitlint.config.js` for why an angle bracket in a commit subject has that effect.
+ * See `commitlint.config.ts` for why an angle bracket in a commit subject has that effect.
  */
 
 import { describe, expect, test } from "bun:test";
 
-import { findAngleTags, findChangelogUnsafeParts } from "../commitlint.config.js";
+import { findAngleTags, findChangelogUnsafeParts } from "../commitlint.config.ts";
 import { findUnsafeCommits, parseLog, report } from "./check-changelog-safety.ts";
 
 describe("findAngleTags", () => {

--- a/scripts/check-changelog-safety.ts
+++ b/scripts/check-changelog-safety.ts
@@ -1,6 +1,6 @@
 /**
  * The CI half of the changelog-safety gate. The rule, the reasoning, and the failure it prevents
- * are all in `commitlint.config.js` — read that first; this file only applies it to a commit
+ * are all in `commitlint.config.ts` — read that first; this file only applies it to a commit
  * range.
  *
  * Both halves exist because they fail at different moments and neither covers the other:
@@ -11,7 +11,7 @@
  *   releases.
  * - This runs in the `checks` job over the pull request's own commits, where nothing can skip it.
  *
- * It reads the rule from `commitlint.config.js` rather than restating it, so the hook and the gate
+ * It reads the rule from `commitlint.config.ts` rather than restating it, so the hook and the gate
  * cannot drift into disagreeing about which subjects are safe.
  *
  * Merge commits are skipped: release-please cannot parse them as conventional commits (its log is
@@ -22,7 +22,7 @@
  *     bun scripts/check-changelog-safety.ts --from <sha> --to <sha>
  */
 
-import { changelogSafetyAdvice, findChangelogUnsafeParts } from "../commitlint.config.js";
+import { changelogSafetyAdvice, findChangelogUnsafeParts } from "../commitlint.config.ts";
 
 export interface UnsafeCommit {
   sha: string;

--- a/scripts/check-release-integrity.test.ts
+++ b/scripts/check-release-integrity.test.ts
@@ -120,6 +120,6 @@ describe("report", () => {
     const text = report(await findGaps([target()], probes({})));
     expect(text).toContain("starters-v1.5.0");
     expect(text).toContain("but not for component");
-    expect(text).toContain("commitlint.config.js");
+    expect(text).toContain("commitlint.config.ts");
   });
 });

--- a/scripts/check-release-integrity.ts
+++ b/scripts/check-release-integrity.ts
@@ -6,7 +6,7 @@
  * lose a release, both of which exit 0:
  *
  * 1. Release-please drops a component whose changelog contains a raw `<tag>` (the defect written up in
- *    `commitlint.config.js`). It logs "Pull request contains releases, but not for component:
+ *    `commitlint.config.ts`). It logs "Pull request contains releases, but not for component:
  *    starters", creates the other 18, and succeeds. The manifest still says 1.5.0.
  * 2. The `release-please` job dies PART WAY THROUGH — a GitHub 5xx while it backfills file lists,
  *    which is exactly what a component with no tag provokes, because it forces a walk back through
@@ -144,7 +144,7 @@ export function report(gaps: ReleaseGap[]): string {
     fixes.push(
       "A missing GitHub release means release-please skipped the component. Check the " +
         "`release-please` job log for “Pull request contains releases, but not for component” " +
-        "and read the header of `commitlint.config.js`.",
+        "and read the header of `commitlint.config.ts`.",
     );
   }
 

--- a/scripts/ci/affected.ts
+++ b/scripts/ci/affected.ts
@@ -153,7 +153,7 @@ const NO_TESTS = [
   ".gitignore",
   ".oxfmtrc.json",
   ".pre-commit-config.yaml",
-  "commitlint.config.js",
+  "commitlint.config.ts",
   "release-please-config.json",
   ".release-please-manifest.json",
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,12 @@
   "exclude": ["node_modules", "**/node_modules", "**/dist", "**/assets", "packages/desktop"],
   "include": [
     "types.d.ts",
+    /* Not a package, but not exempt either. Two transpilers load it without typechecking —
+       cosmiconfig-typescript-loader (jiti) for the commit hook, Bun for
+       `scripts/check-changelog-safety.ts` — so naming it here is the only thing that proves its
+       annotations. It is also why it is no longer in .oxlintrc.typecheck.json's no-unsafe-* waiver:
+       that waiver exists for root-level files with no program at all. */
+    "commitlint.config.ts",
     "packages/**/src/**/*",
     "packages/**/tests/**/*",
     "packages/schema/types.ts",


### PR DESCRIPTION
`commitlint.config.js` was the last JavaScript in the commit-lint path. It is now `commitlint.config.ts`, loaded unchanged by commitlint through `cosmiconfig-typescript-loader` (already a dependency of `@commitlint/load`).

Annotated, not merely renamed:

- `SyncRule` and `UserConfig` come from `@commitlint/types`, now a direct devDependency because the file names it. The imports are TYPE-ONLY on purpose: jiti loads this file for the commit hook and Bun loads it for `scripts/check-changelog-safety.ts`, and neither should have to resolve a package at runtime.
- The `{ part, tags, text }` shape that was an inline JSDoc type is an exported `ChangelogUnsafePart` interface, with `part` narrowed to a union of the two names the reports print. `check-changelog-safety.ts` picks it up for free through its `ReturnType` alias.
- `noUncheckedIndexedAccess` found two real unchecked reads in the BREAKING CHANGE scan. The inner loop now breaks on a blank line rather than testing one in a compound condition — same semantics, guarded index.
- The rule callback is a typed `SyncRule`, so `parsed.raw` resolves through Commit's index signature instead of being `any`.

It is genuinely checked, not just annotated. A root-level `.js` file belongs to no tsconfig project, so every expression in it types as `error` — the reason the type-aware lint config waives the no-unsafe-* family for repo-root entries. Naming the file in `tsconfig.json`'s `include` gives it a program, so that waiver no longer applies to it and it leaves the list. `server.js` stays, and the comment there now says the waiver is for files with no program rather than for root-level files.

Verified through the same path `.husky/commit-msg` uses: a clean subject passes, an angle-bracket tag in a subject and in a BREAKING CHANGE note both fail on `changelog-safe-angle-brackets`, and a bad type still trips the inherited `type-enum`.

`affected.ts` keeps classifying the file as touching no test workspace, under its new name.