### PR TITLE
feat(parser,schema,server): a format may declare rewrite, repairing a reference a CSV row names

### DIFF
--- a/docs/extending/extensions/formats.md
+++ b/docs/extending/extensions/formats.md
@@ -80,16 +80,38 @@ Everything else keeps whatever the host already decided. This list corrects a lo
 
 ## Format capabilities
 
-The block declares _what_ the class handles; the class's [capability methods](/docs/extending/extensions/capabilities) declare _how_. Four roles belong to the `format` block:
+The block declares _what_ the class handles; the class's [capability methods](/docs/extending/extensions/capabilities) declare _how_. Five roles belong to the `format` block:
 
 | Role        | Signature                                                     | Consumers                                   |
 | ----------- | ------------------------------------------------------------- | ------------------------------------------- |
 | `parse`     | `(source, options?) → JxDocument`                             | compiler, server, Studio (open file)        |
 | `serialize` | `(doc, options?) → string`                                    | Studio (save), site build (export sidecars) |
+| `rewrite`   | `(source, edits) → string`                                    | the rename refactor (repair a reference)    |
 | `discover`  | `(source, { baseDir }) → string[]`                            | content loading (list entry files)          |
 | `load`      | `(path, { schema, directiveOptions }) → ContentLoaderEntry[]` | content loading (parse one source)          |
 
 A format implements the subset it needs: a read-only format can ship `parse` without `serialize` (Studio then opens files in this format read-only in structural modes); a data-only format like `Csv` needs `discover`/`load` but has no reason to be a page format.
+
+### `rewrite`: repairing a reference without round-tripping
+
+`serialize` promises a lot: that a parsed document turns back into source your author would recognize. A data format often cannot promise it. Re-emitting a CSV means picking a quoting style, a line ending and a column order the author already picked, and the loader has no opinion about any of them.
+
+But a rename does not need a document back. It needs one cell's text changed. That is what `rewrite` is:
+
+```ts
+static rewrite(source: string, edits: readonly { from: string; to: string }[]): string
+```
+
+You are handed the file's own text and a list of authored values to replace, and you return the text with exactly those values replaced and every other byte preserved. Two rules make it safe:
+
+- **Match whole values, never substrings.** `hero.jpg` must not rewrite the middle of `my-hero.jpg`.
+- **Change nothing else.** Padding, quoting and line endings are the author's.
+
+Declare it and the rename refactor repairs references living in your format instead of reporting them as something the author has to fix by hand. Declare both and the refactor prefers `serialize`, because a full round trip can express a change a list of value edits cannot, such as renaming a custom-element tag.
+
+:::doc-note
+`rewrite` is not a weaker `serialize`, and the two are not ranked. Declare either, both, or neither. Only `serialize` makes your format creatable and convertible in Studio; `rewrite` earns nothing but the refactor, which is exactly what a load-only format wants.
+:::
 
 The `Markdown` class implements all four, plus the standard instance `resolve()`, so `{ "$prototype": "Markdown", "src": "./about.md" }` works as runtime state, satisfying the same [external class contract](/docs/extending/extensions/classes) as every other class.
 
@@ -144,7 +166,8 @@ names, so a format extension reaches both by declaring them:
   `parse` and `serialize` for it. Both are needed: without `parse` the file cannot be opened after
   it is created, and without `serialize` its first save falls through to another format and writes
   that format's bytes into it. (This is why the parser extension's `Csv`, which parses rows and has
-  no serializer, is not offered; a `.csv` is still creatable through the picker's **Other…** row.)
+  no serializer, is not offered; a `.csv` is still creatable through the picker's **Other…** row.
+  `Csv` declares `rewrite` instead, which buys it the refactor and not this picker.)
 - **Convert Format…** offers your format as a conversion endpoint when it declares both capabilities
   **and** `page` or `component` in `documentKinds`. That membership is what says `parse` returns a
   Jx document rather than content entries, and the compiler already relies on it to build its page

--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -18,18 +18,18 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `collab.md`               | 0.2.5-draft  | Partial     | 2026-08-20 |
 | `compiler.md`             | 0.4.1-draft  | Partial     | 2026-08-27 |
 | `desktop.md`              | 0.4.8-draft  | Pending     | 2026-08-28 |
-| `extensions.md`           | 0.4.1-draft  | Partial     | 2026-08-27 |
+| `extensions.md`           | 0.4.2-draft  | Partial     | 2026-08-29 |
 | `imports.md`              | 0.1.10-draft | Partial     | 2026-08-27 |
 | `jx-markdown.md`          | 0.1.9-draft  | Partial     | 2026-08-27 |
 | `parser.md`               | 0.2.10-draft | Partial     | 2026-08-27 |
 | `relationships.md`        | 0.1.4-draft  | Partial     | 2026-08-15 |
 | `schema.md`               | 0.4.8-draft  | Partial     | 2026-08-16 |
 | `server.md`               | 0.2.21       | Implemented | 2026-08-27 |
-| `site-architecture.md`    | 0.6.5-draft  | Partial     | 2026-08-29 |
+| `site-architecture.md`    | 0.6.6-draft  | Partial     | 2026-08-29 |
 | `spec.md`                 | 0.5.8-draft  | Partial     | 2026-08-26 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |
 | `studio-ui-guidelines.md` | 0.3.16       | Implemented | 2026-08-27 |
-| `studio.md`               | 0.10.1-draft | Partial     | 2026-08-28 |
+| `studio.md`               | 0.10.2-draft | Partial     | 2026-08-29 |
 
 ## Sections not yet implemented
 

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -131,6 +131,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `extensions.md`
 
+- **0.4.2-draft** (2026-08-29) — A format may declare rewrite: replace authored values in its own source text, for a format that is read but never round-tripped.
 - **0.4.1-draft** (2026-08-27) — Studio conversion and creation are parse/serialize consumers; what parse returns is decided by documentKinds.
 - **0.4.0-draft** (2026-08-26) — §8.4: an emitter must not emit the same content twice — the search index carries page preamble plus sections, not the corpus twice.
 - **0.3.11-draft** (2026-08-25) — §8.5: record that a host which cannot execute extension code sees only content-section mounts.
@@ -278,6 +279,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `site-architecture.md`
 
+- **0.6.6-draft** (2026-08-29) — A reference inside a format that cannot round-trip is repaired through the rewrite capability rather than reported as a remainder.
 - **0.6.5-draft** (2026-08-29) — A copy map's keys and a directory content source are references the engine reads by name; a copy destination is not, and a rewritten reference keeps its trailing slash.
 - **0.6.4-draft** (2026-08-27) — Record that collection discovery is recursive, so a subdirectory holds entries as well as co-located media.
 - **0.6.3-draft** (2026-08-27) — Reference resolution through the asset lanes is the refactor engine's contract, in both directions: a rooted ref is counted through every lane, rewritten through the lanes a build publishes, and named in the report when it cannot be written.
@@ -474,6 +476,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `studio.md`
 
