### PR TITLE
fix(import): emit a project that actually builds into a working site

### DIFF
--- a/packages/import/src/asset-collect.ts
+++ b/packages/import/src/asset-collect.ts
@@ -72,8 +72,14 @@ export async function collectAssets(page: Page): Promise<AssetCollectionResult> 
     }
 
     function parseSrcset(srcset: string): string[] {
+      // A srcset entry is separated by a comma that starts a NEW URL. Splitting on every comma
+      // Shreds any URL that carries commas in its own path — Wix, Cloudinary and imgix all encode
+      // Transform parameters that way (".../fill/w_375,h_127,al_c,q_85/logo.png"), which turned one
+      // Image into a dozen unfetchable fragments.
       return srcset
-        .split(",")
+        .split(
+          /,(?=\s*(?:https?:\/\/|data:|\/\/|\/|\.{1,2}\/|[A-Za-z0-9_-]+\.[A-Za-z]{2,5}[/?#\s]))/,
+        )
         .map((entry) => entry.trim().split(/\s+/)[0] ?? "")
         .filter(Boolean);
     }

--- a/packages/import/src/asset-download.ts
+++ b/packages/import/src/asset-download.ts
@@ -11,8 +11,9 @@ import type { DiscoveredAsset } from "./asset-collect.ts";
 
 export interface DownloadResult {
   /**
-   * Maps original absolute URL → relative path from project root (e.g.
-   * "public/assets/images/hero.jpg").
+   * Maps the original absolute URL to the site-absolute path the built asset is served from (e.g.
+   * "/assets/images/hero.jpg") — NOT the path it is written to on disk, which keeps the public/
+   * prefix the compiler copies from.
    */
   rewriteMap: Map<string, string>;
   /** URLs that failed to download. */
@@ -172,7 +173,11 @@ export async function downloadAssets(
     usedNames.set(nameKey, count + 1);
 
     const destPath = join(assetsDir, subdir, filename);
-    const relativePath = `public/assets/${subdir}/${filename}`;
+    // The site-absolute path the built asset is served from. `public/` is the compiler's static
+    // ROOT — its contents land at dist/<path>, so the "public/" segment must not survive into a
+    // Reference, and the leading slash must be there or a reference from /components/x.js or a
+    // Nested route resolves against the wrong base.
+    const relativePath = `/assets/${subdir}/${filename}`;
 
     try {
       const headers: Record<string, string> = {

--- a/packages/import/src/asset-rewrite.ts
+++ b/packages/import/src/asset-rewrite.ts
@@ -47,8 +47,12 @@ export function rewriteAssetUrls(
   }
 
   function rewriteSrcset(srcset: string): string {
+    // A srcset entry is separated by a comma that starts a NEW URL. Splitting on every comma
+    // Shreds any URL that carries commas in its own path — Wix, Cloudinary and imgix all encode
+    // Transform parameters that way (".../fill/w_375,h_127,al_c,q_85/logo.png"), which turned one
+    // Image into a dozen unfetchable fragments.
     return srcset
-      .split(",")
+      .split(/,(?=\s*(?:https?:\/\/|data:|\/\/|\/|\.{1,2}\/|[A-Za-z0-9_-]+\.[A-Za-z]{2,5}[/?#\s]))/)
       .map((entry) => {
         const parts = entry.trim().split(/\s+/);
         const [url = ""] = parts;

--- a/packages/import/src/emit.ts
+++ b/packages/import/src/emit.ts
@@ -120,12 +120,41 @@ export async function emitMultiPageProject({
   if (fontFaceRules && fontFaceRules.length > 0) {
     let fontCss = fontFaceRules.join("\n\n");
     if (fontRewriteMap) {
+      // A @font-face rule carries the url() form its AUTHOR wrote — usually root-relative
+      // ("/wp-content/.../lato.woff2"), sometimes protocol-relative. The rewrite map is keyed by the
+      // Absolute URL the downloader resolved, so matching on that alone rewrote nothing: every
+      // Downloaded font stayed unreferenced and the page fell back to system fonts.
+      //
+      // Replaced in ONE pass, longest form first. Replacing form by form re-scans text this loop
+      // Already rewrote, and a bare pathname ("/a.woff2") then matches inside the local path it
+      // Just produced ("/assets/fonts/a.woff2" to "/assets/fonts/assets/fonts/a.woff2").
+      const byForm = new Map<string, string>();
       for (const [originalUrl, localPath] of fontRewriteMap) {
-        // Rewrite absolute URLs in font-face rules to relative local paths
-        const relativePath = localPath.startsWith("public/")
+        const local = localPath.startsWith("public/")
           ? localPath.slice("public/".length)
           : localPath;
-        fontCss = fontCss.replaceAll(originalUrl, `/${relativePath}`);
+        const href = local.startsWith("/") ? local : `/${local}`;
+        const forms = new Set([originalUrl]);
+        try {
+          const u = new URL(originalUrl);
+          forms.add(`//${u.host}${u.pathname}${u.search}`);
+          forms.add(`${u.pathname}${u.search}`);
+        } catch {
+          // Already a relative reference — the literal form is all there is.
+        }
+        for (const form of forms) {
+          if (form) {
+            byForm.set(form, href);
+          }
+        }
+      }
+      const forms = [...byForm.keys()].toSorted((a, b) => b.length - a.length);
+      if (forms.length > 0) {
+        const pattern = new RegExp(
+          forms.map((f) => f.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)).join("|"),
+          "g",
+        );
+        fontCss = fontCss.replaceAll(pattern, (m) => byForm.get(m) ?? m);
       }
     }
     const fontsDir = join(outDir, "public", "assets");

--- a/packages/import/src/emit.ts
+++ b/packages/import/src/emit.ts
@@ -58,7 +58,6 @@ export async function emitProject({
 export async function emitMultiPageProject({
   outDir,
   title,
-  sourceUrl,
   pages,
   layout,
   breakpoints,
@@ -75,8 +74,6 @@ export async function emitMultiPageProject({
 
   const projectJson: Record<string, unknown> = {
     name: title || "Imported Site",
-    title: title || "Imported Site",
-    description: `Imported from ${sourceUrl}`,
     imports: {},
     images: { optimize: false },
   };
@@ -86,7 +83,7 @@ export async function emitMultiPageProject({
   }
 
   if (styleTokens && Object.keys(styleTokens).length > 0) {
-    projectJson.$style = styleTokens;
+    projectJson.style = styleTokens;
   }
 
   const files: string[] = [];

--- a/packages/import/tests/asset-download.test.ts
+++ b/packages/import/tests/asset-download.test.ts
@@ -97,7 +97,7 @@ describe("downloadAssets", () => {
       const url = "https://example.com/images/pic.jpg";
       const result = await downloadAssets([{ url, source: "img-src" }], tmpDir);
 
-      expect(result.rewriteMap.get(url)).toBe("public/assets/images/pic.jpg");
+      expect(result.rewriteMap.get(url)).toBe("/assets/images/pic.jpg");
       expect(result.totalBytes).toBe(5);
       expect(result.failed.length).toBe(0);
       expect(existsSync(join(tmpDir, "public", "assets", "images", "pic.jpg"))).toBe(true);
@@ -122,16 +122,16 @@ describe("downloadAssets", () => {
       const result = await downloadAssets(assets, tmpDir);
 
       expect(result.rewriteMap.get("https://fonts.example.com/custom.ttf")).toBe(
-        "public/assets/fonts/custom.ttf",
+        "/assets/fonts/custom.ttf",
       );
       expect(result.rewriteMap.get("https://example.com/favicon.ico")).toBe(
-        "public/assets/icons/favicon.ico",
+        "/assets/icons/favicon.ico",
       );
       expect(result.rewriteMap.get("https://cdn.example.com/inter.woff2")).toBe(
-        "public/assets/fonts/inter.woff2",
+        "/assets/fonts/inter.woff2",
       );
       expect(result.rewriteMap.get("https://example.com/whitepaper.pdf")).toBe(
-        "public/assets/other/whitepaper.pdf",
+        "/assets/other/whitepaper.pdf",
       );
     } finally {
       globalThis.fetch = originalFetch;
@@ -154,11 +154,11 @@ describe("downloadAssets", () => {
 
       // No extension → ".bin" appended (and classified as "other")
       expect(result.rewriteMap.get("https://example.com/assets/logo")).toBe(
-        "public/assets/other/logo.bin",
+        "/assets/other/logo.bin",
       );
       // 120-char filename → capped to 96 chars + extension
       expect(result.rewriteMap.get(`https://example.com/${longName}.png`)).toBe(
-        `public/assets/images/${"a".repeat(96)}.png`,
+        `/assets/images/${"a".repeat(96)}.png`,
       );
     } finally {
       globalThis.fetch = originalFetch;
@@ -179,10 +179,10 @@ describe("downloadAssets", () => {
       const result = await downloadAssets(assets, tmpDir);
 
       expect(result.rewriteMap.get("https://a.example.com/logo.png")).toBe(
-        "public/assets/images/logo.png",
+        "/assets/images/logo.png",
       );
       expect(result.rewriteMap.get("https://b.example.com/logo.png")).toBe(
-        "public/assets/images/logo-1.png",
+        "/assets/images/logo-1.png",
       );
       expect(existsSync(join(tmpDir, "public", "assets", "images", "logo-1.png"))).toBe(true);
     } finally {

--- a/packages/import/tests/asset-rewrite.test.ts
+++ b/packages/import/tests/asset-rewrite.test.ts
@@ -13,14 +13,12 @@ describe("rewriteAssetUrls", () => {
         },
       ],
     };
-    const map = new Map([["https://example.com/hero.jpg", "public/assets/images/hero.jpg"]]);
+    const map = new Map([["https://example.com/hero.jpg", "/assets/images/hero.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
     expect(count).toBe(1);
-    expect((tree.children as JxElement[])[0]!.attributes!.src).toBe(
-      "public/assets/images/hero.jpg",
-    );
+    expect((tree.children as JxElement[])[0]!.attributes!.src).toBe("/assets/images/hero.jpg");
   });
 
   test("rewrites srcset attribute", () => {
@@ -36,15 +34,15 @@ describe("rewriteAssetUrls", () => {
       ],
     };
     const map = new Map([
-      ["https://example.com/small.jpg", "public/assets/images/small.jpg"],
-      ["https://example.com/large.jpg", "public/assets/images/large.jpg"],
+      ["https://example.com/small.jpg", "/assets/images/small.jpg"],
+      ["https://example.com/large.jpg", "/assets/images/large.jpg"],
     ]);
 
     const count = rewriteAssetUrls(tree, map);
 
     expect(count).toBe(2);
     expect((tree.children as JxElement[])[0]!.attributes!.srcset).toBe(
-      "public/assets/images/small.jpg 320w, public/assets/images/large.jpg 1024w",
+      "/assets/images/small.jpg 320w, /assets/images/large.jpg 1024w",
     );
   });
 
@@ -55,12 +53,12 @@ describe("rewriteAssetUrls", () => {
         backgroundImage: 'url("https://example.com/bg.png")',
       },
     };
-    const map = new Map([["https://example.com/bg.png", "public/assets/images/bg.png"]]);
+    const map = new Map([["https://example.com/bg.png", "/assets/images/bg.png"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
     expect(count).toBe(1);
-    expect(tree.style!.backgroundImage).toBe('url("public/assets/images/bg.png")');
+    expect(tree.style!.backgroundImage).toBe('url("/assets/images/bg.png")');
   });
 
   test("rewrites URLs in $media nested style objects", () => {
@@ -74,16 +72,16 @@ describe("rewriteAssetUrls", () => {
       },
     };
     const map = new Map([
-      ["https://example.com/bg-desktop.png", "public/assets/images/bg-desktop.png"],
-      ["https://example.com/bg-mobile.png", "public/assets/images/bg-mobile.png"],
+      ["https://example.com/bg-desktop.png", "/assets/images/bg-desktop.png"],
+      ["https://example.com/bg-mobile.png", "/assets/images/bg-mobile.png"],
     ]);
 
     const count = rewriteAssetUrls(tree, map);
 
     expect(count).toBe(2);
-    expect(tree.style!.backgroundImage).toBe('url("public/assets/images/bg-desktop.png")');
+    expect(tree.style!.backgroundImage).toBe('url("/assets/images/bg-desktop.png")');
     expect((tree.style!["@--768"] as JxStyle).backgroundImage).toBe(
-      'url("public/assets/images/bg-mobile.png")',
+      'url("/assets/images/bg-mobile.png")',
     );
   });
 
@@ -92,7 +90,7 @@ describe("rewriteAssetUrls", () => {
       tagName: "a",
       attributes: { href: "https://example.com/page" },
     };
-    const map = new Map([["https://example.com/page", "public/assets/other/page"]]);
+    const map = new Map([["https://example.com/page", "/assets/other/page"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
@@ -105,12 +103,12 @@ describe("rewriteAssetUrls", () => {
       tagName: "video",
       attributes: { poster: "https://example.com/thumb.jpg" },
     };
-    const map = new Map([["https://example.com/thumb.jpg", "public/assets/images/thumb.jpg"]]);
+    const map = new Map([["https://example.com/thumb.jpg", "/assets/images/thumb.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
     expect(count).toBe(1);
-    expect(tree.attributes!.poster).toBe("public/assets/images/thumb.jpg");
+    expect(tree.attributes!.poster).toBe("/assets/images/thumb.jpg");
   });
 
   test("skips URLs not in the rewrite map", () => {
@@ -146,7 +144,7 @@ describe("rewriteAssetUrls", () => {
         },
       ],
     };
-    const map = new Map([["https://example.com/deep.jpg", "public/assets/images/deep.jpg"]]);
+    const map = new Map([["https://example.com/deep.jpg", "/assets/images/deep.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
@@ -178,22 +176,18 @@ describe("rewriteAssetUrls", () => {
       ],
     };
     const map = new Map([
-      ["https://tailwindcss.com/_next/static/media/hero.jpg", "public/assets/images/hero.jpg"],
-      ["https://tailwindcss.com/images/logo.svg", "public/assets/images/logo.svg"],
-      ["https://tailwindcss.com/_next/static/media/bg.png", "public/assets/images/bg.png"],
+      ["https://tailwindcss.com/_next/static/media/hero.jpg", "/assets/images/hero.jpg"],
+      ["https://tailwindcss.com/images/logo.svg", "/assets/images/logo.svg"],
+      ["https://tailwindcss.com/_next/static/media/bg.png", "/assets/images/bg.png"],
     ]);
 
     const count = rewriteAssetUrls(tree, map, "https://tailwindcss.com/");
 
     expect(count).toBe(3);
-    expect((tree.children as JxElement[])[0]!.attributes!.src).toBe(
-      "public/assets/images/hero.jpg",
-    );
-    expect((tree.children as JxElement[])[1]!.attributes!.src).toBe(
-      "public/assets/images/logo.svg",
-    );
+    expect((tree.children as JxElement[])[0]!.attributes!.src).toBe("/assets/images/hero.jpg");
+    expect((tree.children as JxElement[])[1]!.attributes!.src).toBe("/assets/images/logo.svg");
     expect((tree.children as JxElement[])[2]!.style!.backgroundImage).toBe(
-      'url("public/assets/images/bg.png")',
+      'url("/assets/images/bg.png")',
     );
   });
 
@@ -202,12 +196,12 @@ describe("rewriteAssetUrls", () => {
       tagName: "img",
       attributes: { src: "//cdn.example.com/image.jpg" },
     };
-    const map = new Map([["https://cdn.example.com/image.jpg", "public/assets/images/image.jpg"]]);
+    const map = new Map([["https://cdn.example.com/image.jpg", "/assets/images/image.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map, "https://example.com/");
 
     expect(count).toBe(1);
-    expect(tree.attributes!.src).toBe("public/assets/images/image.jpg");
+    expect(tree.attributes!.src).toBe("/assets/images/image.jpg");
   });
 
   test("still matches absolute URLs without sourceUrl", () => {
@@ -215,7 +209,7 @@ describe("rewriteAssetUrls", () => {
       tagName: "img",
       attributes: { src: "https://example.com/hero.jpg" },
     };
-    const map = new Map([["https://example.com/hero.jpg", "public/assets/images/hero.jpg"]]);
+    const map = new Map([["https://example.com/hero.jpg", "/assets/images/hero.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
@@ -227,12 +221,12 @@ describe("rewriteAssetUrls", () => {
       tagName: "img",
       attributes: { src: "https://example.com/x" },
     };
-    const map = new Map([["https://example.com/x/", "public/assets/images/x"]]);
+    const map = new Map([["https://example.com/x/", "/assets/images/x"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
     expect(count).toBe(1);
-    expect(tree.attributes!.src).toBe("public/assets/images/x");
+    expect(tree.attributes!.src).toBe("/assets/images/x");
   });
 
   test("leaves relative URLs whose resolution misses the map", () => {
@@ -240,7 +234,7 @@ describe("rewriteAssetUrls", () => {
       tagName: "img",
       attributes: { src: "/missing.jpg" },
     };
-    const map = new Map([["https://example.com/hero.jpg", "public/assets/images/hero.jpg"]]);
+    const map = new Map([["https://example.com/hero.jpg", "/assets/images/hero.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map, "https://example.com/");
 
@@ -253,7 +247,7 @@ describe("rewriteAssetUrls", () => {
       tagName: "img",
       attributes: { src: "/x.jpg" },
     };
-    const map = new Map([["https://example.com/hero.jpg", "public/assets/images/hero.jpg"]]);
+    const map = new Map([["https://example.com/hero.jpg", "/assets/images/hero.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map, "::::not-a-base");
 
@@ -266,7 +260,7 @@ describe("rewriteAssetUrls", () => {
       tagName: "div",
       style: { backgroundImage: 'url("https://unknown.example/bg.png")' },
     };
-    const map = new Map([["https://example.com/hero.jpg", "public/assets/images/hero.jpg"]]);
+    const map = new Map([["https://example.com/hero.jpg", "/assets/images/hero.jpg"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
@@ -279,12 +273,12 @@ describe("rewriteAssetUrls", () => {
       tagName: "link",
       attributes: { href: "https://example.com/favicon.ico", rel: "icon" },
     };
-    const map = new Map([["https://example.com/favicon.ico", "public/assets/icons/favicon.ico"]]);
+    const map = new Map([["https://example.com/favicon.ico", "/assets/icons/favicon.ico"]]);
 
     const count = rewriteAssetUrls(tree, map);
 
     expect(count).toBe(1);
-    expect(tree.attributes!.href).toBe("public/assets/icons/favicon.ico");
+    expect(tree.attributes!.href).toBe("/assets/icons/favicon.ico");
   });
 
   test("rewrites multiple assets in one pass", () => {
@@ -306,9 +300,9 @@ describe("rewriteAssetUrls", () => {
       ],
     };
     const map = new Map([
-      ["https://example.com/a.jpg", "public/assets/images/a.jpg"],
-      ["https://example.com/b.png", "public/assets/images/b.png"],
-      ["https://example.com/c.webp", "public/assets/images/c.webp"],
+      ["https://example.com/a.jpg", "/assets/images/a.jpg"],
+      ["https://example.com/b.png", "/assets/images/b.png"],
+      ["https://example.com/c.webp", "/assets/images/c.webp"],
     ]);
 
     const count = rewriteAssetUrls(tree, map);

--- a/packages/import/tests/crawl-site.test.ts
+++ b/packages/import/tests/crawl-site.test.ts
@@ -68,8 +68,8 @@ void mock.module("../src/asset-collect.ts", () => ({ collectAssets }));
 const downloadAssets = mock(() =>
   Promise.resolve({
     rewriteMap: new Map([
-      ["https://crawl.example/logo.png", "public/assets/images/logo.png"],
-      ["https://crawl.example/font.woff2", "public/assets/fonts/font.woff2"],
+      ["https://crawl.example/logo.png", "/assets/images/logo.png"],
+      ["https://crawl.example/font.woff2", "/assets/fonts/font.woff2"],
     ]),
     failed: [],
     skipped: [],
@@ -187,7 +187,7 @@ describe("crawlSite", () => {
     // Assets: font-face rules deduped across pages, font rewrites collected.
     expect(result.fontFaceRules).toEqual(["@font-face { font-family: X }"]);
     expect(result.fontRewriteMap.get("https://crawl.example/font.woff2")).toBe(
-      "public/assets/fonts/font.woff2",
+      "/assets/fonts/font.woff2",
     );
     expect(messages.some((m) => m.includes("robots.txt"))).toBe(true);
   });

--- a/packages/import/tests/emit-multi.test.ts
+++ b/packages/import/tests/emit-multi.test.ts
@@ -230,7 +230,7 @@ describe("emitMultiPageProject", () => {
           "@font-face { src: url(https://cdn.example.com/b.woff2); }",
         ],
         fontRewriteMap: new Map([
-          ["https://cdn.example.com/a.woff2", "public/assets/fonts/a.woff2"],
+          ["https://cdn.example.com/a.woff2", "/assets/fonts/a.woff2"],
           ["https://cdn.example.com/b.woff2", "assets/fonts/b.woff2"],
         ]),
       });

--- a/packages/import/tests/emit-multi.test.ts
+++ b/packages/import/tests/emit-multi.test.ts
@@ -79,7 +79,7 @@ describe("emitMultiPageProject", () => {
       expect(files.length).toBe(5);
 
       const project = await Bun.file(join(dir, "project.json")).json();
-      expect(project.title).toBe("Multi Page Test");
+      expect(project.name).toBe("Multi Page Test");
 
       const index = await Bun.file(join(dir, "pages", "index.json")).json();
       expect(index.textContent).toBe("Home");
@@ -164,7 +164,7 @@ describe("emitMultiPageProject", () => {
     }
   });
 
-  test("writes style tokens into project.json.$style", async () => {
+  test("writes style tokens into project.json.style", async () => {
     const dir = await mkdtemp(join(tmpdir(), "jx-import-tokens-"));
 
     try {
@@ -177,7 +177,7 @@ describe("emitMultiPageProject", () => {
       });
 
       const project = await Bun.file(join(dir, "project.json")).json();
-      expect(project.$style).toEqual({ "--brand": "#3b82f6", "--space-4": "16px" });
+      expect(project.style).toEqual({ "--brand": "#3b82f6", "--space-4": "16px" });
     } finally {
       await rm(dir, { recursive: true });
     }

--- a/packages/import/tests/emit.test.ts
+++ b/packages/import/tests/emit.test.ts
@@ -27,8 +27,7 @@ describe("emitProject", () => {
       expect(files.length).toBeGreaterThanOrEqual(2);
 
       const project = await Bun.file(join(dir, "project.json")).json();
-      expect(project.title).toBe("Test Site");
-      expect(project.description).toContain("example.com");
+      expect(project.name).toBe("Test Site");
 
       const page = await Bun.file(join(dir, "pages", "index.json")).json();
       expect(page.tagName).toBe("div");

--- a/packages/import/tests/emitted-project-builds.test.ts
+++ b/packages/import/tests/emitted-project-builds.test.ts
@@ -11,7 +11,9 @@ import { tmpdir } from "node:os";
 import { existsSync } from "node:fs";
 import { emitMultiPageProject } from "../src/emit.ts";
 import { downloadAssets } from "../src/asset-download.ts";
+import { rewriteAssetUrls } from "../src/asset-rewrite.ts";
 import type { DiscoveredAsset } from "../src/asset-collect.ts";
+import type { JxElement } from "@jxsuite/schema/types";
 
 /** The keys `project.schema.json` accepts at the top level of a project document. */
 const PROJECT_KEYS = new Set([
@@ -154,5 +156,52 @@ describe("a downloaded font is the one the page asks for", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+describe("srcset survives a URL that carries its own commas", () => {
+  test("a transform-CDN url is one entry, not one per parameter", () => {
+    // Wix, Cloudinary and imgix all encode transform parameters as commas INSIDE the path.
+    // Splitting on every comma turned one image into a dozen unfetchable fragments, and a failed
+    // Download leaves the origin's URL in the page — so the clone hotlinked the site it cloned.
+    const wide = "https://cdn.example.com/media/x.png/v1/fill/w_750,h_254,al_c,q_85/logo.png";
+    const narrow = "https://cdn.example.com/media/x.png/v1/fill/w_375,h_127,al_c,q_85/logo.png";
+    const tree: JxElement = {
+      tagName: "div",
+      children: [{ tagName: "img", attributes: { srcset: `${narrow} 1x, ${wide} 2x` } }],
+    };
+    const map = new Map([
+      [narrow, "/assets/images/logo.png"],
+      [wide, "/assets/images/logo-1.png"],
+    ]);
+
+    const count = rewriteAssetUrls(tree, map);
+
+    expect(count).toBe(2);
+    expect((tree.children as JxElement[])[0]!.attributes!.srcset).toBe(
+      "/assets/images/logo.png 1x, /assets/images/logo-1.png 2x",
+    );
+  });
+
+  test("an ordinary srcset still splits on every entry", () => {
+    const tree: JxElement = {
+      tagName: "div",
+      children: [
+        {
+          tagName: "img",
+          attributes: { srcset: "https://example.com/s.jpg 320w, https://example.com/l.jpg 1024w" },
+        },
+      ],
+    };
+    const map = new Map([
+      ["https://example.com/s.jpg", "/assets/images/s.jpg"],
+      ["https://example.com/l.jpg", "/assets/images/l.jpg"],
+    ]);
+
+    const count = rewriteAssetUrls(tree, map);
+
+    expect(count).toBe(2);
+    expect((tree.children as JxElement[])[0]!.attributes!.srcset).toBe(
+      "/assets/images/s.jpg 320w, /assets/images/l.jpg 1024w",
+    );
   });
 });

--- a/packages/import/tests/emitted-project-builds.test.ts
+++ b/packages/import/tests/emitted-project-builds.test.ts
@@ -107,3 +107,52 @@ describe("an asset reference names the path the built site serves", () => {
     }
   });
 });
+describe("a downloaded font is the one the page asks for", () => {
+  test("a root-relative @font-face url is rewritten, not just the absolute form", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "jx-import-fontform-"));
+    try {
+      await emitMultiPageProject({
+        outDir: dir,
+        title: "Font Form Test",
+        sourceUrl: "https://example.com",
+        pages: new Map([["pages/index.json", { tagName: "div" as const }]]),
+        // The form a stylesheet AUTHOR writes. The rewrite map is keyed by the absolute URL the
+        // Downloader resolved, so matching on that alone rewrote nothing and every downloaded font
+        // Stayed unreferenced.
+        fontFaceRules: ['@font-face { src: url("/fonts/lato.woff2"); }'],
+        fontRewriteMap: new Map([
+          ["https://example.com/fonts/lato.woff2", "/assets/fonts/lato.woff2"],
+        ]),
+      });
+
+      const css = await Bun.file(join(dir, "public", "assets", "fonts.css")).text();
+
+      expect(css).toContain('url("/assets/fonts/lato.woff2")');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rewriting is a single pass, so a local path is never rewritten again", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "jx-import-fontonce-"));
+    try {
+      await emitMultiPageProject({
+        outDir: dir,
+        title: "Font Once Test",
+        sourceUrl: "https://example.com",
+        pages: new Map([["pages/index.json", { tagName: "div" as const }]]),
+        fontFaceRules: ['@font-face { src: url("https://cdn.example.com/a.woff2"); }'],
+        fontRewriteMap: new Map([["https://cdn.example.com/a.woff2", "/assets/fonts/a.woff2"]]),
+      });
+
+      const css = await Bun.file(join(dir, "public", "assets", "fonts.css")).text();
+
+      // Replacing form by form re-scans text already rewritten: the pathname "/a.woff2" then
+      // Matches inside the "/assets/fonts/a.woff2" this loop just produced.
+      expect(css).toContain('url("/assets/fonts/a.woff2")');
+      expect(css).not.toContain("/assets/fonts/assets/");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/import/tests/emitted-project-builds.test.ts
+++ b/packages/import/tests/emitted-project-builds.test.ts
@@ -8,7 +8,10 @@ import { describe, test, expect } from "bun:test";
 import { join } from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
 import { emitMultiPageProject } from "../src/emit.ts";
+import { downloadAssets } from "../src/asset-download.ts";
+import type { DiscoveredAsset } from "../src/asset-collect.ts";
 
 /** The keys `project.schema.json` accepts at the top level of a project document. */
 const PROJECT_KEYS = new Set([
@@ -74,6 +77,32 @@ describe("an emitted project is one the compiler accepts", () => {
       expect(project.style).toEqual({ "--brand": "#3b82f6" });
       expect(project.$style).toBeUndefined();
     } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+describe("an asset reference names the path the built site serves", () => {
+  test("a downloaded asset is mapped site-absolute, with no `public/` segment", async () => {
+    // `public/` is the compiler's static ROOT: its contents land at dist/<path>. A reference that
+    // Keeps the segment names a file that does not exist, and one without a leading slash resolves
+    // Against the current route — so the same document 404s differently on every page.
+    const dir = await mkdtemp(join(tmpdir(), "jx-import-assetpath-"));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("data")) as unknown as typeof fetch;
+    try {
+      const assets: DiscoveredAsset[] = [
+        { url: "https://example.com/logo.png", source: "img-src" },
+      ];
+
+      const { rewriteMap } = await downloadAssets(assets, dir);
+      const mapped = rewriteMap.get("https://example.com/logo.png");
+
+      expect(mapped).toBe("/assets/images/logo.png");
+      expect(mapped).not.toContain("public/");
+      // The file itself still lands under public/, which is what the compiler copies from.
+      expect(existsSync(join(dir, "public", "assets", "images", "logo.png"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/packages/import/tests/emitted-project-builds.test.ts
+++ b/packages/import/tests/emitted-project-builds.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression tests for the defects that stopped an imported project from building into a working
+ * site. Each one passed the whole existing suite while the built output was visibly broken, so each
+ * is pinned here by the property that was actually violated rather than by implementation detail.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { emitMultiPageProject } from "../src/emit.ts";
+
+/** The keys `project.schema.json` accepts at the top level of a project document. */
+const PROJECT_KEYS = new Set([
+  "$defs",
+  "$elements",
+  "$head",
+  "$media",
+  "$schema",
+  "build",
+  "copy",
+  "defaults",
+  "extensions",
+  "i18n",
+  "images",
+  "imports",
+  "manifest",
+  "name",
+  "redirects",
+  "securityTxt",
+  "serviceWorker",
+  "state",
+  "style",
+  "url",
+]);
+
+describe("an emitted project is one the compiler accepts", () => {
+  test("project.json carries no key the schema rejects", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "jx-import-projectkeys-"));
+    try {
+      await emitMultiPageProject({
+        outDir: dir,
+        title: "Key Test",
+        sourceUrl: "https://example.com",
+        pages: new Map([["pages/index.json", { tagName: "div" as const }]]),
+        breakpoints: { "--768": "(min-width: 768px)" },
+        styleTokens: { "--brand": "#3b82f6" },
+      });
+
+      const project = await Bun.file(join(dir, "project.json")).json();
+      const rejected = Object.keys(project).filter((k) => !PROJECT_KEYS.has(k));
+
+      expect(rejected).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("extracted tokens land under `style`, the key the compiler reads", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "jx-import-tokens-"));
+    try {
+      await emitMultiPageProject({
+        outDir: dir,
+        title: "Token Test",
+        sourceUrl: "https://example.com",
+        pages: new Map([["pages/index.json", { tagName: "div" as const }]]),
+        styleTokens: { "--brand": "#3b82f6" },
+      });
+
+      const project = await Bun.file(join(dir, "project.json")).json();
+
+      // Under `$style` the compiler emits no `:root` rule at all, so every var(--brand) in the
+      // Imported CSS resolves to nothing while the build still reports success.
+      expect(project.style).toEqual({ "--brand": "#3b82f6" });
+      expect(project.$style).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/import/tests/run.test.ts
+++ b/packages/import/tests/run.test.ts
@@ -57,8 +57,8 @@ void mock.module("../src/asset-collect.ts", () => ({ collectAssets }));
 const downloadAssets = mock(() =>
   Promise.resolve({
     rewriteMap: new Map([
-      ["https://site.example/hero.jpg", "public/assets/images/hero.jpg"],
-      ["https://site.example/font.woff2", "public/assets/fonts/font.woff2"],
+      ["https://site.example/hero.jpg", "/assets/images/hero.jpg"],
+      ["https://site.example/font.woff2", "/assets/fonts/font.woff2"],
     ]),
     failed: ["https://site.example/broken.png"],
     skipped: [] as string[],
@@ -285,7 +285,7 @@ describe("importSite — single-page mode", () => {
 
   test("reports sub-kilobyte download sizes and skipped tracking URLs", async () => {
     downloadAssets.mockResolvedValueOnce({
-      rewriteMap: new Map([["https://site.example/hero.jpg", "public/assets/images/hero.jpg"]]),
+      rewriteMap: new Map([["https://site.example/hero.jpg", "/assets/images/hero.jpg"]]),
       failed: [],
       skipped: ["https://site.example/analytics.js"],
       totalBytes: 512,
@@ -301,7 +301,7 @@ describe("importSite — single-page mode", () => {
 
   test("reports megabyte-range download sizes", async () => {
     downloadAssets.mockResolvedValueOnce({
-      rewriteMap: new Map([["https://site.example/hero.jpg", "public/assets/images/hero.jpg"]]),
+      rewriteMap: new Map([["https://site.example/hero.jpg", "/assets/images/hero.jpg"]]),
       failed: [],
       skipped: [],
       totalBytes: 3 * 1024 * 1024,


### PR DESCRIPTION
Four independent defects that between them stopped `jx-import` from producing a project that builds into a working site. Each is filed separately with its own repro — #228, #229, #230, #231 — and gets one commit here.

Found while evaluating the importer as a way to seed Jx projects from a prospect's existing website. Measured with the importer's own `--verify` pixel-fidelity metric against real sites, `@jxsuite/import@0.39.8` + `@jxsuite/compiler@2.0.8`.

## What changes

| Commit | Defect | Closes |
|---|---|---|
| `fix(import): emit a project.json the schema accepts` | `title`, `description` and `$style` are not project keys — every import failed `jx validate`, and tokens under `$style` never reached `:root` | #228 |
| `fix(import): reference an asset by the path the built site serves` | references kept the `public/` static-root prefix and had no leading slash — every image 404'd | #229 |
| `fix(import): rewrite a font-face url to the font that was downloaded` | the rewrite matched only the absolute URL, never the authored form — 113 downloaded fonts went unreferenced | #230 |
| `fix(import): parse srcset without shredding a url that carries commas` | `split(",")` broke Wix/Cloudinary/imgix transform URLs; failed downloads then left the origin's URLs in the page | #231 |

## Measured effect

On a four-page WordPress import (`redliondental.com`):

| | before | after |
|---|---|---|
| `jx validate` | INVALID | **valid** |
| broken references on the home page | 15 | **0** |
| pixel fidelity vs the original | 29.3% | **~70%** |

On a Wix single-page import (`onewaymechanical.com`):

| | before | after |
|---|---|---|
| assets reported as failed downloads | 109 | **0** |
| origin URLs left in the emitted page | 46 | **0** |
| pixel fidelity | 8.2% | 33.6% |

The Wix number stays poor for reasons outside this PR — see below.

## The one worth reading twice

The font fix has a trap in it. Matching the URL pathname as well as the absolute form is right, but the replacement **must be a single pass**. Replacing form by form re-scans text the loop already rewrote, and a bare pathname then matches inside the local path it just produced:

```
/assets/fonts/a.woff2  ->  /assets/fonts/assets/fonts/a.woff2
```

I wrote that bug on the first attempt and `emit-multi.test.ts`'s existing "rewrites font URLs to local paths in fonts.css" caught it — nice test. There is now a regression test pinning it directly.

## Tests

New `tests/emitted-project-builds.test.ts` pins all four by the property that was violated rather than by implementation detail. Verified they fail without the corresponding fix: **6 of its 7 tests fail on unpatched `main`**; the seventh is the deliberate no-regression guard that an ordinary `a.png 400w, b.png 800w` still splits on every entry.

This also updates existing expectations across `asset-download`, `asset-rewrite`, `crawl-site`, `run`, `emit` and `emit-multi` that asserted the old shapes — including one test literally named `writes style tokens into project.json.$style`. Those expectations are why the defects survived, so they are corrected rather than worked around.

```
bun run lint          clean
bun run typecheck     clean
bun test --isolate    248 pass / 0 fail   (packages/import)
coverage              100% funcs, 99.75% lines; the four touched files 100/100, 100/99.28
check-coverage-manifest, docs:check, docs:sync   all clean
```

No spec or docs page changes: the CLI surface, options and documented behaviour are unchanged — these are all "the documented behaviour did not actually happen" fixes.

## Deliberately not in this PR

Three things I measured that are design questions rather than defects, so they are not touched here. Happy to open issues if any are wanted:

- **Computed geometry is baked into every element** — one page carries 293 hardcoded `width: Npx` and 190 `height: Npx`, captured at 1440x900. `style-capture.ts` captures `display`/`position`/flex/grid correctly, but the pinned geometry then overrides them, so layout does not survive a different viewport. The same root cause makes output non-reproducible: two imports of the same URL with identical code differ in 196 lines of sub-pixel drift (`17.532px` vs `17.5314px`), a fidelity spread of about 4 points.
- **JS-rendered sites** — the Wix page captured 555 nodes and emitted 16 text nodes.
- **Layout detection** — `No shared layout detected` across four pages with a visually identical header and footer; the header is duplicated as a component into each page instead.

Separately filed, not in this PR: #232 (`--verify` cannot fail — its threshold is a pixelmatch colour tolerance, build errors are logged not enforced, and only the top 900px is compared) and #227, a compiler blocker where a component-less project emits an import map naming `/assets/*.js` files the build never writes.
