### PR TITLE
fix(desktop): exclude vendor from the Nix source so the published path is the one consumers ask for

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,8 @@
 #     `release` branch advances behind. `runner` picks the architecture.
 #   * `schedule`, nightly, which is what keeps that cache warm now that most merges to `main` are
 #     auto-merges and raise no `push` event at all.
-#   * `workflow_dispatch`, to measure what a release would cost a binary cache (see `measure`).
+#   * `workflow_dispatch`, to measure what a release would cost a binary cache (see `measure`), and
+#     to BACKFILL one that shipped without a usable cache entry (see `publish`).
 #
 # A release-PR merge touches packages/desktop/** (the version bump), so it fires the `push` trigger
 # AND the `workflow_call` from release-please. That is two builds of the same commit. It is left
@@ -93,6 +94,15 @@ on:
         description: "Report what one release would cost a binary cache."
         required: false
         default: true
+        type: boolean
+      publish:
+        # Backfill. The release path publishes on its own, but a release whose push landed at a
+        # store path no consumer asks for (#250) leaves a gap that nothing else can close: the tag
+        # is cut, `release` has moved on, and re-running release-please.yml does nothing because
+        # the pull request is already labelled `autorelease: tagged`. Dispatch this on `release`.
+        description: "Push the built closure to the public Cachix cache. Backfills a release."
+        required: false
+        default: false
         type: boolean
 
 permissions:
@@ -233,12 +243,41 @@ jobs:
         continue-on-error: true
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The release leg passes the desktop tag; a backfill dispatch runs on `release` itself.
+          # Both name the same commit, and a store path is a function of the tree rather than of the
+          # ref that reached it, so either answers the question this step asks.
+          PUBLISH_REF: ${{ inputs.ref || github.ref_name }}
         run: |
           set -euo pipefail
           if [ -z "${CACHIX_AUTH_TOKEN:-}" ]; then
             echo "::error::publish was requested but CACHIX_AUTH_TOKEN is empty"
             exit 1
           fi
