### PR TITLE
feat(runtime): @jxsuite/runtime/css, so composing a stylesheet costs no renderer

### DIFF
--- a/docs/framework/concepts/color-schemes.md
+++ b/docs/framework/concepts/color-schemes.md
@@ -6,6 +6,7 @@ spec:
   - spec.md#9.5
 code:
   - packages/runtime/src/runtime.ts
+  - packages/runtime/src/css.ts
   - packages/compiler/src/shared.ts
   - packages/compiler/src/site/site-build.ts
 ---

--- a/docs/framework/concepts/styling.md
+++ b/docs/framework/concepts/styling.md
@@ -5,6 +5,7 @@ spec:
   - spec.md#9
 code:
   - packages/runtime/src/runtime.ts
+  - packages/runtime/src/css.ts
   - packages/compiler/src/shared.ts
 ---
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "exports": {
     ".": "./src/runtime.ts",
+    "./css": "./src/css.ts",
     "./expression": "./src/expression.ts",
     "./pointer": "./src/pointer.ts",
     "./statements": "./src/statements.ts",

--- a/packages/runtime/src/css.ts
+++ b/packages/runtime/src/css.ts
@@ -1,0 +1,119 @@
+/**
+ * The CSS-authoring rules that are not the DOM.
+ *
+ * `@jxsuite/runtime` renders a document in a browser, and every consumer of its root export pays
+ * for that: the element registry, the reactive scope, `@vue/reactivity`. These six exports need
+ * none of it. They are pure string and regex math over what a `style` block MEANS — how a property
+ * name is spelled in CSS, which media query an `@`-key resolves to, and which selector pair a
+ * scheme-conditional rule dual-emits as.
+ *
+ * They are a subpath of their own because of who else needs them. `@jxsuite/site/site-style` turns
+ * `project.json`'s `style` into a stylesheet, and it runs in places the DOM runtime cannot go — a
+ * static build, and a Cloudflare Worker serving a live preview. Importing the root export for
+ * `camelToKebab` would put the whole renderer plus `@vue/reactivity` inside a Worker script for
+ * four pure functions.
+ *
+ * `./runtime` re-exports all of these, so nothing that already imported them from the root export
+ * has to change. This is a narrow door beside the wide one, not a replacement for it.
+ */
+
+/**
+ * Convert camelCase to kebab-case.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+export function camelToKebab(s: string) {
+  return s.replaceAll(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+}
+
+// ─── Style At-Rules ───────────────────────────────────────────────────────────
+
+/**
+ * The four CSS media types. A media _type_ is bare — `@media print` — while a media _feature_ is
+ * parenthesised, so `@media (print)` reads as a boolean feature named `print`, which does not exist
+ * and evaluates false.
+ */
+const MEDIA_TYPES = new Set(["all", "print", "screen", "speech"]);
+
+/**
+ * The media query an `@`-prefixed style key names, or null when the key is some other at-rule
+ * (`@supports`, `@starting-style`) that is emitted verbatim.
+ *
+ * `@--name` resolves through the project's `$media` map. `@(…)` carries its own parentheses, so
+ * they are stripped only when what they wrap is a bare media type: `@(print)` must become `@media
+ * print`, while `@(min-width: 40rem)` keeps them.
+ *
+ * @param {string} atKey
+ * @param {Record<string, string>} mediaQueries
+ * @returns {string | null}
+ * @docs framework/concepts/styling
+ */
+export function resolveAtQuery(atKey: string, mediaQueries: Record<string, string>): string | null {
+  if (atKey.startsWith("@--")) {
+    return mediaQueries[atKey.slice(1)] ?? atKey.slice(1);
+  }
+  if (atKey.startsWith("@(")) {
+    const inner = atKey.slice(2, -1).trim();
+    return MEDIA_TYPES.has(inner.toLowerCase()) ? inner : atKey.slice(1);
+  }
+  return null;
+}
+
+// ─── Color Schemes ────────────────────────────────────────────────────────────
+
+/**
+ * Attribute on the root element (`<html>`) that forces a color scheme. Absent = auto (follow the OS
+ * `prefers-color-scheme`). Values: "light" | "dark".
+ *
+ * @docs framework/concepts/color-schemes
+ */
+export const COLOR_SCHEME_ATTR = "data-color-scheme";
+
+/**
+ * The localStorage key a site switcher persists the visitor's forced scheme under; read by the
+ * compiler-injected pre-paint script. Values: "light" | "dark" (absent = auto).
+ *
+ * @docs framework/concepts/color-schemes
+ */
+export const COLOR_SCHEME_STORAGE_KEY = "jx-color-scheme";
+
+/**
+ * The scheme a _pure_ `prefers-color-scheme` media query targets. Compound queries (any other
+ * conditions attached) return null — they are not eligible for forced-scheme dual emission.
+ *
+ * @param {string} query
+ * @returns {"light" | "dark" | null}
+ * @docs framework/concepts/color-schemes
+ */
+export function pureSchemeOf(query: string): "light" | "dark" | null {
+  const m = /^\(\s*prefers-color-scheme\s*:\s*(light|dark)\s*\)$/.exec(query.trim());
+  return (m?.[1] as "light" | "dark") ?? null;
+}
+
+/**
+ * Selector pair for a scheme-conditional rule: `auto` applies inside the scheme's media query only
+ * while no scheme is forced; `forced` applies unconditionally when the root attribute forces the
+ * scheme. Guards are wrapped in `:where()` so specificity matches the unguarded selector and source
+ * order decides the cascade.
+ *
+ * @param {string} selector
+ * @param {"light" | "dark"} scheme
+ * @returns {{ auto: string; forced: string }}
+ * @docs framework/concepts/color-schemes
+ */
+export function schemeSelectors(
+  selector: string,
+  scheme: "light" | "dark",
+): { auto: string; forced: string } {
+  if (selector === ":root" || selector === "html") {
+    return {
+      auto: `${selector}:where(:not([${COLOR_SCHEME_ATTR}]))`,
+      forced: `${selector}:where([${COLOR_SCHEME_ATTR}="${scheme}"])`,
+    };
+  }
+  return {
+    auto: `:where(:root:not([${COLOR_SCHEME_ATTR}])) ${selector}`,
+    forced: `:where(:root[${COLOR_SCHEME_ATTR}="${scheme}"]) ${selector}`,
+  };
+}

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -23,6 +23,7 @@ import {
   ref,
   toRaw,
 } from "@vue/reactivity";
+import { camelToKebab, pureSchemeOf, resolveAtQuery, schemeSelectors } from "./css.ts";
 import { evaluateExpression, evaluateOperand, isMutating } from "./expression.ts";
 import { readPath } from "./pointer.ts";
 import type { DynamicClass, JxEventHandler, JxPath, JxRenderOptions, JxScope } from "./types.ts";
@@ -2559,15 +2560,19 @@ function mergeProps(def: JxElement, parentState: JxScope): JxScope {
   return child;
 }
 
-/**
- * Convert camelCase to kebab-case.
- *
- * @param {string} s
- * @returns {string}
+/*
+ * The CSS-authoring rules live in `./css.ts`, which imports nothing at all. They are re-exported
+ * here because they always were part of this module's surface and moving them must not break a
+ * consumer; a host that cannot afford the DOM runtime imports `@jxsuite/runtime/css` instead.
  */
-export function camelToKebab(s: string) {
-  return s.replaceAll(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
-}
+export {
+  camelToKebab,
+  COLOR_SCHEME_ATTR,
+  COLOR_SCHEME_STORAGE_KEY,
+  pureSchemeOf,
+  resolveAtQuery,
+  schemeSelectors,
+} from "./css.ts";
 
 /**
  * Convert a style rules object to a CSS text string (skipping nested selectors).
@@ -2580,97 +2585,6 @@ export function toCSSText(rules: Record<string, unknown> | object) {
     .filter(([k, v]) => !isNestedSelector(k) && (v === null || typeof v !== "object"))
     .map(([p, v]) => `${camelToKebab(p)}: ${canvasStyleValue(String(v))}`)
     .join("; ");
-}
-
-// ─── Style At-Rules ───────────────────────────────────────────────────────────
-
-/**
- * The four CSS media types. A media _type_ is bare — `@media print` — while a media _feature_ is
- * parenthesised, so `@media (print)` reads as a boolean feature named `print`, which does not exist
- * and evaluates false.
- */
-const MEDIA_TYPES = new Set(["all", "print", "screen", "speech"]);
-
-/**
- * The media query an `@`-prefixed style key names, or null when the key is some other at-rule
- * (`@supports`, `@starting-style`) that is emitted verbatim.
- *
- * `@--name` resolves through the project's `$media` map. `@(…)` carries its own parentheses, so
- * they are stripped only when what they wrap is a bare media type: `@(print)` must become `@media
- * print`, while `@(min-width: 40rem)` keeps them.
- *
- * @param {string} atKey
- * @param {Record<string, string>} mediaQueries
- * @returns {string | null}
- * @docs framework/concepts/styling
- */
-export function resolveAtQuery(atKey: string, mediaQueries: Record<string, string>): string | null {
-  if (atKey.startsWith("@--")) {
-    return mediaQueries[atKey.slice(1)] ?? atKey.slice(1);
-  }
-  if (atKey.startsWith("@(")) {
-    const inner = atKey.slice(2, -1).trim();
-    return MEDIA_TYPES.has(inner.toLowerCase()) ? inner : atKey.slice(1);
-  }
-  return null;
-}
-
-// ─── Color Schemes ────────────────────────────────────────────────────────────
-
-/**
- * Attribute on the root element (`<html>`) that forces a color scheme. Absent = auto (follow the OS
- * `prefers-color-scheme`). Values: "light" | "dark".
- *
- * @docs framework/concepts/color-schemes
- */
-export const COLOR_SCHEME_ATTR = "data-color-scheme";
-
-/**
- * The localStorage key a site switcher persists the visitor's forced scheme under; read by the
- * compiler-injected pre-paint script. Values: "light" | "dark" (absent = auto).
- *
- * @docs framework/concepts/color-schemes
- */
-export const COLOR_SCHEME_STORAGE_KEY = "jx-color-scheme";
-
-/**
- * The scheme a _pure_ `prefers-color-scheme` media query targets. Compound queries (any other
- * conditions attached) return null — they are not eligible for forced-scheme dual emission.
- *
- * @param {string} query
- * @returns {"light" | "dark" | null}
- * @docs framework/concepts/color-schemes
- */
-export function pureSchemeOf(query: string): "light" | "dark" | null {
-  const m = /^\(\s*prefers-color-scheme\s*:\s*(light|dark)\s*\)$/.exec(query.trim());
-  return (m?.[1] as "light" | "dark") ?? null;
-}
-
-/**
- * Selector pair for a scheme-conditional rule: `auto` applies inside the scheme's media query only
- * while no scheme is forced; `forced` applies unconditionally when the root attribute forces the
- * scheme. Guards are wrapped in `:where()` so specificity matches the unguarded selector and source
- * order decides the cascade.
- *
- * @param {string} selector
- * @param {"light" | "dark"} scheme
- * @returns {{ auto: string; forced: string }}
- * @docs framework/concepts/color-schemes
- */
-export function schemeSelectors(
-  selector: string,
-  scheme: "light" | "dark",
-): { auto: string; forced: string } {
-  if (selector === ":root" || selector === "html") {
-    return {
-      auto: `${selector}:where(:not([${COLOR_SCHEME_ATTR}]))`,
-      forced: `${selector}:where([${COLOR_SCHEME_ATTR}="${scheme}"])`,
-    };
-  }
-  return {
-    auto: `:where(:root:not([${COLOR_SCHEME_ATTR}])) ${selector}`,
-    forced: `:where(:root[${COLOR_SCHEME_ATTR}="${scheme}"]) ${selector}`,
-  };
 }
 
 // ─── Custom Element Registration ──────────────────────────────────────────────

--- a/packages/runtime/tests/css.test.ts
+++ b/packages/runtime/tests/css.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `@jxsuite/runtime/css` exists to be importable where the DOM runtime is not.
+ *
+ * Its behaviour is covered by `runtime.test.ts`, which reaches all six exports through the root
+ * re-export. What is asserted here is the property that made it a subpath in the first place, and
+ * which no behavioural test can see: that importing it costs nothing. A single `import` added to
+ * `css.ts` — a type from `./types.ts`, a helper from `./runtime.ts` — would put the renderer and
+ * `@vue/reactivity` back inside every Worker that composes a stylesheet, and every test here would
+ * still pass.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import * as css from "../src/css.ts";
+
+const SOURCE = readFileSync(join(import.meta.dirname, "../src/css.ts"), "utf8");
+
+/** The source with comments removed — `localStorage` and the DOM are named in prose throughout. */
+const CODE = SOURCE.replaceAll(/\/\*[\s\S]*?\*\//g, "").replaceAll(/\/\/[^\n]*/g, "");
+
+describe("the module has no dependencies at all", () => {
+  test("it imports nothing, from anywhere", () => {
+    const imports = [
+      ...CODE.matchAll(/(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*)["']([^"']+)["']/g),
+    ].map((m) => m[1]);
+    expect({
+      imports,
+      why: "this subpath exists so a Worker can compose a stylesheet without the DOM runtime",
+    }).toEqual({
+      imports: [],
+      why: "this subpath exists so a Worker can compose a stylesheet without the DOM runtime",
+    });
+  });
+
+  test("it names no DOM or platform global", () => {
+    // Pure string and regex math. A `document` here would throw in workerd rather than degrade.
+    for (const global of ["document.", "window.", "navigator.", "localStorage", "process."]) {
+      expect({ global, present: CODE.includes(global) }).toEqual({ global, present: false });
+    }
+  });
+});
+
+describe("the subpath carries what @jxsuite/site/site-style needs", () => {
+  test("all six exports are present", () => {
+    // A move that dropped one would surface as a build failure three packages away.
+    expect(Object.keys(css).toSorted()).toEqual([
+      "COLOR_SCHEME_ATTR",
+      "COLOR_SCHEME_STORAGE_KEY",
+      "camelToKebab",
+      "pureSchemeOf",
+      "resolveAtQuery",
+      "schemeSelectors",
+    ]);
+  });
+
+  test("the root export still answers for every one of them", async () => {
+    /* Moving these must not be a breaking change: the compiler and the studio both import
+       camelToKebab from "@jxsuite/runtime", and canvas-media imports pureSchemeOf. */
+    const root = (await import("../src/runtime.ts")) as Record<string, unknown>;
+    for (const name of Object.keys(css)) {
+      expect({ name, same: root[name] === (css as Record<string, unknown>)[name] }).toEqual({
+        name,
+        same: true,
+      });
+    }
+  });
+});

--- a/packages/site/src/site-style.ts
+++ b/packages/site/src/site-style.ts
@@ -13,7 +13,7 @@
  * origin, which passes identity because a browser tab IS the viewport.
  */
 
-import { pureSchemeOf, resolveAtQuery, schemeSelectors, camelToKebab } from "@jxsuite/runtime";
+import { camelToKebab, pureSchemeOf, resolveAtQuery, schemeSelectors } from "@jxsuite/runtime/css";
 
 /** Id of the injected site-style tag (replace-in-place, never accumulate). */
 export const SITE_STYLE_ID = "jx-site-style";


### PR DESCRIPTION
## Why

`@jxsuite/site/site-style` turns a project's `style` block into a stylesheet, and it runs in places the DOM runtime cannot go — a static build, and a Cloudflare Worker serving a live preview. It needed four pure functions (`camelToKebab`, `resolveAtQuery`, `pureSchemeOf`, `schemeSelectors`) and they lived in the runtime's **root** export, which is the whole renderer plus `@vue/reactivity`.

That is why jx-platform's cloud preview ships **no site stylesheet at all**: taking the one import it needed would have put the browser runtime inside a Worker script. The desktop dev server pays that cost happily because it is a Bun process; a Worker cannot.

## What

The six CSS-authoring exports move to `packages/runtime/src/css.ts`, which **imports nothing**. They were always pure string and regex math over what a `style` block means — nothing about them was ever about the DOM.

`./runtime` re-exports all six, so this is purely additive: `packages/compiler` and `packages/studio` keep importing `camelToKebab` and `pureSchemeOf` from `"@jxsuite/runtime"` and neither had to change. New `"./css"` subpath in the export map.

## The test asserts the property, not the behaviour

`runtime.test.ts` already covers all six through the re-export (`css.ts` lands at 100/100 without a new behavioural test). What `tests/css.test.ts` adds is the thing that justifies the subpath and that no behavioural test can see: **that the module imports nothing and names no platform global.** A single import added later would put the renderer back inside every Worker composing a stylesheet, and every behavioural test would still pass.

## Verification

| Workspace | Result |
| --- | --- |
| `packages/runtime` | 645 pass |
| `packages/site` | 224 pass |
| `packages/compiler` | 1371 pass |
| `packages/studio` | 9805 pass |

`tsc`, `oxlint`, `oxlint --type-aware`, `oxfmt --check`, `docs:check` and `docs:markdown` all green. Coverage floors untouched in both affected workspaces (`statements.ts` at 95.0 lines and `runtime.ts` at 97.66 funcs still pin `packages/runtime`), so no ratchet is owed.

## Specs & docs

Pure refactor — `docs:sync` flags `runtime.ts`, and no page needs updating: the exports, their signatures and their behaviour are identical. The two pages whose `@docs` tags travelled with the code (`framework/concepts/color-schemes`, `framework/concepts/styling`) gain `packages/runtime/src/css.ts` in their `code:` frontmatter, so a future change there still triggers the sync check. No spec section changed.

## Follow-up

Once this releases, jx-platform can pass `ShellOptions.styleUrl` and its cloud preview stops rendering unstyled. That change is prepared in jxsuite/platform and is waiting only on the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)