### PR TITLE
docs(site-architecture): record why cross-root collection media has no usage count

### DIFF
--- a/docs/extending/reference/implementation-status.md
+++ b/docs/extending/reference/implementation-status.md
@@ -25,7 +25,7 @@ This page is generated from the `> **Status: …**` markers in the specification
 | `relationships.md`        | 0.1.4-draft  | Partial     | 2026-08-15 |
 | `schema.md`               | 0.4.8-draft  | Partial     | 2026-08-16 |
 | `server.md`               | 0.2.21       | Implemented | 2026-08-27 |
-| `site-architecture.md`    | 0.6.6-draft  | Partial     | 2026-08-29 |
+| `site-architecture.md`    | 0.6.8-draft  | Partial     | 2026-08-29 |
 | `spec.md`                 | 0.5.8-draft  | Partial     | 2026-08-26 |
 | `standards.md`            | 0.1.15-draft | Partial     | 2026-08-17 |
 | `studio-ui-guidelines.md` | 0.3.16       | Implemented | 2026-08-27 |

--- a/docs/extending/reference/spec-changelog.md
+++ b/docs/extending/reference/spec-changelog.md
@@ -278,6 +278,7 @@ Versions are `MAJOR.MINOR.PATCH` — **major** for a breaking change to a docume
 
 ## `site-architecture.md`
 
+- **0.6.8-draft** (2026-08-29) — Media reachable only through a cross-root asset mount has no project-relative name, which is why it has no usage count; addressing it is a host file-API question, not an engine one.
 - **0.6.6-draft** (2026-08-29) — A copy map's keys and a directory content source are references the engine reads by name; a copy destination is not, and a rewritten reference keeps its trailing slash.
 - **0.6.5-draft** (2026-08-29) — A media usage query asks about the file once; enumerating a file's authored spellings host-side is the engine's job, not a media surface's.
 - **0.6.4-draft** (2026-08-27) — Record that collection discovery is recursive, so a subdirectory holds entries as well as co-located media.

--- a/packages/server/src/refactor/mounts.ts
+++ b/packages/server/src/refactor/mounts.ts
@@ -19,6 +19,14 @@
  * dropped: its files are not addressable by a project-relative path, so no rename can reach them
  * and no reference to them can be counted. `projectPathsForSiteUrl` declines the same case by
  * name.
+ *
+ * That drop is deliberate and is not the near half of a bug. A collection's `source` may point
+ * outside the project (site-architecture.md §9.3), and its media renders — the compiler and the dev
+ * server both publish it at the mount URL — but the editing host's file API is project-scoped by
+ * containment check, so no surface can list, open or ask about the file either. Nothing therefore
+ * reports a confident zero about it, which is the failure the lane math exists to prevent. Reaching
+ * such a file means giving it a mount-relative identity in that file API, not widening this filter;
+ * see §9.3, which records the decision (issue 244).
  */
 
 import { relative } from "node:path";

--- a/specs/site-architecture.md
+++ b/specs/site-architecture.md
@@ -2,7 +2,7 @@
 
 ## File-Based Routing, Content Collections, Layouts, and Static Site Generation
 
-**Version:** 0.6.6-draft
+**Version:** 0.6.8-draft
 **Status:** Partial
 **Updated:** 2026-08-29
 **License:** MIT
@@ -1424,6 +1424,19 @@ So the contract binds the engine, both ways:
 - A reference is not always a VALUE, and not always shaped like a file. `project.json`'s `copy` map names the files it copies in its **keys**, and a content collection's `source` may name a **directory**, which carries no extension for the shape rule below to recognise. Both sit at a key the engine already knows by name, so both are read by name. The other half of `copy` is the counterexample that makes the rule: its values are destinations inside `outDir`, a directory no rename inside the project can move, so they are not references and are never rewritten.
 - A rewritten reference keeps the style the author wrote, trailing slash included. A directory `source` re-emitted without one is a diff on a line the rename had no business restyling.
 
+**A file outside the project root has no project-relative name, and that is the whole of why it has
+no usage count.** A collection's `source` may point outside the project (§9.3), and the compiler and
+the dev server both publish its media at the collection's mount URL, so it renders correctly. Nothing
+else about it works, and the pieces agree with each other: the engine drops a mount resolving outside
+the root, because no project-relative path names the file and no rename inside the project could move
+it; and the editing host's file API is project-scoped by containment check, so such a file cannot be
+listed, opened or previewed either. The result is coherent rather than broken — no surface can name
+the file, so no surface reports a confident zero about it, which is the failure this section exists
+to prevent. Closing the gap is not a matter of widening the engine: it means deciding how a file
+outside the project is ADDRESSED at all, most likely a mount-relative identity rather than a
+project-relative path, which is a change to the host's file API and not to the reference engine. That
+decision is not owed until a cross-root collection ships.
+
 Which keys carry a reference is not a fixed list. The document shapes that carry one grow with every extension that defines a media-typed prop, so an engine that enumerates key names is wrong by construction the next time one is added; what it can rely on is that a reference is a string SHAPED like a file, and that precision comes from resolving it and comparing against the file in question.
 
 Only statically referenced files are copied into the build. A `src` computed at runtime belongs in `public/`.
@@ -2690,6 +2703,7 @@ This spec builds on existing Jx primitives wherever possible:
 
 ## Changelog
 
+- **0.6.8-draft** (2026-08-29) — Media reachable only through a cross-root asset mount has no project-relative name, which is why it has no usage count; addressing it is a host file-API question, not an engine one.
 - **0.6.6-draft** (2026-08-29) — A copy map's keys and a directory content source are references the engine reads by name; a copy destination is not, and a rewritten reference keeps its trailing slash.
 - **0.6.5-draft** (2026-08-29) — A media usage query asks about the file once; enumerating a file's authored spellings host-side is the engine's job, not a media surface's.
 - **0.6.4-draft** (2026-08-27) — Record that collection discovery is recursive, so a subdirectory holds entries as well as co-located media.


### PR DESCRIPTION
Closes #244

#244 reads as a silent capability gap in the media browser: a collection whose `source` points outside the project has media that renders, reports zero usages, and would not be rewritten if it moved. A confident zero is the one answer a destructive surface must never invent, so that framing would make this urgent.

**Checked, and the framing is wrong in the way that matters.** `refactorMounts` drops a mount resolving outside the root, and the editing host's file API independently refuses any path outside the active project by containment check (symlink-safe, `assertAccessible` → `path is outside the active project`). So such a file cannot be listed, opened, previewed or asked about: **no surface can name it, and therefore no surface reports a confident zero about it.** The pieces agree with each other rather than half-failing.

## What is actually left

A real gap with a different shape. It is not that the engine declines too much — declining is correct, since no project-relative path names the file and no rename inside the project could move it. It is that **a file outside the project has no identity to be addressed by.** Closing it means deciding on one, most likely mount-relative, in the host's file API rather than in the reference engine.

Recorded in `site-architecture.md` §9.3 (0.6.4-draft → 0.6.5-draft) and pointed at from `mounts.ts`, where the drop happens, so the next reader of that filter finds the decision instead of re-deriving it.

No behaviour change; nothing is owed until a cross-root collection ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174XXa9vSu2si7BgniowRs4