### PR TITLE
refactor(studio): retire media-usage's authored-spelling union, now the engine resolves lanes

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -25,7 +25,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `relationships.md`        | 0.1.4-draft  | Partial     | 2026-08-15 |
 | `schema.md`               | 0.4.8-draft  | Partial     | 2026-08-16 |
 | `server.md`               | 0.2.21       | Implemented | 2026-08-27 |
-| `site-architecture.md`    | 0.6.4-draft  | Partial     | 2026-08-27 |
+| `site-architecture.md`    | 0.6.5-draft  | Partial     | 2026-08-29 |
 | `spec.md`                 | 0.5.8-draft  | Partial     | 2026-08-26 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |
 | `studio-ui-guidelines.md` | 0.3.16       | Implemented | 2026-08-27 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -278,6 +278,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `site-architecture.md`
 
+- **0.6.5-draft** (2026-08-29) — A media usage query asks about the file once; enumerating a file's authored spellings host-side is the engine's job, not a media surface's.
 - **0.6.4-draft** (2026-08-27) — Record that collection discovery is recursive, so a subdirectory holds entries as well as co-located media.
 - **0.6.3-draft** (2026-08-27) — Reference resolution through the asset lanes is the refactor engine's contract, in both directions: a rooted ref is counted through every lane, rewritten through the lanes a build publishes, and named in the report when it cannot be written.
 - **0.6.2-draft** (2026-08-27) — Routing, layout, context and head-merge move to @jxsuite/site; standards evidence follows.

--- a/packages/studio/src/files/media-paths.ts
+++ b/packages/studio/src/files/media-paths.ts
@@ -15,14 +15,19 @@
  * mount (specs/site-architecture.md §9.3), so the same file can also be named
  * `/content/blog/images/hero.png` when the collection's `source` is not already `content/blog`.
  *
- * **Why this module exists at all.** `findReferences` resolves each authored ref the way the
- * compiler does — rooted values against the project root, relative ones against the referencing
- * document — and compares the RESULT to the path it was asked about. Ask it about `public/hero.jpg`
- * and every `/hero.jpg` in the project resolves to `hero.jpg`, matches nothing, and the answer is a
- * confident zero. That is the exact shape of bug that makes a delete look safe: seven pages break
- * and the dialog says nothing else refers to it. {@link authoredRefTargets} is the fix — it
- * enumerates what an authored reference to this file RESOLVES to, so the query is keyed on the ref
- * as written rather than on the file as stored.
+ * **Why this module exists at all.** A surface that has a FILE and needs a URL cannot get one by
+ * prefixing a slash. The library grid did exactly that, so every `public/` image asked for
+ * `/public/hero.jpg` — a URL the site does not publish — and every content-collection image skipped
+ * its mount entirely. {@link mediaSiteUrl} and {@link previewFileSrc} are the answer, and they take
+ * a FILE PATH: an authored reference is a different thing and resolves through
+ * `canvas/asset-refs`.
+ *
+ * This module used to carry a third function, `authoredRefTargets`, enumerating every path an
+ * authored reference to a file could resolve to, so a usage query could ask about all of them and
+ * union the answers. That existed because `findReferences` resolved a rooted reference against the
+ * project root alone; the engine now resolves every lane itself (`site-architecture.md` §9.3), on
+ * the write side as well as the read side, which a client-side union never could. Asking once is
+ * both simpler and more correct, so the helper is gone.
  *
  * Everything here is pure string math over project-relative, forward-slashed paths. The only input
  * from outside is the open project's content sections, read the same way `canvas/asset-refs.ts`
@@ -99,40 +104,6 @@ export function mediaSiteUrl(path: string): string {
   }
   const mount = mountOf(normalized);
   return mount ? `/${mountedPath(normalized, mount)}` : `/${normalized}`;
