### PR TITLE
refactor(desktop): the project session derives component metadata from the shared extractor

### DIFF
--- a/packages/desktop/src/project-session.ts
+++ b/packages/desktop/src/project-session.ts
@@ -30,6 +30,7 @@ import {
   buildProjectExtensionRegistry,
 } from "@jxsuite/compiler/format-host";
 import { readBundledProjectSchemas } from "@jxsuite/compiler/schema-command";
+import { componentMetaFrom } from "@jxsuite/schema/component-meta";
 import type { ExtensionsPayloadEntry } from "@jxsuite/compiler/format-host";
 import type { ExtensionRegistry } from "@jxsuite/schema/extension-registry";
 import type {
@@ -40,13 +41,11 @@ import type {
 } from "@jxsuite/server/refactor";
 import { openExternal as handUrlToOs } from "./utils.ts";
 import type {
-  ComponentSlotMeta,
   DataPushRequest,
   DataRowDelete,
   DataRowInsert,
   DataRowsQuery,
   DataRowUpdate,
-  JsonValue,
   SecretsSetRequest,
 } from "@jxsuite/protocol";
 import type { FormatCapability, FormatRegistry } from "@jxsuite/schema/format-registry";
@@ -58,9 +57,6 @@ import type {
   OpenProjectResult,
   SiteConfig,
 } from "./rpc-schema";
-
-/** One entry of `ComponentMeta.props`, kept in step with the protocol rather than restated. */
-type ComponentProp = NonNullable<ComponentMeta["props"]>[number];
 
 // ─── Internal schema types for class.json parsing ─────────────────────────────
 
@@ -81,46 +77,6 @@ interface CtorParam {
   $ref?: string;
   identifier?: string;
   name?: string;
-}
-
-interface ComponentJsonDef {
-  tagName?: string;
-  $id?: string;
-  $elements?: unknown[];
-  state?: Record<string, unknown>;
-}
-
-/* The protocol's shape, not a restatement: a local copy typed `fallback?: unknown[]` drifted from
-   `(JxMutableNode | string)[]` and made every ComponentMeta unassignable — see rpc-schema.ts. */
-type SlotDef = ComponentSlotMeta;
-
-/**
- * Collect slot definitions (name + fallback children) from a parsed component tree. Whitespace-only
- * names count as unnamed (""). Only static children arrays are walked.
- */
-function collectSlotDefs(node: unknown, out: SlotDef[] = []): SlotDef[] {
-  if (!node || typeof node !== "object" || Array.isArray(node)) {
-    return out;
-  }
-  const el = node as Record<string, unknown>;
-  if (el.tagName === "slot") {
-    const attrs = el.attributes as Record<string, unknown> | undefined;
-    const rawName = attrs?.name;
-    const name = typeof rawName === "string" ? rawName.trim() : "";
-    const { children } = el;
-    out.push({
-      name,
-      ...(Array.isArray(children) && children.length > 0
-        ? { fallback: children as SlotDef["fallback"] }
-        : {}),
-    });
-  }
-  if (Array.isArray(el.children)) {
-    for (const c of el.children) {
-      collectSlotDefs(c, out);
-    }
-  }
-  return out;
 }
 
 interface ClassJsonDef {
@@ -903,44 +859,18 @@ export function createProjectSession(initialRoot: string | null) {
       }
       const fp = resolve(scanRoot, match);
       try {
-        const content = JSON.parse(await readFile(fp, "utf8")) as ComponentJsonDef;
-        if (content.tagName && content.tagName.includes("-")) {
-          const slotDefs = collectSlotDefs(content);
-          components.push({
-            $id: content.$id || null,
-            hasElements: Array.isArray(content.$elements) && content.$elements.length > 0,
-            path: match,
-            props: Object.entries(content.state || {})
-              .filter(([, d]) => {
-                if (d == null) {
-                  return false;
-                }
-                if (typeof d !== "object") {
-                  return true;
-                }
-                const entry = d as Record<string, unknown>;
-                return !entry.$prototype && !entry.$handler && !entry.$compute;
-              })
-              .map(([name, d]): ComponentProp => {
-                if (typeof d !== "object") {
-                  return { default: d as JsonValue, name, type: typeof d };
-                }
-                const entry = d as Record<string, unknown>;
-                const propResult: ComponentProp = {
-                  default: entry.default as JsonValue,
-                  name,
-                };
-                if (entry.type != null) {
-                  propResult.type = entry.type as string;
-                }
-                if (entry.format != null) {
-                  propResult.format = entry.format as string;
-                }
-                return propResult;
-              }),
-            ...(slotDefs.length > 0 ? { slots: slotDefs } : {}),
-            tagName: content.tagName,
-          });
+        /* The rules for "is this a component, and which of its `state` entries are props" live in
+           @jxsuite/schema/component-meta, shared with the dev server and the cloud adapter. This
+           session had its own copy and the two had already drifted — it set `type`/`format` only
+           when non-null, which JSON hides — so the answer is one function rather than three.
+
+           The cast is the same one the cloud adapter makes, for the same reason: @jxsuite/schema
+           sits UNDER @jxsuite/protocol in the dependency graph, so it reports a `state` entry's
+           `type` and `format` as it finds them (`unknown`) while the wire type narrows `type` to
+           `string`. Narrowing here would be the extractor lying about a document it just read. */
+        const meta = componentMetaFrom(JSON.parse(await readFile(fp, "utf8")), match);
+        if (meta) {
+          components.push(meta as ComponentMeta);
         }
       } catch {}
     }


### PR DESCRIPTION
Closes #201. Follow-up to #200, which introduced `@jxsuite/schema/component-meta` and moved the dev server onto it; `packages/desktop/src/project-session.ts` still carried its own copy.

## The drift, and why it was invisible

The desktop copy set `type` and `format` only when non-null:

```ts
if (entry.type != null) { propResult.type = entry.type as string; }
```

while the dev server always emitted them. Both paths reach Studio over an RPC boundary that serialises to JSON — `packages/desktop/src/platform.ts` through electrobun's RPC, `chromium/platform.ts` through HTTP — and there an `undefined`-valued key and an absent key are the same byte. So the two answers to "which `state` entries are props, and what shape does a prop have" never disagreed out loud. The cloud adapter was added as a third caller of that logic precisely to stop it becoming three answers.

## The change

`collectSlotDefs`, the local `ComponentJsonDef` / `SlotDef` / `ComponentProp` types and the inline extraction are deleted; discovery is now one call:

```ts
const meta = componentMetaFrom(JSON.parse(await readFile(fp, "utf8")), match);
if (meta) {
  components.push(meta as ComponentMeta);
}
```

The scan itself is untouched — still `**/*.json` only, still skipping `node_modules`, `dist/` and `.claude/`. Folding in the dev server's registry-driven extension scan would be a behaviour change, not this refactor.

The cast is the one `platforms/cloud.ts` already makes, for the same reason: `@jxsuite/schema` sits **under** `@jxsuite/protocol` in the dependency graph, so the extractor reports a `state` entry's `type` and `format` as it finds them (`unknown`) while the wire type narrows `type` to `string`. Narrowing inside the extractor would be it lying about a document it just read; the comment at the call site says so.

## What changes for a caller

Two reads get stricter, neither observable over the wire:

- a non-string `$id` now reports `null` rather than passing the value through;
- `type` and `format` are always present on a prop object rather than conditionally set — which is the drift itself, resolved in the dev server's favour.

The eight existing discovery tests in `handlers.test.ts` and `handlers-gaps.test.ts` pass unchanged. That is the check that matters: they assert the extraction's output, not its author, so they cover the shared function now without an edit.

## Verification

The issue asked for this to be done somewhere the desktop typecheck matches CI, and it now does — the vendored `vendor/electrobun` submodule closed the environment divergence it was filed around, so the before/after is a real signal rather than noise.

| | |
| --- | --- |
| `bun run --cwd packages/desktop typecheck` | clean before, clean after |
| `bun test --isolate` (packages/desktop) | 725 pass, 0 fail |
| `bun test --isolate --coverage` | worst file unchanged; `project-session.ts` 97.53% funcs / 98.16% lines, over the workspace's 0.90/0.96 gate. Marginally below its own baseline (97.62/98.31) because the code removed was fully covered — no ratchet |
| `bun scripts/check-coverage-manifest.ts packages/desktop` | all src files present |
| `bun run typecheck`, `bun run lint`, `bun run docs:sync` | green; `docs:sync` reports nothing, as a pure refactor should |

## Not in scope

`packages/studio/src/component-props.ts` answers a nearby question — the editable prop rows for the document open in the editor — with a deliberately stricter rule (template strings excluded, private keys excluded). It is not a copy of this one, and unifying them would change Studio behaviour rather than remove a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEhLfzM4F8WugjyC97w1PV