+- **0.10.2-draft** (2026-08-29) — A format declaring rewrite rather than serialize has its references repaired by the rename refactor, so it is no longer a reported remainder.
 - **0.10.1-draft** (2026-08-28) — studioShellHtml() now links a favicon for hosts whose window chrome has no native icon of its own.
 - **0.10.0-draft** (2026-08-27) — New File chooses a format rather than an extension (Other... preserves arbitrary names); a document converts between formats in place; creating in a collection source routes to New Entry.
 - **0.9.53-draft** (2026-08-27) — A rename or drag-move whose refactor report names references it could not rewrite reports a warning, not a plain success; a drag-move invalidates the usage cache like its siblings.

--- a/docs/studio/projects/media.md
+++ b/docs/studio/projects/media.md
@@ -123,7 +123,7 @@ A count Studio could not produce is reported as **unknown**, never as zero. If t
 Studio finds those references wherever they are written. An image is referenced as a site URL (`/images/hero.jpg`), and the same file might be named by a page's `src`, by a component property you filled in on the canvas, by a content entry's front matter, or by the social card in your project settings. All of them count, and all of them are rewritten when the file moves. If the file leaves `public/`, the rewritten reference follows it, and Studio picks the form the published site will actually serve.
 
 :::doc-note
-Some files can be read but not written back. A CSV collection is a data source Studio loads entries from, not a document it round-trips. A reference in one still counts toward what a delete breaks, and a rename that could not update it reports a **warning** naming the file rather than a plain success. The same applies when you drag a file to a new folder.
+A CSV collection is a data source Studio loads entries from, not a document it round-trips, so it is never rewritten wholesale. A reference in one is still repaired: Studio replaces that cell's text and leaves the rest of the file exactly as you wrote it. Where a reference genuinely cannot be updated (a file that will not parse), the rename reports a **warning** naming the file rather than a plain success. The same applies when you drag a file to a new folder.
 :::
 
 ## What the build does to images

--- a/docs/studio/projects/pages-layouts-components.md
+++ b/docs/studio/projects/pages-layouts-components.md
@@ -73,7 +73,7 @@ Renaming a **folder** counts too. If a content collection's `source` points at t
 If Studio cannot count (a backend without project search), the confirmation says so rather than showing a zero. "We could not check" and "nothing uses this" are never displayed as the same thing.
 
 :::doc-note
-A handful of files can be read but not written back: a CSV content collection, for instance, is a data source Studio loads entries from rather than a document it round-trips. A reference living in one still counts toward what a delete would break, and a rename that could not update it says so, reporting a **warning** that names the files instead of a plain "Renamed", so you know where to look. Dragging a file to a new folder in the Files panel does the same refactor, and reports the same way, as does converting one to another format.
+A CSV content collection is a data source Studio loads entries from rather than a document it round-trips, so it is never rewritten wholesale. A reference inside one is still repaired: Studio replaces that cell's text and leaves the rest of the file byte for byte as you wrote it, quoting and line endings included. Where a reference genuinely cannot be updated (a file that will not parse), the rename says so, reporting a **warning** that names the files instead of a plain "Renamed", so you know where to look. Dragging a file to a new folder in the Files panel does the same refactor, and reports the same way, as does converting one to another format.
 :::
 
 ## Which one do I want?

--- a/examples/document.schema.json
+++ b/examples/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/extensions/parser/src/Csv.class.json
+++ b/extensions/parser/src/Csv.class.json
@@ -115,6 +115,37 @@
         "returnType": { "$ref": "#/$defs/returnTypes/ContentLoaderEntries" },
         "description": "Parse CSV text into typed content entries (pure, browser-safe)"
       },