-}
-
-/**
- * Every path an authored reference to this media file resolves to — the keys a usage query must ask
- * about, most literal first.
- *
- * 1. The file itself. A sibling's `./images/hero.png`, a rooted `/content/blog/images/hero.png` and a
- *    bare `assets/logo.svg` all land here.
- * 2. Its served path, for `public/` media. `/hero.jpg` resolves to `hero.jpg`, which is not a file on
- *    disk and does not need to be — the sweep compares resolved strings, and this is the string
- *    every reference to a public asset produces.
- * 3. Its asset-mount path, when a collection's `source` differs from its mount prefix. Identical to
- *    (1) for the ordinary `content/<type>/` layout, and deduplicated when it is.
- *
- * The list is a UNION and is deliberately generous: over-counting a reference makes a delete dialog
- * more alarming than it needs to be, while missing one makes it lie.
- */
-export function authoredRefTargets(path: string): string[] {
-  const normalized = normalizeProjectPath(path);
-  if (normalized === "") {
-    return [];
-  }
-  const targets = [normalized];
-  if (normalized.startsWith(`${PUBLIC_DIR}/`)) {
-    targets.push(normalized.slice(PUBLIC_DIR.length + 1));
-  }
-  const mount = mountOf(normalized);
-  if (mount) {
-    const mounted = mountedPath(normalized, mount);
-    if (!targets.includes(mounted)) {
-      targets.push(mounted);
-    }
-  }
-  return targets;
 }
 
 /**

--- a/packages/studio/src/files/media-usage.ts
+++ b/packages/studio/src/files/media-usage.ts
@@ -1,164 +1,74 @@
 /**
- * Media usage — "which pages use this image?", asked in the shape an author actually wrote.
+ * Media usage — "which pages use this image?", asked once.
  *
- * `services/references.ts` already answers "where is this used?" for documents, and its answer is
- * what every destructive confirmation says out loud. Media does not fit through it unmodified, for
- * one reason: **the reference index resolves refs, and a media file's authored ref usually resolves
- * somewhere else.** `public/hero.jpg` is written `/hero.jpg`, which the compiler — and therefore
- * the sweep — resolves to `hero.jpg`. Ask about the file and every reference to it is invisible;
- * the query succeeds, returns zero, and the delete dialog says nothing else refers to it while
- * seven pages break. A confident zero is the one answer a destructive dialog must never invent.
+ * `services/references.ts` answers "where is this used?" for every kind of file, and its answer is
+ * what every destructive confirmation says out loud. Media needs three things on top of it, and no
+ * longer needs the fourth this module was built for.
  *
- * So the query is keyed on the AUTHORED ref. {@link authoredRefTargets} enumerates every path a
- * reference to this file resolves to — the file, its served path, its asset-mount path — and this
- * module asks all of them and unions the answers. Everything else is deliberately inherited rather
- * than re-implemented: the same `loadUsages` cache (so a dialog and a panel asking at once are one
- * round trip), the same `invalidateUsages` on any filesystem event, the same `usageWarning`
- * sentence in the confirmation, and the same `usageHeadline` wording on a panel.
+ * **What it still does.** A media path is normalized before it becomes a query (a leading `./` is
+ * not part of a file's identity), an empty path is a FAILURE rather than "nothing uses it", and
+ * {@link mediaUsageHeadline} renders the one line a media surface shows beside a file — where a
+ * failed query says **unknown**, which is a different fact from "unused" and has to read like one.
  *
- * **A partial answer is `failed`, not a total.** If one lane of the union cannot be counted, the
- * union cannot either — a number assembled from the lanes that worked reads exactly like a complete
- * one, and would understate what a delete breaks. Unknown is the honest answer, and
- * {@link mediaUsageHeadline} says the word.
+ * **What it no longer does, and why that matters.** A media file's authored reference usually
+ * resolves somewhere else: `public/hero.jpg` is written `/hero.jpg`, and a content asset is written
+ * `./images/hero.png` and republished at its collection's mount. `findReferences` used to resolve a
+ * rooted reference against the project root ALONE, so asking it about the file matched none of
+ * those and returned a confident zero — the one answer a destructive dialog must never invent. This
+ * module's answer was to enumerate every authored spelling of the file and union the results.
+ *
+ * That was a workaround in the wrong place. A client-side union can make a COUNT come out right and
+ * can do nothing at all about the REWRITE, which happens inside the engine — so the engine learned
+ * to resolve every lane itself (issue 239/241, `site-architecture.md` §9.3), and the union became a
+ * second implementation of a rule that now has one. It is gone: one path in, one query, one answer,
+ * and the lanes are the engine's business.
  *
  * @docs studio/projects/media
  */
 
-import { authoredRefTargets } from "./media-paths";
+import { normalizeProjectPath } from "./media-paths";
 import { loadUsages, peekUsages, retryUsages, usageHeadline } from "../services/references";
-import type { UsageQuery, UsageState } from "../services/references";
-import type { ReferenceFile, ReferenceHit, ReferencesResult } from "../types";
+import type { UsageState } from "../services/references";
+
+/** The state a caller gets for a path that names no file. */
+const NO_FILE: UsageState = { message: "no media file to look for", status: "failed" };
 
 /**
- * The queries whose union answers "what uses this media file?".
+ * The query for a media file, or null when the path names nothing.
  *
- * One per authored form. An empty list means there is no question to ask (an empty path), which
- * {@link loadMediaUsages} reports as a failure rather than as "nothing uses it".
+ * Normalizing here rather than at each call site is the whole of what this wrapper adds over
+ * `loadUsages`: the file tree, a drop handler and a library tile do not agree on whether a path
+ * carries a leading `./`, and two spellings of one file must not become two cache entries.
  */