+
+          # A closure is only as useful as the address it lands at, and for desktop-v5.0.0 the two
+          # disagreed. This job builds the CHECKOUT; a consumer evaluates the GITHUB FLAKE, and the
+          # `vendor/electrobun` gitlink made those two trees differ by two empty directory entries —
+          # one commit, two store paths. The push succeeded, `nix path-info` found every byte of what
+          # it sent, and `nix build github:jxsuite/jx/release --max-jobs 0` still built from source.
+          # package.nix now filters `vendor` so the two agree by construction; this is the assertion
+          # that they still do, and it is the sentence the next such divergence will need — the
+          # symptom alone (`verify-cache` reporting a missing path) names no cause at all.
+          #
+          # NOT `2>&1`: `nix eval` prints fetch progress and evaluation warnings to stderr, and
+          # merging those into the VALUE is exactly the defect that had `verify-cache` file five
+          # phantom cache misses (release-please.yml carries that story).
+          system="$(nix eval --raw --impure --expr 'builtins.currentSystem')"
+          built="$(readlink -f ./result)"
+          want="$(nix eval --raw --accept-flake-config \
+            "github:${GITHUB_REPOSITORY}/${PUBLISH_REF}#packages.${system}.default.outPath")"
+          echo "built    -> $built"
+          echo "consumer -> $want"
+          if [ "$built" != "$want" ]; then
+            echo "::error::built $built, but a consumer of github:${GITHUB_REPOSITORY}/${PUBLISH_REF}"\
+                 "asks for $want — publishing this would fill the cache at an address nobody requests"
+            exit 1
+          fi
+
           nix path-info --json --recursive ./result \
             | jq 'if type == "array" then . else (to_entries | map({path: .key} + .value)) end' \
             | jq -r '.[] | select((.signatures // []) | length == 0) | .path' \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ exact release the `electrobun` devDependency names.** `packages/desktop/tsconfig
   and why `.oxlintignore` is inert (oxlint's ignore file is `.eslintignore`, via `--ignore-path`,
   and the lint script passes neither). `vendor` therefore needs an explicit entry in **both**
   `.oxlintrc.json` and `.oxlintrc.typecheck.json`, plus `.oxfmtrc.json` and root `bunfig.toml`.
+- **The Nix derivation is the fifth of those, and the one that cost a release.** `package.nix`
+  takes the whole repository as `src`, so a tracked path is part of the tree whose NAR hash IS the
+  store path `nix run github:jxsuite/jx/release` resolves — and `vendor/electrobun` is the one
+  tracked path whose PRESENCE depends on how the tree was fetched. GitHub's tarball materialises the
+  gitlink as an empty directory; nix's git-tree source for a checkout omits it. The submodule is
+  uninitialised either way, so no build phase notices — but two empty directories are two NAR
+  entries, and `desktop-v5.0.0` had two store paths for one commit. CI published `sq57vgab…` and
+  every consumer asked for `671d1spz…`: the push succeeded, the closure was complete, and the cache
+  was useless (#250). `src` now filters `vendor` so the two agree by construction, asserted in
+  `electrobun-config.test.ts` and re-checked against a live `nix eval` on nix.yml's publish leg.
 - **`.d.ts` remains impossible.** `TS4094` in the SDK's own `index.ts` blocks declaration emit, so
   `skipLibCheck` cannot help and `packages/desktop` keeps its own tsconfig. That carve-out is
   asserted, not just written down, in `packages/desktop/tests/electrobun-config.test.ts`.

--- a/packages/desktop/package.nix
+++ b/packages/desktop/package.nix
@@ -136,12 +136,33 @@ let
   );
 
   registryPort = "48732";
+
+  # The build sysroot is not the typecheck sysroot, and for one release the difference between them
+  # was decided by the FETCHER rather than by the tree.
+  #
+  # `vendor/electrobun` is a git submodule carrying the Electrobun SDK's TypeScript sources — what
+  # `packages/desktop/tsconfig.json` typechecks against, and what no phase below reads. Nothing here
+  # initialises it, so its CONTENT is absent either way. Its DIRECTORY is not: GitHub's tarball, the
+  # thing `github:jxsuite/jx/release` actually fetches, materialises the gitlink as an empty
+  # `vendor/electrobun`, while nix's git-tree source for a plain checkout — what CI builds — has no
+  # `vendor` entry at all. Two empty directories are still two NAR entries, so ONE commit produced
+  # TWO store paths: `671d1spz…` for the consumer, `sq57vgab…` for CI. The release pushed the second.
+  # `nix path-info` then found every byte of what was published and `nix build
+  # github:jxsuite/jx/release --max-jobs 0` still built from source, because the cache was complete
+  # at an address nobody asks for (#250, first release after the submodule landed).
+  #
+  # Filtering it states the invariant instead: `$out` is a function of the tree's CONTENT, not of how
+  # the tree arrived. The two trees are otherwise byte-identical — the NAR hash of the tarball source
+  # minus `vendor` equals the NAR hash of the checkout source exactly.
+  root = ../..;
+  src = lib.cleanSourceWith {
+    src = lib.cleanSource root;
+    filter = path: _type: path != "${toString root}/vendor";
+  };
 in
 stdenv.mkDerivation {
   pname = "jx-studio";
-  inherit version;
-
-  src = lib.cleanSource ../..;
+  inherit version src;
 
   nativeBuildInputs = [
     bun

--- a/packages/desktop/tests/electrobun-config.test.ts
+++ b/packages/desktop/tests/electrobun-config.test.ts
@@ -58,14 +58,15 @@ describe("electrobun config", () => {
  * go, and nothing else would ever tell us. When this fails: try deleting `packages/desktop` from
  * the root `exclude` and this package's tsconfig with it.
  */
-describe("the electrobun SDK's shipped types", () => {
-  /* Read as text, not JSON.parse: this tsconfig carries comments. Each paths entry is one line of
-     the form `"electrobun/main": ["../../vendor/electrobun/…"],`. */
-  const targets = readFileSync(resolve(desktopDir, "tsconfig.json"), "utf8")
-    .split(/\r?\n/)
-    .filter((line) => line.trimStart().startsWith('"electrobun'))
-    .flatMap((line) => [...line.matchAll(/"((?:\.\.?\/)[^"]+)"/g)].map((m) => m[1]!));
+/* Read as text, not JSON.parse: this tsconfig carries comments. Each paths entry is one line of
+   the form `"electrobun/main": ["../../vendor/electrobun/…"],`. Hoisted out of the describe below
+   because the Nix invariant at the bottom of this file is stated in terms of the same list. */
+const targets = readFileSync(resolve(desktopDir, "tsconfig.json"), "utf8")
+  .split(/\r?\n/)
+  .filter((line) => line.trimStart().startsWith('"electrobun'))
+  .flatMap((line) => [...line.matchAll(/"((?:\.\.?\/)[^"]+)"/g)].map((m) => m[1]!));
 
+describe("the electrobun SDK's shipped types", () => {
   /* These paths ARE the import, so a `.d.ts` target here would be the end of the carve-out even if
      the SDK still shipped sources everywhere else. */
   test("this package's own paths point at raw .ts", () => {
@@ -86,5 +87,45 @@ describe("the electrobun SDK's shipped types", () => {
         vendored: true,
       });
     }
+  });
+});
+
+// ─── Why the Nix derivation excludes the directory the tsconfig above requires ───────────────
+
+/*
+ * The submodule is the TYPECHECK sysroot. `package.nix` is the BUILD one, and it takes the whole
+ * repository as `src` — so every tracked path is part of the tree whose NAR hash IS the store path a
+ * `nix run github:jxsuite/jx/release` consumer resolves.
+ *
+ * `vendor/electrobun` is the one tracked path whose PRESENCE depends on how the tree was fetched
+ * rather than on what the commit says. GitHub's tarball materialises the gitlink as an empty
+ * directory; nix's git-tree source for a plain checkout omits it entirely. Nothing initialises the
+ * submodule on either path, so its CONTENT is absent both ways and no build phase notices — but two
+ * empty directories are still two NAR entries, and desktop-v5.0.0 therefore had TWO store paths for
+ * ONE commit. CI built and published `sq57vgab…`; every consumer asked for `671d1spz…`. The push
+ * reported success, `nix path-info` found every byte of what it sent, and the cache was useless
+ * (#250) — the first release after the submodule landed, and no release before it affected.
+ *
+ * So the two configs name the same directory for opposite reasons, and that pairing is the
+ * invariant: whatever `vendor/…` prefix the tsconfig resolves through, package.nix must exclude.
+ * Asserted here because nothing else would notice in time — nix.yml's publish leg now checks the
+ * built path against the one a consumer evaluates, but that runs during a release rather than on
+ * the pull request that breaks it.
+ */
+describe("the vendored SDK stays out of the Nix build sysroot", () => {
+  const nix = readFileSync(resolve(desktopDir, "package.nix"), "utf8");
+
+  test("package.nix excludes exactly the directory the typecheck paths resolve through", () => {
+    // `../../vendor/electrobun/…` → `vendor`, the top-level directory as package.nix sees it.
+    expect([...new Set(targets.map((target) => target.split("/")[2]))]).toEqual(["vendor"]);
+    expect(nix).toContain('filter = path: _type: path != "${toString root}/vendor";');
+  });
+
+  test("src is filtered rather than a bare cleanSource", () => {
+    /* `src = lib.cleanSource ../..;` is the form that shipped the divergence. The filter is the
+       whole fix, so a revert to the bare form would read like a simplification and is worth
+       failing on by name. */
+    expect(nix).toContain("lib.cleanSourceWith");
+    expect(nix).not.toMatch(/^\s*src = lib\.cleanSource \.\.\/\.\.;/m);
   });
 });


### PR DESCRIPTION
Closes #250.

## The report, and what was actually wrong

A NixOS user on `github:jxsuite/jx/release` builds Jx Studio from source instead of downloading it. `verify-cache` was right, and the cause is not what "the cache is missing a path" suggests — the path was pushed, successfully, to a different address than the one anybody asks for.

```
github:jxsuite/jx/release  ->  /nix/store/671d1spzalwpbwr9lcw1cx1fdzn6xmgv-jx-studio-5.0.0
the CI checkout            ->  /nix/store/sq57vgab50cb25ifvr8xcymvkfpwxdwf-jx-studio-5.0.0
```

Both reproduced locally with stock Nix, so this is not a Determinate/lazy-trees artefact.

`package.nix` takes the whole repository as `src`, so every tracked path is part of the tree whose NAR hash **is** the store path. `vendor/electrobun` is the one tracked path whose *presence* depends on how the tree was fetched rather than on what the commit says:

- GitHub's tarball — what the `github:` fetcher downloads — materialises the gitlink as an **empty directory**.
- nix's git-tree source for a plain `actions/checkout` **omits it entirely**.

The submodule is uninitialised either way, so its content is absent on both paths and no build phase notices. But two empty directories are still two NAR entries.

`diff -rq` between the two source trees reports exactly one difference — `Only in <tarball>: vendor` — and their NAR hashes are equal once it is removed:

```
github-src-minus-vendor: sha256-EEiGuFSebSspvAFxJMfyLGnwptV2vf713a1IWXNBbvs=
local-src              : sha256-EEiGuFSebSspvAFxJMfyLGnwptV2vf713a1IWXNBbvs=
```

## It is a regression, not a standing gap

The submodule landed in 66af6e64, **after** `desktop-v4.0.0`. Checked against the live cache:

| tag | consumer's path | cachix |
|---|---|---|
| `desktop-v3.0.1` | `5fppvcm3…` | 200 |
| `desktop-v4.0.0` | `g17ffj0l…` | 200 |
| `desktop-v5.0.0` | `671d1spz…` | **404** |

So the note in nix.yml stands: #161/#169/#172/#178/#190 really were phantoms from the merged-stderr bug. This one is the first true positive, and it dates precisely to the vendored-SDK PR.

## The change

**`packages/desktop/package.nix`** — `src` filters `vendor`. Stated declaratively: `$out` is a function of the tree's *content*, not of how the tree arrived. The build sysroot is not the typecheck sysroot.

Verified, not reasoned about — with the patch applied to both trees:

```
tarball tree (has vendor/)  -> /nix/store/bqjyhnw63qqb2r2bfscnixzpskj1nc28-jx-studio-5.0.0
checkout tree (no vendor/)  -> /nix/store/bqjyhnw63qqb2r2bfscnixzpskj1nc28-jx-studio-5.0.0
```

**`.github/workflows/nix.yml`** — the publish leg now asserts the built path equals what a consumer evaluates, *before* pushing. It stays inside the existing `continue-on-error` step, because the rationale written there still holds: a cache is an optimisation and must not fail the job `advance-release-branch` gates on. What changes is that the log names the cause — the symptom alone never could, which is why this took a release to understand.

`workflow_dispatch` also gains `publish`, so a release that shipped without a usable cache entry can be backfilled. Nothing else can close that gap: the tag is cut, and re-running release-please.yml does nothing once the pull request is labelled `autorelease: tagged`.

**`packages/desktop/tests/electrobun-config.test.ts`** — asserted beside the tsconfig `paths` that require the same directory for the opposite reason. Whatever `vendor/…` prefix the typecheck resolves through, package.nix must exclude. Both new tests were mutation-checked: they fail against the unpatched `package.nix`.

## Backfilling desktop-v5.0.0

This PR does not retroactively cache the shipped release — a consumer at the fixed commit asks for a different path anyway. Once merged, the next release publishes at the right address. To close the gap for the current one:

```sh
gh workflow run nix.yml --ref release -f publish=true
gh workflow run nix.yml --ref release -f publish=true -f runner=ubuntu-24.04-arm
```

## Verification

- `packages/desktop`: 762 pass, 0 fail; coverage manifest clean
- `bun run lint`, `bun run --cwd packages/desktop typecheck`, `bun run docs:markdown`, `bun run docs:sync`, `nixfmt --check`, `oxfmt --check` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJm1NoddNjWw2W23eHN21d