+      "rewrite": {
+        "role": "rewrite",
+        "$prototype": "Function",
+        "access": "public",
+        "scope": "static",
+        "identifier": "rewrite",
+        "timing": ["compiler", "server", "client"],
+        "parameters": [
+          {
+            "identifier": "source",
+            "type": { "type": "string" },
+            "description": "Raw CSV text"
+          },
+          {
+            "identifier": "edits",
+            "type": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": { "type": "string" },
+                  "to": { "type": "string" }
+                }
+              }
+            },
+            "description": "Authored cell values to replace, matched whole against a data cell"
+          }
+        ],
+        "returnType": { "type": "string" },
+        "description": "Replace authored cell values in CSV source text, preserving every other byte"
+      },
       "discover": {
         "role": "discover",
         "$prototype": "Function",

--- a/extensions/parser/src/csv.ts
+++ b/extensions/parser/src/csv.ts
@@ -2,9 +2,14 @@
  * Csv — CSV content format for Jx
  *
  * RFC 4180-style CSV parsing with schema-driven type coercion, packaged as a Jx
- * format-extension class. `parse` is pure and browser-safe; `discover`, `load`, and
+ * format-extension class. `parse` and `rewrite` are pure and browser-safe; `discover`, `load`, and
  * instance `resolve` touch the filesystem (or fetch remote URLs) and dynamically
  * import node modules so the module itself stays importable in the browser.
+ *
+ * There is no `serialize`, and there will not be one: a collection is a data source entries are
+ * loaded FROM, and re-emitting one would mean choosing a quoting style, a line ending and a column
+ * order the author already chose. `rewrite` is the narrower promise that covers the case that
+ * actually needed it — a rename repairing a reference a row names (specs/extensions.md §8).
  *
  * @module @jxsuite/parser/csv
  * @license MIT
@@ -90,6 +95,164 @@ export function parseCSV(csv: string): Record<string, string>[] {
   return rows;
 }
 
+// ─── Cell-level rewriting ────────────────────────────────────────────────────
+
+/** One authored value to replace, wherever a data cell holds exactly it. */
+export interface CsvEdit {
+  /** The cell value as `parse` produced it — unquoted and trimmed. */
+  from: string;
+  /** What to write in its place. */
+  to: string;
+}
+
+/** One field of a CSV source: where its bytes are, and what {@link parseCSV} made of it. */
+interface CsvField {
+  /** Row index in the source. Row 0 is the header. */
+  row: number;
+  /** Offsets of the field's raw text within the source, delimiting commas excluded. */
+  start: number;
+  end: number;
+  /** The value {@link parseCSV} produces for it — unquoted and trimmed. */
+  value: string;
+}
+
+/**
+ * Row spans, splitting on newlines that are not inside quotes.
+ *
+ * A deliberate mirror of {@link parseCSV}'s first pass, offsets instead of text: the two must agree
+ * on where a row ends or a rewrite would splice into the wrong cell. The accumulated text there is
+ * exactly `source.slice(start, end)` here, because the only characters that pass are contiguous.
+ */
+function scanRows(csv: string): { start: number; end: number }[] {
+  const rows: { start: number; end: number }[] = [];
+  let start = 0;
+  let inQuotes = false;
+  for (let i = 0; i < csv.length; i++) {
+    const ch = csv[i];
+    if (ch === '"') {
+      if (inQuotes && csv[i + 1] === '"') {
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if ((ch === "\n" || (ch === "\r" && csv[i + 1] === "\n")) && !inQuotes) {
+      rows.push({ end: i, start });
+      if (ch === "\r") {
+        i += 1;
+      }
+      start = i + 1;
+    }
+  }
+  // The same test {@link parseCSV} applies to its final accumulated row, which is exactly this
+  // Slice: a trailing newline leaves whitespace behind, and that is not a row.
+  if (csv.slice(start).trim()) {
+    rows.push({ end: csv.length, start });
+  }
+  return rows;
+}
+
+/** Field spans within one row, mirroring {@link parseCSV}'s second pass. */
+function scanRowFields(csv: string, row: number, span: { start: number; end: number }): CsvField[] {
+  const line = csv.slice(span.start, span.end);
+  const fields: CsvField[] = [];
+  let fieldStart = 0;
+  let value = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        value += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      fields.push({
+        end: span.start + i,
+        row,
+        start: span.start + fieldStart,
+        value: value.trim(),
+      });
+      value = "";
+      fieldStart = i + 1;
+    } else {
+      value += ch;
+    }
+  }
+  fields.push({ end: span.end, row, start: span.start + fieldStart, value: value.trim() });
+  return fields;
+}
+
+/** Every field of a CSV source in document order, with the offsets a splice needs. */
+function scanFields(csv: string): CsvField[] {
+  return scanRows(csv).flatMap((span, row) => scanRowFields(csv, row, span));
+}
+
+/**
+ * Write `value` into the space a field's raw text occupied, keeping that field's own conventions.
+ *
+ * Padding survives because it is the author's, and quoting survives for the same reason — a column
+ * written `"a","b"` stays quoted even when the new value would not need it. A value that WOULD be
+ * misread unquoted (a comma, a quote, a newline, or padding of its own) is quoted regardless, which
+ * is the only case where the output style is not simply the input's.
+ */
+function encodeField(raw: string, value: string): string {
+  const lead = raw.slice(0, raw.length - raw.trimStart().length);
+  const trail = raw.slice(raw.trimEnd().length);
+  const core = raw.trim();
+  const wasQuoted = core.length >= 2 && core.startsWith('"') && core.endsWith('"');
+  const mustQuote = /["\r\n,]/.test(value) || value.trim() !== value;
+  return lead + (wasQuoted || mustQuote ? `"${value.replaceAll('"', '""')}"` : value) + trail;
+}
+
+/**
+ * Replace authored cell values in CSV source text, preserving every other byte.
+ *
+ * The `rewrite` capability (specs/extensions.md §8), and deliberately narrower than `serialize`. A
+ * CSV collection is a data source entries are loaded FROM, not a document Jx round-trips, so it has
+ * no serializer and never will — quoting style, line endings and column order are the author's and
+ * the loader has no opinion about any of them. But the rename refactor does not need a document
+ * back; it needs one cell's text changed. Without that, renaming a file a CSV row names updated
+ * every other reference and reported this one as a remainder the author had to repair by hand
+ * (issue 246).
+ *
+ * Matching is on the WHOLE cell value as {@link parseCSV} produced it, never on a substring:
+ * `hero.jpg` must not rewrite the middle of `my-hero.jpg`. The HEADER row is never touched — it
+ * names columns rather than files, `parse` does not expose it as a value, and an edit derived from
+ * `parse` output therefore cannot legitimately name it.
+ *
+ * @param source — the CSV file's original text
+ * @param edits — authored values to replace
+ * @returns The source with exactly those cells rewritten
+ */
+export function rewriteCSV(source: string, edits: readonly CsvEdit[]): string {
+  const replacements = new Map<string, string>();
+  for (const edit of edits) {
+    if (edit.from !== edit.to) {
+      replacements.set(edit.from, edit.to);
+    }
+  }
+  if (replacements.size === 0) {
+    return source;
+  }
+  let out = "";
+  let cursor = 0;
+  for (const field of scanFields(source)) {
+    if (field.row === 0) {
+      continue;
+    }
+    const to = replacements.get(field.value);
+    if (to === undefined) {
+      continue;
+    }
+    out += source.slice(cursor, field.start);
+    out += encodeField(source.slice(field.start, field.end), to);
+    cursor = field.end;
+  }
+  return out + source.slice(cursor);
+}
+
 // ─── Type coercion ───────────────────────────────────────────────────────────
 
 export interface CsvOptions {
@@ -169,6 +332,18 @@ export class Csv {
   /** Parse CSV source text into content entries (pure, browser-safe). */
   static parse(source: string, options: CsvOptions = {}): ContentLoaderEntry[] {
     return coerceCSVRows(parseCSV(source), options.schema, options.idField);
+  }
+
+  /**
+   * Replace authored cell values, preserving every other byte (pure, browser-safe).
+   *
+   * The `rewrite` capability. Csv declares it and deliberately declares no `serialize`: rows are
+   * loaded, not round-tripped, so there is no document to write back — but one cell's text can be
+   * changed without inventing an opinion about quoting, line endings or column order. See
+   * {@link rewriteCSV}.
+   */
+  static rewrite(source: string, edits: readonly CsvEdit[] = []): string {
+    return rewriteCSV(source, edits);
   }
 
   /** List .csv entry files for a content-type source (file path or directory). */

--- a/extensions/parser/tests/csv.test.ts
+++ b/extensions/parser/tests/csv.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { Csv, coerceCSVRows, parseCSV } from "../src/csv";
+import { Csv, coerceCSVRows, parseCSV, rewriteCSV } from "../src/csv";
 
 const TMP = resolve(import.meta.dir, "__test-csv__");
 
@@ -144,5 +144,81 @@ describe("Csv.discover / Csv.load / resolve", () => {
     const entries = await csv.resolve();
     expect(entries.length).toBe(1);
     expect(entries[0]!.data.name).toBe("Widget");
+  });
+});
+
+/*
+ * The `rewrite` capability, which exists because a CSV collection has a parser and deliberately no
+ * serializer (issue 246). Everything here is a byte-level assertion on purpose: the whole promise
+ * is that a rename changes one cell and leaves the file otherwise untouched, and a test comparing
+ * parsed rows would pass while the quoting, the padding and the line endings were all rewritten.
+ */
+describe("rewriteCSV", () => {
+  const SRC =
+    "Title,slug,image\r\n" +
+    'Cedar Lane,"cedar-lane",/images/listing-1.jpg\r\n' +
+    "Harbor View,harbor-view, /images/listing-1.jpg \r\n" +
+    "Lakeview,lakeview,/images/listing-10.jpg\r\n";
+
+  test("replaces every data cell holding the value, preserving quoting, padding and CRLF", () => {
+    const out = rewriteCSV(SRC, [{ from: "/images/listing-1.jpg", to: "/images/villa.jpg" }]);
+    expect(out).toBe(
+      "Title,slug,image\r\n" +
+        'Cedar Lane,"cedar-lane",/images/villa.jpg\r\n' +
+        "Harbor View,harbor-view, /images/villa.jpg \r\n" +
+        "Lakeview,lakeview,/images/listing-10.jpg\r\n",
+    );
+  });
+
+  test("matches the whole cell, never a substring", () => {
+    // `/images/listing-1.jpg` is a prefix of `/images/listing-10.jpg`. A textual replace would
+    // Corrupt the third row into `/images/villa.jpg0.jpg`.
+    const out = rewriteCSV(SRC, [{ from: "/images/listing-1.jpg", to: "/images/villa.jpg" }]);
+    expect(out).toContain("/images/listing-10.jpg");
+  });
+
+  test("never rewrites the header row", () => {
+    // The header names columns, not files. `parse` does not expose it as a value, so an edit
+    // Derived from parse output cannot legitimately name it — and renaming a column would be a
+    // Data-loss bug wearing a rename's clothes.
+    expect(rewriteCSV(SRC, [{ from: "image", to: "photo" }])).toBe(SRC);
+  });
+
+  test("a value that would be misread unquoted is quoted, and quotes inside it are doubled", () => {
+    const out = rewriteCSV("a,b\nx,hero.jpg\n", [{ from: "hero.jpg", to: 'my, "big" hero.jpg' }]);
+    expect(out).toBe('a,b\nx,"my, ""big"" hero.jpg"\n');
+  });
+
+  test("a cell that was quoted stays quoted even when it no longer needs to be", () => {
+    const out = rewriteCSV('a,b\nx,"hero, one.jpg"\n', [{ from: "hero, one.jpg", to: "hero.jpg" }]);
+    expect(out).toBe('a,b\nx,"hero.jpg"\n');
+  });
+
+  test("a quoted cell spanning a newline is one cell, and its row indexing survives", () => {
+    const src = 'a,b\n"line\none",hero.jpg\nz,other.jpg\n';
+    expect(rewriteCSV(src, [{ from: "hero.jpg", to: "villa.jpg" }])).toBe(
+      'a,b\n"line\none",villa.jpg\nz,other.jpg\n',
+    );
+  });
+
+  test("no matching cell, a no-op edit, and an empty edit list all return the source unchanged", () => {
+    expect(rewriteCSV(SRC, [{ from: "/images/nothing.jpg", to: "/x.jpg" }])).toBe(SRC);
+    expect(rewriteCSV(SRC, [{ from: "/images/listing-1.jpg", to: "/images/listing-1.jpg" }])).toBe(
+      SRC,
+    );
+    expect(rewriteCSV(SRC, [])).toBe(SRC);
+  });
+
+  test("a file with no trailing newline, and one with only a header, are both handled", () => {
+    expect(rewriteCSV("a,b\nx,hero.jpg", [{ from: "hero.jpg", to: "villa.jpg" }])).toBe(
+      "a,b\nx,villa.jpg",
+    );
+    expect(rewriteCSV("a,b\n", [{ from: "a", to: "z" }])).toBe("a,b\n");
+    expect(rewriteCSV("", [{ from: "a", to: "z" }])).toBe("");
+  });
+
+  test("Csv.rewrite is the capability entry point and defaults to no edits", () => {
+    expect(Csv.rewrite(SRC, [{ from: "/images/listing-1.jpg", to: "/x.jpg" }])).toContain("/x.jpg");
+    expect(Csv.rewrite(SRC)).toBe(SRC);
   });
 });

--- a/packages/schema/class-schema.json
+++ b/packages/schema/class-schema.json
@@ -105,7 +105,7 @@
       "type": "object"
     },
     "ClassMethodDef": {
-      "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+      "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
       "properties": {
         "$prototype": {
           "const": "Function",
@@ -175,6 +175,7 @@
             "accessor",
             "parse",
             "serialize",
+            "rewrite",
             "discover",
             "load",
             "projectData",

--- a/packages/schema/defs/class-def.schema.ts
+++ b/packages/schema/defs/class-def.schema.ts
@@ -9,6 +9,7 @@ export const CLASS_METHOD_ROLES = [
   "accessor",
   "parse",
   "serialize",
+  "rewrite",
   "discover",
   "load",
   "projectData",
@@ -96,7 +97,7 @@ export const classConstructorDefSchema = {
 
 export const classMethodDefSchema = {
   description:
-    "A class method or accessor definition. Capability roles (parse, serialize, discover, load) " +
+    "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) " +
     "mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
   properties: {
     $prototype: { const: "Function", type: "string" },

--- a/packages/schema/schema.json
+++ b/packages/schema/schema.json
@@ -562,7 +562,7 @@
       "type": "object"
     },
     "ClassMethodDef": {
-      "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+      "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
       "properties": {
         "$prototype": {
           "const": "Function",
@@ -632,6 +632,7 @@
             "accessor",
             "parse",
             "serialize",
+            "rewrite",
             "discover",
             "load",
             "projectData",

--- a/packages/schema/src/format-registry.ts
+++ b/packages/schema/src/format-registry.ts
@@ -12,11 +12,12 @@
 
 import { mediaTypeEssence, mediaTypeProblem } from "./media-type";
 
-export type FormatCapability = "parse" | "serialize" | "discover" | "load";
+export type FormatCapability = "parse" | "serialize" | "rewrite" | "discover" | "load";
 
 export const FORMAT_CAPABILITIES: readonly FormatCapability[] = [
   "parse",
   "serialize",
+  "rewrite",
   "discover",
   "load",
 ];
@@ -27,6 +28,13 @@ export const FORMAT_CAPABILITIES: readonly FormatCapability[] = [
  * asset emission (`emit`), `<head>` contribution (`head`), static asset mounts (`assets`),
  * server-mount (`mount`), and connector (`dialect`, `deploySchema`, `bindings`, `testConnection`)
  * roles.
+ *
+ * `rewrite` is the narrow sibling of `serialize`, and the two are not ranked: a format may declare
+ * either, both or neither. `serialize` says "this document round-trips through me"; `rewrite` says
+ * only "I can replace these authored values in my own source text and change nothing else". A
+ * load-only format — a CSV collection is read to load entries, never re-emitted as a document — can
+ * honestly promise the second and not the first, which is enough for a rename to repair a reference
+ * living inside it (specs/extensions.md §8).
  */
 export type ExtensionCapability =
   | FormatCapability

--- a/packages/schema/tests/schema.test.ts
+++ b/packages/schema/tests/schema.test.ts
@@ -137,6 +137,7 @@ describe("generateClassSchema", () => {
       "accessor",
       "parse",
       "serialize",
+      "rewrite",
       "discover",
       "load",
       "projectData",

--- a/packages/server/src/refactor/apply.ts
+++ b/packages/server/src/refactor/apply.ts
@@ -122,7 +122,7 @@ export async function applyRename(opts: ApplyRenameOptions): Promise<RenameRepor
     }
     const fp = fwd(resolve(opts.root, match));
     try {
-      const { doc, serialize } = await loadDoc(fp, opts.registry);
+      const { doc, rewrite, serialize } = await loadDoc(fp, opts.registry);
       const docNewDir = dirname(fp);
       const docOldDir = isUnder(fp, absTo) ? dirname(absFrom + fp.slice(absTo.length)) : docNewDir;
 
@@ -139,11 +139,29 @@ export async function applyRename(opts: ApplyRenameOptions): Promise<RenameRepor
       if (changes.length === 0 && tagCount === 0) {
         continue;
       }
-      if (!serialize) {
+      /*
+       * Two ways to write a document back, and the narrower one is not a fallback for a broken
+       * format — it is the only honest promise a load-only format can make. A CSV collection has a
+       * parser and deliberately no serializer, so a reference living in one used to be COUNTED and
+       * then reported as a remainder the author had to repair by hand (issue 246). `rewrite`
+       * replaces the authored values in the file's own bytes and changes nothing else, which is all
+       * a rename ever needed.
+       *
+       * `serialize` still wins where it exists: a full round trip can express a change a list of
+       * value edits cannot. A TAG rename is exactly such a change, so a document carrying one and
+       * no serializer is still named in the report rather than half-written.
+       */
+      const written =
+        serialize === null
+          ? tagCount === 0 && rewrite !== null
+            ? await rewrite(changes)
+            : null
+          : await serialize(doc);
+      if (written === null) {
         report.errors.push({ error: `No serializer for "${match}"`, path: fwd(match) });
         continue;
       }
-      await writeFile(fp, await serialize(doc));
+      await writeFile(fp, written);
 
       if (changes.length > 0) {
         report.references.files.push({ changes, count: changes.length, path: fwd(match) });

--- a/packages/server/src/refactor/scan.ts
+++ b/packages/server/src/refactor/scan.ts
@@ -14,10 +14,28 @@ import type { FormatRegistry } from "@jxsuite/schema/format-registry";
 /** Normalise a path to forward slashes (Windows `path` returns backslashes). */
 export const fwd = (p: string) => p.replaceAll("\\", "/");
 
-/** A parsed document plus the serializer that round-trips it back to disk (null when none). */
+/** One authored value to replace in a document's own source text. */
+export interface ValueEdit {
+  from: string;
+  to: string;
+}
+
+/** A parsed document and the two ways it might be written back. */
 export interface LoadedDoc {
   doc: unknown;
+  /** Round-trips the whole document. Null when the format declares no `serialize`. */
   serialize: ((doc: unknown) => Promise<string>) | null;
+  /**
+   * Replaces authored values in the file's own bytes, changing nothing else. Null when the format
+   * declares no `rewrite`.
+   *
+   * The narrower of the two, and the only one a load-only format can offer: a CSV collection is a
+   * data source entries are read FROM, so there is no document to serialize — but one cell's text
+   * can be changed without inventing a quoting style. `applyRename` prefers `serialize` where it
+   * exists, because a full round trip can express a change (a tag rename) that a list of value
+   * edits cannot.
+   */
+  rewrite: ((edits: readonly ValueEdit[]) => Promise<string>) | null;
 }
 
 const isJsonPath = (p: string) => p.endsWith(".json");
@@ -58,8 +76,8 @@ export function documentGlob(registry: FormatRegistry): Bun.Glob {
 }
 
 /**
- * Read + parse a file, returning the doc and a matching serializer (null when the format can parse
- * but not serialize). Throws when no parser claims the extension.
+ * Read + parse a file, returning the doc and whichever write-back paths the format declares. Throws
+ * when no parser claims the extension.
  */
 export async function loadDoc(fp: string, registry: FormatRegistry): Promise<LoadedDoc> {
   const raw = await readFile(fp, "utf8");
@@ -67,6 +85,7 @@ export async function loadDoc(fp: string, registry: FormatRegistry): Promise<Loa
     const trailingNewline = raw.endsWith("\n");
     return {
       doc: JSON.parse(raw) as unknown,
+      rewrite: null,
       serialize: (doc) =>
         Promise.resolve(JSON.stringify(doc, null, 2) + (trailingNewline ? "\n" : "")),
     };
@@ -78,8 +97,15 @@ export async function loadDoc(fp: string, registry: FormatRegistry): Promise<Loa
   }
   const doc = await parseEntry.call("parse", raw);
   const serializeEntry = registry.byExtension(ext, "serialize");
+  const rewriteEntry = registry.byExtension(ext, "rewrite");
   return {
     doc,
+    rewrite: rewriteEntry
+      ? async (edits) => {
+          const out = await rewriteEntry.call("rewrite", raw, edits);
+          return typeof out === "string" ? out : String(out);
+        }
+      : null,
     serialize: serializeEntry
       ? async (d) => {
           const out = await serializeEntry.call("serialize", d);

--- a/packages/server/tests/refactor-apply.test.ts
+++ b/packages/server/tests/refactor-apply.test.ts
@@ -2,7 +2,8 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { buildProjectFormatRegistry } from "@jxsuite/compiler/format-host";
+import { buildProjectFormatRegistry, createNodeFormatIO } from "@jxsuite/compiler/format-host";
+import { buildFormatRegistry } from "@jxsuite/schema/format-registry";
 import { applyRename, deriveTag } from "../src/refactor/index";
 import type { AssetMount } from "@jxsuite/schema/asset-paths";
 import type { ProjectConfig } from "@jxsuite/schema/types";
@@ -458,5 +459,92 @@ describe("applyRename — rooted references through an asset mount", () => {
       serialized({ children: [{ src: "/m/y.png", tagName: "img" }] }),
     );
     expect(report.references.refsUpdated).toBe(1);
+  });
+});
+
+/*
+ * The two write-back capabilities, driven through the parser extension's REAL class descriptors.
+ *
+ * A hand-written fake would assert that `applyRename` calls whatever it was handed; the point here
+ * is that `Csv` declares `rewrite` and no `serialize`, `Markdown` declares `serialize`, and the
+ * engine does the right thing with each. `refactor-parity.test.ts` cannot cover this: it stages
+ * starters into a temp directory, where a bare `@jxsuite/parser` resolves to the PUBLISHED package
+ * rather than to this workspace.
+ */
+describe("applyRename — write-back capabilities", () => {
+  const PARSER_SRC = join(import.meta.dir, "../../../extensions/parser/src");
+
+  const CSV_BEFORE =
+    "Title,slug,image\r\n" +
+    'Cedar Lane,"cedar-lane",/images/listing-1.jpg\r\n' +
+    "Lakeview,lakeview,/images/listing-10.jpg\r\n";
+
+  const CSV_AFTER =
+    "Title,slug,image\r\n" +
+    'Cedar Lane,"cedar-lane",/images/villa.jpg\r\n' +
+    "Lakeview,lakeview,/images/listing-10.jpg\r\n";
+
+  /** A registry built from the workspace's own class descriptors, by absolute path. */
+  async function workspaceRegistry() {
+    return buildFormatRegistry(
+      {
+        Csv: join(PARSER_SRC, "Csv.class.json"),
+        Markdown: join(PARSER_SRC, "Markdown.class.json"),
+      },
+      createNodeFormatIO(root),
+    );
+  }
+
+  test("Csv declares rewrite and no serialize; Markdown declares serialize", async () => {
+    const registry = await workspaceRegistry();
+    const csv = registry.byName("Csv")!;
+    expect(csv.capabilities.rewrite).toBeDefined();
+    expect(csv.capabilities.serialize).toBeUndefined();
+    expect(registry.byName("Markdown")!.capabilities.serialize).toBeDefined();
+  });
+
+  test("a reference inside a CSV collection is rewritten, not reported as a remainder", async () => {
+    write("project.json", JSON.stringify({ name: "p" }));
+    write("content/listings.csv", CSV_BEFORE);
+    write("public/images/listing-1.jpg", "jpg");
+    write("public/images/listing-10.jpg", "jpg");
+
+    renameSync(join(root, "public/images/listing-1.jpg"), join(root, "public/images/villa.jpg"));
+    const report = await applyRename({
+      absFrom: join(root, "public/images/listing-1.jpg"),
+      absTo: join(root, "public/images/villa.jpg"),
+      registry: await workspaceRegistry(),
+      root,
+    });
+
+    expect(report.errors).toEqual([]);
+    expect(report.references.refsUpdated).toBe(1);
+    /* Byte-for-byte outside the one cell: the quoting, the padding and the CRLF line endings are
+       the author's, and a rename has no business restyling any of them. The sibling row proves the
+       match is on the whole cell — `/images/listing-1.jpg` is a prefix of `/images/listing-10.jpg`. */
+    expect(read("content/listings.csv")).toBe(CSV_AFTER);
+  });
+
+  test("a tag rename in a format with rewrite but no serialize is still named in the report", async () => {
+    /* `rewrite` replaces authored VALUES. A tag rename is a structural change no list of value
+       edits can express, so the honest answer is the one the engine already gave: name the file
+       rather than half-write it. */
+    const rows = "tagName,image\r\nmy-counter,/hero.jpg\r\n";
+    write("project.json", JSON.stringify({ name: "p" }));
+    write("content/rows.csv", rows);
+    write("components/counter.json", JSON.stringify({ children: [], tagName: "my-counter" }));
+
+    renameSync(join(root, "components/counter.json"), join(root, "components/my-button.json"));
+    const report = await applyRename({
+      absFrom: join(root, "components/counter.json"),
+      absTo: join(root, "components/my-button.json"),
+      registry: await workspaceRegistry(),
+      root,
+    });
+
+    expect(report.errors).toEqual([
+      { error: 'No serializer for "content/rows.csv"', path: "content/rows.csv" },
+    ]);
+    expect(read("content/rows.csv")).toBe(rows);
   });
 });

--- a/packages/starters/sites/blog/document.schema.json
+++ b/packages/starters/sites/blog/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/course/document.schema.json
+++ b/packages/starters/sites/course/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/event/document.schema.json
+++ b/packages/starters/sites/event/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/fitness-studio/document.schema.json
+++ b/packages/starters/sites/fitness-studio/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/home-services/document.schema.json
+++ b/packages/starters/sites/home-services/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/museum/document.schema.json
+++ b/packages/starters/sites/museum/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/nonprofit/document.schema.json
+++ b/packages/starters/sites/nonprofit/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/portfolio/document.schema.json
+++ b/packages/starters/sites/portfolio/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/professional-firm/document.schema.json
+++ b/packages/starters/sites/professional-firm/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/real-estate/document.schema.json
+++ b/packages/starters/sites/real-estate/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/restaurant/document.schema.json
+++ b/packages/starters/sites/restaurant/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/saas/document.schema.json
+++ b/packages/starters/sites/saas/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/starters/sites/shop/document.schema.json
+++ b/packages/starters/sites/shop/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/packages/studio/src/files/files.ts
+++ b/packages/studio/src/files/files.ts
@@ -1910,10 +1910,12 @@ function renameStatus(newName: string, report: RenameResult): string {
  *
  * The dialog above a rename states, in a modal the user has to accept, that N references "will be
  * updated automatically. Nothing else changes." The engine keeps that promise for every document it
- * can write — but some it cannot: a content source like a `.csv` collection has a parser and
- * deliberately no serializer, and a document that fails to parse cannot be rewritten either. In
- * both cases `applyRename` names the file rather than dropping it, and this is the half that makes
- * the naming reach a person. Silence here is what turns a stated promise into a false one.
+ * can write, and it can write more than it round-trips: a `.csv` collection has a parser and
+ * deliberately no serializer, but declares the narrower `rewrite` capability, so a reference in one
+ * is repaired cell by cell. What is left over is a document that fails to parse, and a tag rename
+ * inside a format with no serializer. In those `applyRename` names the file rather than dropping
+ * it, and this is the half that makes the naming reach a person. Silence here is what turns a
+ * stated promise into a false one.
  *
  * A drag-move makes no promise at all — it has no dialog — which is exactly why it needs this more,
  * not less. A format CONVERSION makes the strongest promise of the three, and shares this for that

--- a/scripts/ci/affected.ts
+++ b/scripts/ci/affected.ts
@@ -124,12 +124,13 @@ const EXTRA_EDGES: ExtraEdge[] = [
   },
   {
     patterns: ["extensions/feed/src/**", "extensions/parser/src/**"],
-    seeds: ["packages/compiler"],
+    seeds: ["packages/compiler", "packages/server"],
     evidence: [
       "packages/compiler/tests/feed-integration.test.ts",
       "packages/compiler/tests/sitemap-lastmod.test.ts",
+      "packages/server/tests/refactor-apply.test.ts",
     ],
-    why: "Two compiler tests build a real project that loads @jxsuite/parser (and, for feeds, @jxsuite/feed), so a change to either extension's src can break a compiler test. The sitemap one spans three packages by construction: the parser carries an entry's timestamp, the compiler lifts it onto the route, and the sitemap prints it.",
+    why: "Two compiler tests build a real project that loads @jxsuite/parser (and, for feeds, @jxsuite/feed), so a change to either extension's src can break a compiler test. The sitemap one spans three packages by construction: the parser carries an entry's timestamp, the compiler lifts it onto the route, and the sitemap prints it. The refactor engine reads the parser's class descriptors by absolute path to drive its write-back capabilities against the real Csv and Markdown declarations, which is the one thing the parity suite cannot do — it stages starters into a temp directory, where a bare @jxsuite/parser resolves to the PUBLISHED package. Server is already a dependent of compiler, so this seed is redundant today and is named anyway: it is the edge that is actually asserted, and a later narrowing of the compiler seed must not silently un-gate it.",
   },
   {
     patterns: ["packages/starters/sites/portfolio/**", "packages/starters/sites/real-estate/**"],

--- a/scripts/screenshots/fixtures/counter-elements/document.schema.json
+++ b/scripts/screenshots/fixtures/counter-elements/document.schema.json
@@ -619,7 +619,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -689,6 +689,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/counter-preview/document.schema.json
+++ b/scripts/screenshots/fixtures/counter-preview/document.schema.json
@@ -619,7 +619,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -689,6 +689,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/counter/document.schema.json
+++ b/scripts/screenshots/fixtures/counter/document.schema.json
@@ -619,7 +619,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -689,6 +689,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/data/document.schema.json
+++ b/scripts/screenshots/fixtures/data/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/first-collection-bind/document.schema.json
+++ b/scripts/screenshots/fixtures/first-collection-bind/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/first-collection-card/document.schema.json
+++ b/scripts/screenshots/fixtures/first-collection-card/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/first-collection-start/document.schema.json
+++ b/scripts/screenshots/fixtures/first-collection-start/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/first-collection-state/document.schema.json
+++ b/scripts/screenshots/fixtures/first-collection-state/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/first-collection/document.schema.json
+++ b/scripts/screenshots/fixtures/first-collection/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/scripts/screenshots/fixtures/statements/document.schema.json
+++ b/scripts/screenshots/fixtures/statements/document.schema.json
@@ -619,7 +619,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -689,6 +689,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/sites/jxsuite.com/document.schema.json
+++ b/sites/jxsuite.com/document.schema.json
@@ -622,7 +622,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -692,6 +692,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/sites/test-blank/document.schema.json
+++ b/sites/test-blank/document.schema.json
@@ -619,7 +619,7 @@
           "type": "object"
         },
         "ClassMethodDef": {
-          "description": "A class method or accessor definition. Capability roles (parse, serialize, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
+          "description": "A class method or accessor definition. Capability roles (parse, serialize, rewrite, discover, load) mark static methods that hosts (compiler, server, studio) invoke for format dispatch.",
           "properties": {
             "$prototype": {
               "const": "Function",
@@ -689,6 +689,7 @@
                 "accessor",
                 "parse",
                 "serialize",
+                "rewrite",
                 "discover",
                 "load",
                 "projectData",

--- a/specs/extensions.md
+++ b/specs/extensions.md
@@ -2,9 +2,9 @@
 
 ## Extension Packages, Schema Composition, and the Capability Contract
 
-**Version:** 0.4.1-draft
+**Version:** 0.4.2-draft
 **Status:** Partial
-**Updated:** 2026-08-27
+**Updated:** 2026-08-29
 **License:** MIT
 
 Supersedes v1 ("Format-Extension Classes and the Capability Contract"). The
@@ -534,6 +534,7 @@ implementation class without constructing an instance. The instance
 | -------------- | ----------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | `parse`        | `format`    | `(source, options?) → JxDocument \| ContentLoaderEntry[]`                   | compiler, server, studio (open file, convert a file)                               |
 | `serialize`    | `format`    | `(doc, options?) → string`                                                  | studio (save, create a file, convert a file), site build (export sidecars)         |
+| `rewrite`      | `format`    | `(source, edits) → string`                                                  | rename refactor (repair a reference inside a format that does not round-trip)      |
 | `discover`     | `format`    | `(source, { baseDir }) → string[]`                                          | content loading (list entry files)                                                 |
 | `load`         | `format`    | `(path, { schema, directiveOptions }) → ContentLoaderEntry[]`               | content loading (parse one source)                                                 |
 | `projectData`  | `project`   | `(sectionValue, { projectConfig, root, registry, io }) → unknown`           | compiler site build, dev server resolve — result stored as `_project[<key>]`       |
@@ -552,6 +553,21 @@ globs from `documentExtensions("page"|"component")` and casts every `parse` resu
 already load-bearing in the build. A format declaring only `content` makes no such claim, and may
 return `ContentLoaderEntry[]` — the parser's `Csv` does exactly that, which is why it declares no
 `serialize`.
+
+**`rewrite` is not a weaker `serialize`, and the two are not ranked.** `serialize` says _this
+document round-trips through me_; `rewrite` says only _I can replace these authored values in my own
+source text and change nothing else_. A format may declare either, both or neither, and a load-only
+format can honestly promise the second while never being able to promise the first: re-emitting a
+CSV collection would mean choosing a quoting style, a line ending and a column order the author
+already chose, while replacing one cell's text requires no opinion about any of them.
+
+`edits` is a list of `{ from, to }` naming values as `parse` produced them, and a match is on the
+WHOLE value, never a substring — `hero.jpg` must not rewrite the middle of `my-hero.jpg`. Every
+other byte of the source is preserved. That is the whole contract, and it is enough for the rename
+refactor: a reference living inside a collection is repaired rather than reported as a remainder the
+author has to fix by hand (§9.3 of site-architecture.md). Where a format declares both, a rename
+prefers `serialize`, because a full round trip can express a change — a custom-element tag rename —
+that a list of value edits cannot.
 
 Studio reads the pair to answer two questions it used to have no answer for:
 
@@ -1164,6 +1180,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.4.2-draft** (2026-08-29) — A format may declare rewrite: replace authored values in its own source text, for a format that is read but never round-tripped.
 - **0.4.1-draft** (2026-08-27) — Studio conversion and creation are parse/serialize consumers; what parse returns is decided by documentKinds.
 - **0.4.0-draft** (2026-08-26) — §8.4: an emitter must not emit the same content twice — the search index carries page preamble plus sections, not the corpus twice.
 - **0.3.11-draft** (2026-08-25) — §8.5: record that a host which cannot execute extension code sees only content-section mounts.
@@ -1192,4 +1209,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_Jx Extensions Specification v0.4.1-draft_
+_Jx Extensions Specification v0.4.2-draft_

--- a/specs/site-architecture.md
+++ b/specs/site-architecture.md
@@ -2,7 +2,7 @@
 
 ## File-Based Routing, Content Collections, Layouts, and Static Site Generation
 
-**Version:** 0.6.5-draft
+**Version:** 0.6.6-draft
 **Status:** Partial
 **Updated:** 2026-08-29
 **License:** MIT
@@ -1420,7 +1420,8 @@ So the contract binds the engine, both ways:
 
 - A rooted reference resolves through every lane the host serves, and a match against **any** of them is a usage. Where two lanes both name an existing file the reference is genuinely ambiguous, and a warning shown before a destructive action counts both.
 - A rewritten rooted reference is re-emitted through the lanes a **build** publishes, falling back to the project-root lane only for a file no build would publish. A `public/` file must come back as `/hero.jpg`, never `/public/hero.jpg`: the second resolves on a local editing server and 404s on the deployed site, which is the failure mode this section exists to prevent.
-- A reference the engine counts but **cannot** write — a document that fails to parse, or a format that can be read but not round-tripped — is NAMED in the report rather than dropped. A rename that reports success while leaving a reference pointing at a moved file is worse than one that never claimed to fix it, because the claim is what stops the author looking.
+- A reference the engine counts but **cannot** write is NAMED in the report rather than dropped. A rename that reports success while leaving a reference pointing at a moved file is worse than one that never claimed to fix it, because the claim is what stops the author looking.
+- Writing a reference back does not require the document to round-trip. A format that can be read but not re-emitted — a CSV collection is a data source entries are loaded FROM, and re-emitting one would mean choosing a quoting style, a line ending and a column order the author already chose — may instead declare that it can replace authored VALUES in its own source text and change nothing else (`extensions.md` §8's `rewrite`). That is all a rename ever needed, so a reference inside such a file is repaired rather than left as a remainder. What stays un-writable is a document that fails to parse, and a structural change no list of value edits can express: renaming a custom-element tag inside a format with no serializer.
 - A reference is not always a VALUE, and not always shaped like a file. `project.json`'s `copy` map names the files it copies in its **keys**, and a content collection's `source` may name a **directory**, which carries no extension for the shape rule below to recognise. Both sit at a key the engine already knows by name, so both are read by name. The other half of `copy` is the counterexample that makes the rule: its values are destinations inside `outDir`, a directory no rename inside the project can move, so they are not references and are never rewritten.
 - A rewritten reference keeps the style the author wrote, trailing slash included. A directory `source` re-emitted without one is a diff on a line the rename had no business restyling.
 
@@ -2688,6 +2689,7 @@ This spec builds on existing Jx primitives wherever possible:
 
 ## Changelog
 
+- **0.6.6-draft** (2026-08-29) — A reference inside a format that cannot round-trip is repaired through the rewrite capability rather than reported as a remainder.
 - **0.6.5-draft** (2026-08-29) — A copy map's keys and a directory content source are references the engine reads by name; a copy destination is not, and a rewritten reference keeps its trailing slash.
 - **0.6.4-draft** (2026-08-27) — Record that collection discovery is recursive, so a subdirectory holds entries as well as co-located media.
 - **0.6.3-draft** (2026-08-27) — Reference resolution through the asset lanes is the refactor engine's contract, in both directions: a rooted ref is counted through every lane, rewritten through the lanes a build publishes, and named in the report when it cannot be written.

--- a/specs/studio.md
+++ b/specs/studio.md
@@ -2,9 +2,9 @@
 
 ## Visual Builder for Jx Documents
 
-**Version:** 0.10.1-draft
+**Version:** 0.10.2-draft
 **Status:** Partial
-**Updated:** 2026-08-28
+**Updated:** 2026-08-29
 **License:** MIT
 
 ---
@@ -1040,7 +1040,9 @@ The registry answers three more questions, all derived from the same declaration
 list this app maintains: which formats a new file may be created as (§9.1.1), which pairs a document
 may be converted between (§8.4), and which extensions the rename refactor can write back. `.json` is
 the endpoint every one of them shares, because a registry never claims it. A format extension that
-declares `parse` and `serialize` therefore reaches all three with no edit to the studio.
+declares `parse` and `serialize` therefore reaches all three with no edit to the studio. The refactor
+alone also accepts `rewrite` in place of `serialize`, which is how a format that is read but never
+round-tripped still has its references repaired.
 
 The format's `$studio` block drives the control surface:
 
@@ -1403,10 +1405,12 @@ exists.
 
 **A promise made must be a promise reported on.** The rename sentence commits the refactor pass to
 rewriting the references it counted, and the pass can fail to keep that for a nameable reason — a
-content source with a parser and deliberately no serializer, a document that does not parse. The
-engine names those files rather than dropping them (`site-architecture.md` §9.3), and Studio MUST
-surface the naming: a move whose report carries them reports a **warning** identifying them, not the
-plain success. This binds the drag-move most of all, since it shows no dialog and therefore makes
+document that does not parse, or a tag rename inside a format with no serializer. A format that is
+read but never round-tripped is NOT such a reason: a CSV collection declares the narrower `rewrite`
+capability (`extensions.md` §8), so a reference inside one is repaired cell by cell. Where the pass
+genuinely cannot write, the engine names those files rather than dropping them
+(`site-architecture.md` §9.3), and Studio MUST surface the naming: a move whose report carries them
+reports a **warning** identifying them, not the plain success. This binds the drag-move most of all, since it shows no dialog and therefore makes
 its promise only in retrospect.
 
 ### 9.1.2 The Library
@@ -2841,6 +2845,7 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ## Changelog
 
+- **0.10.2-draft** (2026-08-29) — A format declaring rewrite rather than serialize has its references repaired by the rename refactor, so it is no longer a reported remainder.
 - **0.10.1-draft** (2026-08-28) — studioShellHtml() now links a favicon for hosts whose window chrome has no native icon of its own.
 - **0.10.0-draft** (2026-08-27) — New File chooses a format rather than an extension (Other... preserves arbitrary names); a document converts between formats in place; creating in a collection source routes to New Entry.
 - **0.9.53-draft** (2026-08-27) — A rename or drag-move whose refactor report names references it could not rewrite reports a warning, not a plain success; a drag-move invalidates the usage cache like its siblings.
@@ -2951,4 +2956,4 @@ External standards this specification binds itself to. Vocabulary and cell gramm
 
 ---
 
-_`@jxsuite/studio` Specification v0.10.1-draft_
+_`@jxsuite/studio` Specification v0.10.2-draft_


### PR DESCRIPTION
Closes #246

> **Stacked on #256** (`fix/refactor-copy-keys-and-directory-sources`), and based against it so the diff reads clean. Merge #256 first; this retargets to `main` automatically.

`extensions/parser` declares `serialize` for Markdown and none for CSV, and correctly so: a collection is a data source entries are loaded FROM, and re-emitting one would mean choosing a quoting style, a line ending and a column order the author already chose. `applyRename` handled that honestly — it pushed `No serializer for "content/listings.csv"` into the report and left the file alone — so renaming `public/images/listing-1.jpg` in the `real-estate` starter updated two of its three references and told the author about the third.

That was honest, and it was not finished. **The engine never needed a document back. It needed one cell's text changed.**

## `rewrite` is not a weaker `serialize`

The two are not ranked, and a format may declare either, both or neither. `serialize` says _this document round-trips through me_; `rewrite` says only that authored VALUES can be replaced in the format's own source text with every other byte preserved. A load-only format can promise the second while never being able to promise the first.

- **`Csv.rewrite`** scans the source for field spans, mirroring the two passes `parseCSV` already makes so the two cannot disagree about where a cell is, and splices. Matching is on the whole cell value, never a substring, so `hero.jpg` cannot rewrite the middle of `my-hero.jpg`. Padding, quoting and CRLF survive; a replacement that would be misread unquoted is quoted. The **header row is never touched** — it names columns, `parse` does not expose it as a value, and renaming a column would be data loss wearing a rename's clothes.
- **`applyRename` prefers `serialize` where it exists**, because a full round trip can express a change a list of value edits cannot. A tag rename is exactly such a change, so a document carrying one and no serializer is still named in the report rather than half-written.

## Verification

`extensions/parser` 624 pass · `packages/server` 1025 pass · `packages/schema` 426 pass — 0 fail, `src/csv.ts` at 100%/100%, manifests clean.

The new server test drives the parser's **real** class descriptors by absolute path. `refactor-parity.test.ts` cannot: it stages starters into a temp directory, where a bare `@jxsuite/parser` resolves to the published package rather than to this workspace. That edge is now named in `affected.ts`'s `EXTRA_EDGES` — redundant today (server is already a dependent of compiler) and named anyway, so a later narrowing of the compiler seed cannot silently un-gate it.

## Specs & docs

`extensions.md` §8 gains the capability row and its contract (0.4.1 → 0.4.2-draft); `site-architecture.md` §9.3 and `studio.md` §9.1.1 stop calling CSV an unwritable remainder; `docs/extending/extensions/formats.md` documents `rewrite` for extension authors, and the two user-facing pages that claimed a CSV reference could not be repaired now say what actually happens. The `role` enum in `class-def.schema.ts` gained `rewrite`, with the 28 committed schemas regenerated by `schema:sync` — the drift guard caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174XXa9vSu2si7BgniowRs4