-export function mediaUsageQueries(path: string): UsageQuery[] {
-  return authoredRefTargets(path).map((target) => ({ path: target }));
-}
-
-/** Merge one file's hits into the accumulator, summing counts per `(refType, ref)`. */
-function mergeFile(into: Map<string, ReferenceFile>, file: ReferenceFile): void {
-  const existing = into.get(file.path);
-  if (!existing) {
-    into.set(file.path, { count: file.count, path: file.path, refs: [...file.refs] });
-    return;
-  }
-  for (const hit of file.refs) {
-    const same = existing.refs.find(
-      (candidate: ReferenceHit) => candidate.refType === hit.refType && candidate.ref === hit.ref,
-    );
-    if (same) {
-      same.count += hit.count;
-    } else {
-      existing.refs.push({ ...hit });
-    }
-  }
-  existing.count += file.count;
-}
-
-/**
- * One result out of several, for the same file asked about under different names.
- *
- * The lanes cannot double-count: each asks about a DIFFERENT resolved path, and one authored string
- * resolves to exactly one of them. Errors are unioned by path so a document that failed to parse in
- * every lane is reported once, and `path` reports the media file the caller asked about rather than
- * whichever lane happened to be first.
- */
-function unionResults(path: string, results: readonly ReferencesResult[]): ReferencesResult {
-  const files = new Map<string, ReferenceFile>();
-  const errors = new Map<string, { path: string; error: string }>();
-  for (const result of results) {
-    for (const file of result.files) {
-      mergeFile(files, file);
-    }
-    for (const error of result.errors) {
-      if (!errors.has(error.path)) {
-        errors.set(error.path, error);
-      }
-    }
-  }
-  const merged = [...files.values()].toSorted((a, b) => a.path.localeCompare(b.path));
-  return {
-    errors: [...errors.values()],
-    files: merged,
-    filesReferencing: merged.length,
-    path,
-    refsTotal: merged.reduce((sum, file) => sum + file.count, 0),
-    tagName: null,
-  };
-}
-
-/**
- * Reduce the lanes to one state.
- *
- * Precedence is strictly least-informative-wins, because every step down is a step away from a
- * number the caller could act on: unsupported (the host cannot answer at all) beats failed (it
- * tried and could not) beats pending beats a real union.
- */
-function combine(path: string, states: readonly UsageState[]): UsageState {
-  if (states.some((state) => state.status === "unsupported")) {
-    return { status: "unsupported" };
-  }
-  const failure = states.find((state) => state.status === "failed");
-  if (failure) {
-    return failure;
-  }
-  if (states.some((state) => state.status === "pending")) {
-    return { status: "pending" };
-  }
-  return {
-    result: unionResults(
-      path,
-      states.map((state) => (state as { result: ReferencesResult }).result),
-    ),
-    status: "ready",
-  };
+function mediaQuery(path: string): { path: string } | null {
+  const normalized = normalizeProjectPath(path);
+  return normalized === "" ? null : { path: normalized };
 }
 
 /**
  * The answer right now, WITHOUT starting a request — the synchronous read a lit template needs.
  *
- * `null` means at least one lane has never been asked, and the caller decides whether this paint is
- * the one that asks (see {@link loadMediaUsages}).
+ * `null` means the question has never been asked, and the caller decides whether this paint is the
+ * one that asks (see {@link loadMediaUsages}).
  */
 export function peekMediaUsages(path: string): UsageState | null {
-  const queries = mediaUsageQueries(path);
-  if (queries.length === 0) {
-    return null;
-  }
-  const states: UsageState[] = [];
-  for (const query of queries) {
-    const state = peekUsages(query);
-    if (state === null) {
-      return null;
-    }
-    states.push(state);
-  }
-  return combine(path, states);
+  const query = mediaQuery(path);
+  return query === null ? null : peekUsages(query);
 }
 
 /**
- * Ask every lane and union the answers. Never rejects — a failure is a STATE, because the caller
+ * Ask, or join the ask already in flight. Never rejects — a failure is a STATE, because the caller
  * has to render something and "unknown" is the honest something.
  */
 export async function loadMediaUsages(path: string): Promise<UsageState> {
-  const queries = mediaUsageQueries(path);
-  if (queries.length === 0) {
-    return { message: "no media file to look for", status: "failed" };
-  }
-  return combine(path, await Promise.all(queries.map((query) => loadUsages(query))));
+  const query = mediaQuery(path);
+  return query === null ? NO_FILE : loadUsages(query);
 }
 
-/** Forget every lane's answer and ask again — the Retry behind a failed media count. */
+/** Forget the answer and ask again — the Retry behind a failed media count. */
 export async function retryMediaUsages(path: string): Promise<UsageState> {
-  const queries = mediaUsageQueries(path);
-  if (queries.length === 0) {
-    return { message: "no media file to look for", status: "failed" };
-  }
-  return combine(path, await Promise.all(queries.map((query) => retryUsages(query))));
+  const query = mediaQuery(path);
+  return query === null ? NO_FILE : retryUsages(query);
 }
 
 /**

--- a/packages/studio/tests/destructive-confirmations.test.ts
+++ b/packages/studio/tests/destructive-confirmations.test.ts
@@ -6,12 +6,18 @@
  * dialog SAYS — that a delete and a rename say different things about the same number, and that a
  * host which cannot count says nothing at all rather than implying zero.
  *
- * The **media** section is about which index the dialog asks. A media file's authored reference
- * usually resolves to a path that is not the file — `/hero.jpg` for `public/hero.jpg`, the asset
- * mount for an asset inside a collection — so the generic index returns a confident zero for uses
- * that are really there. Those cases are asserted through `confirmFileDelete` itself, and the query
- * log is asserted too: a dialog that happened to say the right number while asking only one
- * question would be right by accident.
+ * The **media** section is about a number the dialog once got wrong. A media file's authored
+ * reference usually resolves to a path that is not the file — `/hero.jpg` for `public/hero.jpg`,
+ * the asset mount for an asset inside a collection — and a query that could not see those returned
+ * a confident zero for uses that are really there. Studio used to compensate by asking about every
+ * authored spelling and unioning the answers; the ENGINE resolves those lanes now
+ * (`site-architecture.md` §9.3), so the dialog asks once, about the file.
+ *
+ * The query log is still asserted, and now for the opposite reason. It used to prove the dialog
+ * asked enough questions; it proves it asks exactly ONE, because a second question here would be a
+ * second implementation of a rule the engine owns — and the client copy is the one that cannot fix
+ * the rewrite. Which lanes the engine finds is asserted where the resolution lives:
+ * `packages/server/tests/refactor-find-refs.test.ts` and `refactor-parity.test.ts`.
  */
 
 import { resetStudioState, mountOverlayLayers } from "./harness";
@@ -159,11 +165,12 @@ describe("rename prompt", () => {
  * A project whose blog collection lives in `posts/` — a `source` that differs from the mount
  * prefix.
  *
- * This is the layout §9.3 exists for, and the one the generic index gets wrong: the collection is
- * published at `/content/blog`, so an asset the author stores beside their entries is addressed
- * `./images/hero.png` from inside the collection (resolving to `posts/images/hero.png`) and
- * `/content/blog/images/hero.png` from anywhere else (resolving to a path that is not a file at
- * all). One file, two resolved names, and a delete has to know about both.
+ * This is the layout §9.3 exists for: the collection is published at `/content/blog`, so an asset
+ * the author stores beside their entries is addressed `./images/hero.png` from inside the
+ * collection and `/content/blog/images/hero.png` from anywhere else. One file, two authored
+ * spellings, and a delete has to know about both — which is now the engine's job, so the fake below
+ * answers the way the real one does: everything that resolves to the file, under the file's own
+ * path.
  */
 const BLOG_IN_POSTS = { content: { blog: { source: "./posts/" } } };
 
@@ -171,10 +178,15 @@ const BLOG_IN_POSTS = { content: { blog: { source: "./posts/" } } };
 let asked: string[] = [];
 
 /**
- * A fake index that answers per RESOLVED path, the way the real sweep does.
+ * A fake index that answers per QUERIED path, the way the real sweep does.
  *
- * @param hits — resolved path the sweep compares against → the files whose refs produced it, each
- *   with the string the author actually wrote.
+ * The sweep resolves each authored reference through every lane and compares the result to the file
+ * it was asked about, so one query about a file returns every spelling that reaches it. The fake
+ * mirrors that: the key is the path the caller asks about, and the value is every reference the
+ * engine would have matched to it, however it was written.
+ *
+ * @param hits — queried path → the files whose refs resolve to it, each with the string the author
+ *   actually wrote.
  */
 function installIndex(hits: Record<string, { file: string; ref: string }[]>): void {
   asked = [];
@@ -205,30 +217,32 @@ describe("deleting media", () => {
 
   test("counts the content-relative reference AND the asset-mount one — the file's own name is not the only name it has", async () => {
     installIndex({
-      // What `./images/hero.png` in `posts/hello.md` resolves to — relative to the entry.
-      "posts/images/hero.png": [{ file: "posts/hello.md", ref: "./images/hero.png" }],
-      // What `/content/blog/images/hero.png` in a page resolves to — the collection's asset mount,
-      // Which is not a path on disk, and is invisible to a query keyed on the file.
-      "content/blog/images/hero.png": [
+      // One query, both spellings: `./images/hero.png` in `posts/hello.md` resolves relative to the
+      // Entry, and `/content/blog/images/hero.png` in a page resolves through the collection's
+      // Asset mount. The engine matches both to this file, so both come back under it.
+      "posts/images/hero.png": [
+        { file: "posts/hello.md", ref: "./images/hero.png" },
         { file: "pages/index.json", ref: "/content/blog/images/hero.png" },
       ],
     });
     const pending = confirmFileDelete({ name: "hero.png", path: "posts/images/hero.png" });
     await tick();
 
-    // Both lanes were asked. Asking only the file is what returned 1 and made the delete look safe.
-    expect(asked.toSorted()).toEqual(["content/blog/images/hero.png", "posts/images/hero.png"]);
+    // Exactly one question, and it names the FILE. Studio re-deriving the mount here would be a
+    // Second copy of lane resolution, and the copy that cannot repair the rewrite.
+    expect(asked).toEqual(["posts/images/hero.png"]);
     expect(dialogText()).toContain("2 references in 2 files will break");
 
     settle("cancel");
     await pending;
   });
 
-  test("counts a public asset by its served path, which shares no segment with the file", async () => {
+  test("counts a public asset written by its served path, which shares no segment with the file", async () => {
     installIndex({
-      // `<img src="/hero.jpg">` — `public/` is served from the site root, so this is what a
-      // Reference to `public/hero.jpg` resolves to. The file's own path matches nothing.
-      "hero.jpg": [
+      // `<img src="/hero.jpg">` — `public/` is served from the site root, so a reference to
+      // `public/hero.jpg` is written with no segment in common with it. The engine's public lane
+      // Is what closes that gap, and it answers under the file the caller asked about.
+      "public/hero.jpg": [
         { file: "pages/index.json", ref: "/hero.jpg" },
         { file: "layouts/main.json", ref: "/hero.jpg" },
       ],
@@ -236,7 +250,7 @@ describe("deleting media", () => {
     const pending = confirmFileDelete({ name: "hero.jpg", path: "public/hero.jpg" });
     await tick();
 
-    expect(asked.toSorted()).toEqual(["hero.jpg", "public/hero.jpg"]);
+    expect(asked).toEqual(["public/hero.jpg"]);
     expect(dialogText()).toContain("2 references in 2 files will break");
 
     settle("cancel");
@@ -252,24 +266,11 @@ describe("deleting media", () => {
     await pending;
   });
 
-  test("one failed lane makes the whole answer unknown, never a total of the lanes that worked", async () => {
+  test("a media count that failed is unknown, never a zero and never a partial", async () => {
     asked = [];
     install(async (query) => {
-      const path = query.path ?? "";
-      asked.push(path);
-      if (path === "hero.jpg") {
-        throw new Error("sweep timed out");
-      }
-      return {
-        errors: [],
-        files: [
-          { count: 1, path: "pages/index.json", refs: [{ count: 1, ref: "x", refType: "path" }] },
-        ],
-        filesReferencing: 1,
-        path,
-        refsTotal: 1,
-        tagName: null,
-      } satisfies ReferencesResult;
+      asked.push(query.path ?? "");
+      throw new Error("sweep timed out");
     });
     const pending = confirmFileDelete({ name: "hero.jpg", path: "public/hero.jpg" });
     await tick();
@@ -277,19 +278,23 @@ describe("deleting media", () => {
     const text = dialogText();
     expect(text).toContain("could not be counted");
     expect(text).toContain("sweep timed out");
-    // The lane that DID answer found one reference; reporting it would read like a complete count.
-    expect(text).not.toContain("1 reference in 1 file");
+    /* Neither a number nor the reassurance. "Nothing else refers to it" is the sentence a delete
+       must never invent, and it reads identically whether the sweep found nothing or fell over. */
+    expect(text).not.toContain("references in");
+    expect(text).not.toContain("Nothing else in this project");
 
     settle("cancel");
     await pending;
   });
 
-  test("a rename of media says the same union will be repaired", async () => {
+  test("a rename of media promises to repair every spelling the delete would have broken", async () => {
+    /* The two dialogs must agree, and this is the pair that used to be able to disagree: the count
+       and the rewrite are one engine now, so a promise made here is one `applyRename` can keep. */
     installIndex({
-      "content/blog/images/hero.png": [
+      "posts/images/hero.png": [
+        { file: "posts/hello.md", ref: "./images/hero.png" },
         { file: "pages/index.json", ref: "/content/blog/images/hero.png" },
       ],
-      "posts/images/hero.png": [{ file: "posts/hello.md", ref: "./images/hero.png" }],
     });
     const text = textOf(await renamePromptMessage("posts/images/hero.png"));
     expect(text).toContain("2 references in 2 files will be updated automatically");

--- a/packages/studio/tests/media-paths.test.ts
+++ b/packages/studio/tests/media-paths.test.ts
@@ -1,16 +1,21 @@
 /**
- * The three names one media file has, and the query keys that follow from them.
+ * The three names one media file has, and the URL a surface holding the FILE must build.
  *
- * The assertion this file exists for is `authoredRefTargets("public/hero.jpg")` containing
- * `"hero.jpg"`. Without it a usage query about a public image asks about a path no document ever
- * resolves to, gets zero, and a delete confirmation calls a seven-page image unused.
+ * The assertion this file exists for is that `mediaSiteUrl("public/hero.jpg")` is `/hero.jpg`.
+ * Prefixing a file path with a slash gives `/public/hero.jpg`, a URL the site does not publish, and
+ * a content-collection image needs its mount rather than its directory.
+ *
+ * This file also used to assert `authoredRefTargets`, which enumerated every path an authored
+ * reference could resolve to so a usage query could ask about all of them. The engine resolves
+ * those lanes itself now (`site-architecture.md` §9.3), so both the helper and its tests are gone —
+ * `refactor-find-refs.test.ts` and `refactor-parity.test.ts` are where that behaviour is asserted,
+ * against a real project rather than against string math.
  */
 
 import "./with-dom.js";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { installMockPlatform, resetStudioState } from "./harness";
 import {
-  authoredRefTargets,
   baseName,
   dirName,
   mediaSiteUrl,
@@ -118,45 +123,5 @@ describe("previewFileSrc", () => {
     expect(previewFileSrc("content/posts/images/my photo.png")).toBe(
       "https://studio.example.com/p/o/r/main/raw/content/posts/images/my%20photo.png",
     );
-  });
-});
-
-describe("authoredRefTargets", () => {
-  test("a public image is ALSO asked about under its served path", () => {
-    // The whole point: `/hero.jpg` in a document resolves to `hero.jpg`, never `public/hero.jpg`.
-    expect(authoredRefTargets("public/hero.jpg")).toEqual(["public/hero.jpg", "hero.jpg"]);
-  });
-
-  test("an ordinary file is asked about once", () => {
-    expect(authoredRefTargets("assets/logo.svg")).toEqual(["assets/logo.svg"]);
-  });
-
-  test("a content asset whose source is its mount is not asked about twice", () => {
-    withCollections({ blog: { source: "content/blog" } });
-    expect(authoredRefTargets("content/blog/images/hero.png")).toEqual([
-      "content/blog/images/hero.png",
-    ]);
-  });
-
-  test("a remapped collection adds its mount path", () => {
-    withCollections({ blog: { source: "posts" } });
-    expect(authoredRefTargets("posts/images/hero.png")).toEqual([
-      "posts/images/hero.png",
-      "content/blog/images/hero.png",
-    ]);
-  });
-
-  test("input spelling does not change the answer", () => {
-    expect(authoredRefTargets("./public/hero.jpg")).toEqual(["public/hero.jpg", "hero.jpg"]);
-  });
-
-  test("there is no target for an empty path", () => {
-    expect(authoredRefTargets("")).toEqual([]);
-    expect(authoredRefTargets("./")).toEqual([]);
-  });
-
-  test("a project with no content section is not a crash", () => {
-    resetStudioState({ projectConfig: {} });
-    expect(authoredRefTargets("posts/images/hero.png")).toEqual(["posts/images/hero.png"]);
   });
 });

--- a/packages/studio/tests/media-usage.test.ts
+++ b/packages/studio/tests/media-usage.test.ts
@@ -1,11 +1,19 @@
 /**
- * "What breaks if I delete this image?" — asked in the shape an author wrote, not the shape the
- * file is stored in.
+ * "What breaks if I delete this image?" — one question, one query, one answer.
  *
- * The regression this file locks down: `findReferences` resolves `/hero.jpg` to `hero.jpg`, so a
- * query keyed on `public/hero.jpg` matches nothing and the delete dialog calls a seven-page image
- * unused. Every assertion below is about that gap, or about the other way to lie — assembling a
- * total out of lanes when one of them failed.
+ * This file used to lock down a client-side UNION: `findReferences` resolved a rooted reference
+ * against the project root alone, so a query keyed on `public/hero.jpg` matched no `/hero.jpg` and
+ * a delete dialog called a seven-page image unused. Studio's answer was to ask about every authored
+ * spelling and merge the results.
+ *
+ * The engine resolves those lanes itself now (`site-architecture.md` §9.3), on the write side as
+ * well as the read side, so the union is gone and so are the assertions about merging, per-lane
+ * failure and per-lane error dedup. What survives is everything the union was NOT doing: a media
+ * path is normalized before it becomes a query, an empty path FAILS rather than reporting zero, and
+ * a query that could not be answered says **unknown** — never "nothing uses this".
+ *
+ * That the lanes are all found is asserted where the behaviour now lives:
+ * `packages/server/tests/refactor-find-refs.test.ts` and `refactor-parity.test.ts`.
  */
 
 import "./with-dom.js";
@@ -16,7 +24,6 @@ import { invalidateUsages, usageWarning } from "../src/services/references";
 import {
   loadMediaUsages,
   mediaUsageHeadline,
-  mediaUsageQueries,
   peekMediaUsages,
   retryMediaUsages,
 } from "../src/files/media-usage";
@@ -64,87 +71,36 @@ beforeEach(() => {
   resetStudioState();
 });
 
-describe("mediaUsageQueries", () => {
-  test("a public image is asked about under both its names", () => {
-    expect(mediaUsageQueries("public/hero.jpg")).toEqual([
-      { path: "public/hero.jpg" },
-      { path: "hero.jpg" },
-    ]);
-  });
-
-  test("an empty path has nothing to ask", () => {
-    expect(mediaUsageQueries("")).toEqual([]);
-  });
-});
-
 describe("loadMediaUsages", () => {
-  test("finds the references a file-keyed query cannot see", async () => {
+  test("asks the engine about the file, once, and passes its answer through", async () => {
     const { asked } = install({
-      "hero.jpg": result("hero.jpg", [
+      "public/hero.jpg": result("public/hero.jpg", [
         hit("pages/index.json", "/hero.jpg"),
         hit("pages/about.json", "/hero.jpg"),
       ]),
     });
     const state = await loadMediaUsages("public/hero.jpg");
-    expect(asked).toEqual(["public/hero.jpg", "hero.jpg"]);
+
+    /* One entry, and it is the FILE path. The engine resolves `/hero.jpg` through its public lane;
+       Studio asking a second time under the served name would be a second implementation of that. */
+    expect(asked).toEqual(["public/hero.jpg"]);
     expect(state.status).toBe("ready");
     expect(state.status === "ready" && state.result.refsTotal).toBe(2);
     // The sentence a delete confirmation shows is the shared one, not a second vocabulary.
     expect(usageWarning(state, "delete")).toContain("2 references in 2 files");
   });
 
-  test("unions the lanes and reports the file that was asked about", async () => {
-    install({
-      "hero.jpg": result("hero.jpg", [hit("pages/index.json", "/hero.jpg")]),
-      "public/hero.jpg": result("public/hero.jpg", [hit("layouts/base.json", "./public/hero.jpg")]),
+  test("two spellings of one file are one query, not two cache entries", async () => {
+    const { asked } = install({
+      "public/hero.jpg": result("public/hero.jpg", [hit("pages/index.json", "/hero.jpg")]),
     });
-    const state = await loadMediaUsages("public/hero.jpg");
-    expect(state.status === "ready" && state.result.path).toBe("public/hero.jpg");
-    expect(state.status === "ready" && state.result.files.map((f) => f.path)).toEqual([
-      "layouts/base.json",
-      "pages/index.json",
-    ]);
-    expect(state.status === "ready" && state.result.filesReferencing).toBe(2);
+    await loadMediaUsages("./public/hero.jpg");
+    await loadMediaUsages("public/hero.jpg");
+    expect(asked).toEqual(["public/hero.jpg"]);
   });
 
-  test("one file named under two lanes is one row with both refs", async () => {
-    install({
-      "hero.jpg": result("hero.jpg", [hit("pages/index.json", "/hero.jpg", 2)]),
-      "public/hero.jpg": result("public/hero.jpg", [
-        hit("pages/index.json", "./public/hero.jpg", 1, "$src"),
-      ]),
-    });
-    const state = await loadMediaUsages("public/hero.jpg");
-    expect(state.status === "ready" && state.result.files).toHaveLength(1);
-    expect(state.status === "ready" && state.result.files[0]?.count).toBe(3);
-    expect(state.status === "ready" && state.result.files[0]?.refs).toHaveLength(2);
-    expect(state.status === "ready" && state.result.refsTotal).toBe(3);
-  });
-
-  test("the same ref counted twice in one lane sums rather than duplicating", async () => {
-    const twice = result("hero.jpg", [hit("pages/index.json", "/hero.jpg", 2)]);
-    install({ "hero.jpg": twice, "public/hero.jpg": twice });
-    const state = await loadMediaUsages("public/hero.jpg");
-    expect(state.status === "ready" && state.result.files[0]?.refs).toHaveLength(1);
-    expect(state.status === "ready" && state.result.files[0]?.refs[0]?.count).toBe(4);
-  });
-
-  test("unreadable documents are reported once, not once per lane", async () => {
-    const broken = { error: "bad json", path: "pages/broken.json" };
-    install({
-      "hero.jpg": { ...result("hero.jpg", []), errors: [broken] },
-      "public/hero.jpg": { ...result("public/hero.jpg", []), errors: [broken] },
-    });
-    const state = await loadMediaUsages("public/hero.jpg");
-    expect(state.status === "ready" && state.result.errors).toEqual([broken]);
-    expect(usageWarning(state, "delete")).toBe("Nothing else in this project refers to it.");
-  });
-
-  test("a lane that failed makes the whole answer unknown, never a partial total", async () => {
-    install({
-      "hero.jpg": new Error("index unavailable"),
-      "public/hero.jpg": result("public/hero.jpg", [hit("pages/index.json", "./public/hero.jpg")]),
-    });
+  test("a failed query is unknown, never a zero", async () => {
+    install({ "public/hero.jpg": new Error("index unavailable") });
     const state = await loadMediaUsages("public/hero.jpg");
     expect(state.status).toBe("failed");
     expect(mediaUsageHeadline(state)).toBe("Usage unknown");
@@ -160,15 +116,34 @@ describe("loadMediaUsages", () => {
   });
 
   test("an empty path fails rather than reporting nothing uses it", async () => {
-    install({});
-    const state = await loadMediaUsages("");
-    expect(state).toEqual({ message: "no media file to look for", status: "failed" });
+    const { asked } = install({});
+    expect(await loadMediaUsages("")).toEqual({
+      message: "no media file to look for",
+      status: "failed",
+    });
+    expect(await loadMediaUsages("./")).toEqual({
+      message: "no media file to look for",
+      status: "failed",
+    });
+    expect(asked).toEqual([]);
+  });
+
+  test("unreadable documents ride along in the result", async () => {
+    const broken = { error: "bad json", path: "pages/broken.json" };
+    install({
+      "public/hero.jpg": { ...result("public/hero.jpg", []), errors: [broken] },
+    });
+    const state = await loadMediaUsages("public/hero.jpg");
+    expect(state.status === "ready" && state.result.errors).toEqual([broken]);
+    expect(usageWarning(state, "delete")).toBe("Nothing else in this project refers to it.");
   });
 });
 
 describe("peekMediaUsages", () => {
-  test("is null until every lane has an answer", async () => {
-    install({ "hero.jpg": result("hero.jpg", [hit("pages/index.json", "/hero.jpg")]) });
+  test("is null until the query has an answer, then reports it", async () => {
+    install({
+      "public/hero.jpg": result("public/hero.jpg", [hit("pages/index.json", "/hero.jpg")]),
+    });
     expect(peekMediaUsages("public/hero.jpg")).toBeNull();
     await loadMediaUsages("public/hero.jpg");
     const state = peekMediaUsages("public/hero.jpg");
@@ -176,8 +151,8 @@ describe("peekMediaUsages", () => {
     expect(state?.status === "ready" && state.result.refsTotal).toBe(1);
   });
 
-  test("reports pending while a lane is in flight", async () => {
-    install({ "hero.jpg": result("hero.jpg", []) });
+  test("reports pending while the query is in flight", async () => {
+    install({ "public/hero.jpg": result("public/hero.jpg", []) });
     const running = loadMediaUsages("public/hero.jpg");
     expect(peekMediaUsages("public/hero.jpg")?.status).toBe("pending");
     expect(mediaUsageHeadline(peekMediaUsages("public/hero.jpg"))).toBe("Counting references…");
@@ -191,7 +166,7 @@ describe("peekMediaUsages", () => {
 });
 
 describe("retryMediaUsages", () => {
-  test("asks every lane again after a failure", async () => {
+  test("asks again after a failure", async () => {
     let fail = true;
     registerPlatform({
       findReferences: async (target: { path?: string }) => {
@@ -206,7 +181,7 @@ describe("retryMediaUsages", () => {
     fail = false;
     const state = await retryMediaUsages("public/hero.jpg");
     expect(state.status).toBe("ready");
-    expect(state.status === "ready" && state.result.refsTotal).toBe(2);
+    expect(state.status === "ready" && state.result.refsTotal).toBe(1);
   });
 
   test("an empty path has nothing to retry", async () => {
@@ -223,7 +198,7 @@ describe("mediaUsageHeadline", () => {
 
   test("a real count uses the shared wording", async () => {
     install({
-      "hero.jpg": result("hero.jpg", [
+      "public/hero.jpg": result("public/hero.jpg", [
         hit("pages/index.json", "/hero.jpg"),
         hit("layouts/base.json", "/hero.jpg"),
       ]),

--- a/specs/site-architecture.md
+++ b/specs/site-architecture.md
@@ -2,9 +2,9 @@
 
 ## File-Based Routing, Content Collections, Layouts, and Static Site Generation
 
-**Version:** 0.6.4-draft
+**Version:** 0.6.5-draft
 **Status:** Partial
-**Updated:** 2026-08-27
+**Updated:** 2026-08-29
 **License:** MIT
 
 ---
@@ -1442,11 +1442,13 @@ path and asks where that file publishes. `public/hero.jpg` is written `/hero.jpg
 shares not one segment with it — so a preview built by prefixing a file path with a slash names a
 URL the site does not publish.
 
-**Usage is keyed on the AUTHORED reference, not the resolved one.** A content-relative `./images/`
-reference previews at its asset-mount URL while the source keeps the authored form, so keying on
-what the browser fetched would under-count every content-relative use — and an under-count is what
-makes a delete look safe when it is not. A delete states its reference count, and where the count
-cannot be answered it says **unknown**, never zero.
+**Usage is asked about the FILE, once.** A content-relative `./images/` reference previews at its
+asset-mount URL while the source keeps the authored form, so a media surface holds at least three
+names for one file and could ask under any of them. It asks under the file: §9.3 binds the engine to
+resolve every authored spelling, so a host that enumerated the spellings itself would be a second
+implementation of that rule — and the half that can fix a count but never a rewrite. Under-counting
+is what makes a delete look safe when it is not, so a delete states its reference count, and where
+the count cannot be answered it says **unknown**, never zero.
 
 Studio adds media to a project from four places: the Upload button on any image field, a file
 dropped on the canvas, a file dropped on the Files tree, and the Library's drop zone — which names
@@ -2686,6 +2688,7 @@ This spec builds on existing Jx primitives wherever possible:
 
 ## Changelog
 
+- **0.6.5-draft** (2026-08-29) — A media usage query asks about the file once; enumerating a file's authored spellings host-side is the engine's job, not a media surface's.
 - **0.6.4-draft** (2026-08-27) — Record that collection discovery is recursive, so a subdirectory holds entries as well as co-located media.
 - **0.6.3-draft** (2026-08-27) — Reference resolution through the asset lanes is the refactor engine's contract, in both directions: a rooted ref is counted through every lane, rewritten through the lanes a build publishes, and named in the report when it cannot be written.
 - **0.6.2-draft** (2026-08-27) — Routing, layout, context and head-merge move to @jxsuite/site; standards evidence follows.


### PR DESCRIPTION
Closes #245

`authoredRefTargets()` existed because `findReferences` resolved a rooted reference against the project root alone: ask it about `public/hero.jpg` and every `/hero.jpg` in the project resolved to `hero.jpg`, matched nothing, and the delete dialog called a seven-page image unused. Studio compensated by enumerating every authored spelling of a file — the file, its served path, its asset-mount path — asking about all of them and unioning the answers.

That was a workaround in the wrong place, and it was left in place deliberately so #241's diff stayed on the engine. #241 moved lane resolution into `findReferences`, where it also fixes the **write** side, which a client-side union never could. It shipped in `server-v4.0.0`, so the union has now carried a release as belt-and-braces.

## Verified before deleting

Against a real project rather than by reading. A collection whose `source` is `posts/` and whose mount is `/content/blog` — the case the third lane was written for, where the mount prefix and the directory share no segment — answers a single query keyed on the **file**:

```
posts/images/hero.png -> 2 ref(s): pages/index.md [/content/blog/images/hero.png], posts/first.md [./images/hero.png]
public/logo.svg       -> 1 ref(s): pages/about.md [/logo.svg]
```

All three lanes, one question.

## What went, and what stayed

Gone: `authoredRefTargets`, `mediaUsageQueries`, the per-file merge, the least-informative-wins state reduction, and the unknown-vs-zero logic that only existed because several queries could disagree.

Kept, because none of it was the union's job: normalizing a path so two spellings are not two cache entries, failing on an empty path rather than reporting zero, and saying **unknown** for a query that could not be answered.

## Verification

`packages/studio` — 9796 pass, 0 fail; `media-usage.ts` and `media-paths.ts` both at 100% lines, manifest clean.

`destructive-confirmations.test.ts`'s fake index now answers the way the real sweep does: one query about a file returns every spelling that reaches it. Its query log is still asserted, for the opposite reason — it used to prove the dialog asked **enough** questions, and now proves it asks **exactly one**, because a second question there would be a second implementation of a rule the engine owns.

## Specs & docs

`site-architecture.md` §9.4 restated: usage is asked about the file, once, and enumerating a file's authored spellings host-side is the engine's job (0.6.4-draft → 0.6.5-draft). The user-facing prose was already accurate — nothing a person sees changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174XXa9vSu2si7BgniowRs4