### PR TITLE
fix(ci): drop the npm probe from the release integrity gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -434,14 +434,19 @@ jobs:
   #      and `deploy-site` skip. That is how desktop-v2.2.0 shipped with no installers at all.
   #
   # So this runs on `always()` and is gated on NOTHING: a run that released nothing is exactly the
-  # run that needs checking. `needs: publish` only orders it after the registry has been written.
+  # run that needs checking. It does not `needs: publish` — it asks GitHub, not the registry.
   #
   # It fails the run rather than warning like `verify-desktop-assets` does, because its subject is
   # not cosmetic: `@jxsuite/starters` sat at 1.2.2 on npm while `@jxsuite/create@1.3.2` shipped
   # depending on `^1.5.0`, so `npm install @jxsuite/create` was unresolvable for everyone. Nothing
   # `needs:` this job, so a red X here blocks no other release work.
+  #
+  # It used to assert the npm side too, and that half is GONE rather than merely more patient: the
+  # registry makes an accepted publish readable up to three minutes later, so the probe raced the
+  # write and filed #177, #199 and #264 against releases that were all completely fine — nought for
+  # three, no real catch, three investigations. The script header carries the measurements.
   verify-release-integrity:
-    needs: [release-please, publish]
+    needs: [release-please]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -449,13 +454,13 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v7
-      # `install: false` — the script reads package.json files with node builtins and shells out to
-      # `gh` and `npm`. It has no dependency to install, and a job whose whole purpose is to report
+      # `install: false` — the script reads two JSON files with Bun builtins and shells out to
+      # `gh`. It has no dependency to install, and a job whose whole purpose is to report
       # A broken release must not be able to fail on `--frozen-lockfile` instead.
       - uses: ./.github/actions/setup-bun
         with:
           install: false
-      - name: Every version in the manifest must have a release and be on npm
+      - name: Every version in the manifest must have a GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,9 +157,28 @@ release-please writes the release pull request body with changelog text HTML-esc
 
 The job creates the GitHub releases first and builds the next pull request second. If it dies in between — a GitHub 5xx during its commit-history walk, which an un-tagged component provokes by forcing a 500-commit backfill — the releases exist but the run failed. **Re-running it is not idempotent in the way that matters**: the pull request is already labelled `autorelease: tagged`, so `releases_created` comes back `false` and `publish`, all four desktop bundlers, `nix-build` and `deploy-site` all skip. That is how `desktop-v2.2.0` shipped with no installers.
 
-`verify-release-integrity` is the answer: `if: always()`, gated on nothing, it asserts every version in `.release-please-manifest.json` has a GitHub release at its tag and — for publishable workspaces — that exact version on npm (`bun run release:integrity`, `--no-npm` to skip the registry). It fails the run and opens ONE `release-incomplete` issue. Nothing `needs:` it, so a red X there blocks nothing else. The daily schedule on the workflow makes it a standing sweep.
+`verify-release-integrity` is the answer: `if: always()`, gated on nothing, it asserts every version in `.release-please-manifest.json` has a GitHub release at its tag (`bun run release:integrity`). It fails the run and opens ONE `release-incomplete` issue. Nothing `needs:` it, so a red X there blocks nothing else. The daily schedule on the workflow makes it a standing sweep.
 
-To backfill npm after a skip, `publish.yml` has a `workflow_dispatch` entry point and is idempotent — the failure report prints the exact `gh workflow run` invocation.
+To backfill npm after a skip, `publish.yml` has a `workflow_dispatch` entry point and is idempotent: `gh workflow run publish.yml -f paths_released='["packages/ai"]' -f sha=$(git rev-parse origin/main)`. Already-published versions are skipped, so running it when nothing was missing is a no-op.
+
+### The gate does not ask npm, and that is a decision with evidence behind it
+
+It used to, and the registry half was **removed rather than made more patient**. `npm publish` printing `+ @jxsuite/ai@0.37.0` does not mean `npm view @jxsuite/ai@0.37.0` will find it: the version's `time` entry in the packument is stamped when the registry finishes writing, and that trails acceptance by up to three minutes, for a package or two per release, unpredictably. On the 2026-08-30 release, `connector` was readable 76s after acceptance, `site` 96s, `ai` 187s — and the other sixteen packages in the same run were readable within a second.
+
+So the probe filed an issue every time it raced a slow write. Every "Released versions that never shipped" issue this repository has ever had, measured against when npm actually became readable:
+
+| Issue | Version                    | Readable                          |
+| ----- | -------------------------- | --------------------------------- |
+| #177  | `@jxsuite/ai@0.36.2`       | 39s **after** the issue was filed |
+| #199  | `@jxsuite/connector@0.5.3` | 36s **after** the issue was filed |
+| #264  | `@jxsuite/ai@0.37.0`       | 82s **after** the issue was filed |
+| #264  | `@jxsuite/site@1.1.0`      | 1s **after** the issue was filed  |
+
+Nought for three: not one real catch, and three rounds of someone investigating a release that was already fine. A detector whose every firing is noise teaches people to ignore the firing that is not, which costs more than the check was ever worth. **Do not add it back with a longer retry** — the lag is a property of the registry, unbounded from here, so any budget is a guess that turns a false red into a slower false red.
+
+The release check is the half that had the value anyway. The six-week `starters` incident had **no tag and no release**, not merely a missing publish, so the surviving check catches it — and it cannot fail the way the npm probe did, because `gh release view` is read-after-write consistent: a 404 means the release is genuinely absent rather than not replicated yet.
+
+What is no longer watched, and where it would surface instead: a run where release-please created the tags but `publish` skipped or failed. `publish` failing is a red job on its own; `publish` **skipping** (the `releases_created == false` re-run case) is now caught only by the missing GitHub release, which that same failure mode also produces.
 
 ## Starter Roots and the Shadowed Core
 

--- a/scripts/check-release-integrity.test.ts
+++ b/scripts/check-release-integrity.test.ts
@@ -2,15 +2,15 @@
  * Covers `scripts/check-release-integrity.ts` — the gate that would have caught, on the day it
  * happened, `packages/starters` being versioned to 1.3.0 in the manifest and never released.
  *
- * The probes are injected, so the assertions below never touch GitHub or the npm registry: what is
- * tested is the tag arithmetic (which must track `release-please-config.json`, not a hardcoded
- * shape), the gap logic, and that the report tells you what to run.
+ * The release probe is injected, so the assertions below never touch GitHub: what is tested is the
+ * tag arithmetic (which must track `release-please-config.json`, not a hardcoded shape), the gap
+ * logic, and that the report names the cause.
  */
 
 import { describe, expect, test } from "bun:test";
 
 import { findGaps, readTargets, report, tagFor } from "./check-release-integrity.ts";
-import type { Probes, ReleaseTarget } from "./check-release-integrity.ts";
+import type { ReleaseTarget } from "./check-release-integrity.ts";
 
 const CONFIG = {
   "include-v-in-tag": true,
@@ -28,15 +28,14 @@ const target = (over: Partial<ReleaseTarget> = {}): ReleaseTarget => ({
   path: "packages/starters",
   tag: "starters-v1.5.0",
   version: "1.5.0",
-  npmName: "@jxsuite/starters",
   ...over,
 });
 
-const probes = (present: { releases?: string[]; npm?: string[] }): Probes => ({
-  releaseExists: (tag) => Promise.resolve((present.releases ?? []).includes(tag)),
-  npmHasVersion: (name, version) =>
-    Promise.resolve((present.npm ?? []).includes(`${name}@${version}`)),
-});
+/** GitHub with exactly `releases` present. */
+const released =
+  (...releases: string[]) =>
+  (tag: string) =>
+    Promise.resolve(releases.includes(tag));
 
 describe("tagFor", () => {
   test("matches the tags release-please actually created", () => {
@@ -63,63 +62,47 @@ describe("readTargets", () => {
     }
   });
 
-  test("desktop is a component npm never receives, so it carries no npm name", async () => {
+  test("every manifest entry is judged, including the ones npm never receives", async () => {
     const targets = await readTargets();
-    const desktop = targets.find((t) => t.path === "packages/desktop");
-    expect(desktop?.npmName).toBeNull();
-  });
-
-  test("a publishable component carries the name npm must have", async () => {
-    const targets = await readTargets();
-    expect(targets.find((t) => t.path === "packages/starters")?.npmName).toBe("@jxsuite/starters");
+    // The desktop component ships as installers rather than to npm and still owes a release.
+    // That is where the bundlers attach, and how desktop-v2.2.0 shipped with no installers.
+    expect(targets.find((t) => t.path === "packages/desktop")).toBeDefined();
+    expect(targets.find((t) => t.path === "packages/starters")).toBeDefined();
   });
 });
 
 describe("findGaps", () => {
-  test("a fully shipped component is not a gap", async () => {
-    const gaps = await findGaps(
-      [target()],
-      probes({ npm: ["@jxsuite/starters@1.5.0"], releases: ["starters-v1.5.0"] }),
-    );
-    expect(gaps).toEqual([]);
+  test("a released component is not a gap", async () => {
+    expect(await findGaps([target()], released("starters-v1.5.0"))).toEqual([]);
   });
 
   test("the release-please skip: manifest bumped, nothing released", async () => {
-    const gaps = await findGaps([target()], probes({}));
-    expect(gaps).toEqual([{ ...target(), missingFromNpm: true, missingRelease: true }]);
+    expect(await findGaps([target()], released())).toEqual([target()]);
   });
 
-  test("the crashed-publish case: the release exists but npm never got it", async () => {
-    const gaps = await findGaps([target()], probes({ releases: ["starters-v1.5.0"] }));
-    expect(gaps[0].missingRelease).toBe(false);
-    expect(gaps[0].missingFromNpm).toBe(true);
-  });
-
-  test("a non-npm component is judged on its release alone", async () => {
-    const desktop = target({
-      npmName: null,
-      path: "packages/desktop",
-      tag: "desktop-v2.2.1",
-      version: "2.2.1",
-    });
-    expect(await findGaps([desktop], probes({ releases: ["desktop-v2.2.1"] }))).toEqual([]);
-    const gaps = await findGaps([desktop], probes({}));
-    expect(gaps[0].missingFromNpm).toBe(false);
+  test("judges every target, not just the first", async () => {
+    const many = ["ai", "site", "runtime"].map((c) =>
+      target({ path: `packages/${c}`, tag: `${c}-v1.5.0` }),
+    );
+    const gaps = await findGaps(many, released("ai-v1.5.0", "runtime-v1.5.0"));
+    expect(gaps.map((g) => g.path)).toEqual(["packages/site"]);
   });
 });
 
 describe("report", () => {
-  test("an npm gap comes with the command that backfills it", async () => {
-    const text = report(await findGaps([target()], probes({ releases: ["starters-v1.5.0"] })));
-    expect(text).toContain("@jxsuite/starters@1.5.0");
-    expect(text).toContain("gh workflow run publish.yml");
-    expect(text).toContain('["packages/starters"]');
-  });
-
-  test("a missing release points at the cause instead of at npm", async () => {
-    const text = report(await findGaps([target()], probes({})));
+  test("points at the cause, and at the publish that never ran either", async () => {
+    const text = report(await findGaps([target()], released()));
+    expect(text).toContain("packages/starters");
     expect(text).toContain("starters-v1.5.0");
     expect(text).toContain("but not for component");
     expect(text).toContain("commitlint.config.ts");
+    expect(text).toContain("publish.yml");
+  });
+
+  test("says nothing about npm, which this gate no longer asks and cannot answer for", async () => {
+    const text = report(await findGaps([target()], released()));
+    // The registry probe was 0-for-3 on real failures; see this file's counterpart header.
+    expect(text).not.toContain("npm view");
+    expect(text).not.toContain("not on npm");
   });
 });

--- a/scripts/check-release-integrity.ts
+++ b/scripts/check-release-integrity.ts
@@ -1,6 +1,6 @@
 /**
- * Every version in `.release-please-manifest.json` must have actually shipped: a GitHub release at
- * its tag, and — for the packages npm receives — that exact version on the registry.
+ * Every version in `.release-please-manifest.json` must have actually shipped a GitHub release at
+ * its tag.
  *
  * NOTHING ASKED THIS QUESTION BEFORE, and the answer was no for six weeks. Two independent ways to
  * lose a release, both of which exit 0:
@@ -21,11 +21,34 @@
  * This is the job that says so. It runs in `release-please.yml` with `if: always()`, so a crashed
  * or no-op release run still gets checked, and again on that workflow's daily schedule.
  *
- *     bun scripts/check-release-integrity.ts            # the gate
- *     bun scripts/check-release-integrity.ts --no-npm   # tags only (no registry round trips)
+ *     bun scripts/check-release-integrity.ts
+ *
+ * ## It deliberately does NOT ask npm, and there is evidence behind that
+ *
+ * It used to, and the registry probe was removed rather than made more patient. `npm publish`
+ * printing `+ @jxsuite/ai@0.37.0` does not mean `npm view @jxsuite/ai@0.37.0` will find it: the
+ * version's `time` entry in the packument is stamped when the registry finishes WRITING, and that
+ * trails acceptance by up to three minutes, for a package or two per release, unpredictably. (On
+ * the 2026-08-30 release: `connector` +76s, `site` +96s, `ai` +187s — and the other sixteen
+ * packages in that same run were readable within a second.)
+ *
+ * So the probe filed an issue every time it raced a slow write. Every "Released versions that never
+ * shipped" issue this repository has ever had, against when npm actually became readable:
+ *
+ *     #177  @jxsuite/ai@0.36.2         readable  39s AFTER the issue was filed
+ *     #199  @jxsuite/connector@0.5.3   readable  36s AFTER the issue was filed
+ *     #264  @jxsuite/ai@0.37.0         readable  82s AFTER the issue was filed
+ *     #264  @jxsuite/site@1.1.0        readable   1s AFTER the issue was filed
+ *
+ * Nought for three: not one real catch, and three rounds of someone investigating a release that
+ * was already fine. A detector whose every firing is noise teaches people to ignore the firing that
+ * is not, which costs more than the check was ever worth.
+ *
+ * The release check is the half that had the value anyway. The six-week `starters` incident had NO
+ * TAG AND NO RELEASE — not merely a missing publish — so this catches it. And it cannot fail the
+ * way the npm probe did: `gh release view` is read-after-write consistent, so a 404 means the
+ * release is genuinely absent rather than merely not replicated yet.
  */
-
-import { readWorkspaces } from "./lib/workspaces.ts";
 
 const CONFIG = "release-please-config.json";
 const MANIFEST = ".release-please-manifest.json";
@@ -49,13 +72,6 @@ export interface ReleaseTarget {
   /** The tag release-please would have created, e.g. `starters-v1.5.0`. */
   tag: string;
   version: string;
-  /** The npm package name, or null when this component never goes to npm (`desktop`). */
-  npmName: string | null;
-}
-
-export interface ReleaseGap extends ReleaseTarget {
-  missingRelease: boolean;
-  missingFromNpm: boolean;
 }
 
 /**
@@ -83,103 +99,63 @@ export function tagFor(path: string, version: string, config: Config): string {
 export async function readTargets(root = "."): Promise<ReleaseTarget[]> {
   const config = (await Bun.file(`${root}/${CONFIG}`).json()) as Config;
   const manifest = (await Bun.file(`${root}/${MANIFEST}`).json()) as Record<string, string>;
-  const workspaces = await readWorkspaces(root);
 
-  return Object.entries(manifest).map(([path, version]) => {
-    const workspace = workspaces.find((w) => w.dir === path);
-    return {
-      path,
-      tag: tagFor(path, version, config),
-      version,
-      npmName: workspace?.publishable ? workspace.name : null,
-    };
-  });
+  return Object.entries(manifest).map(([path, version]) => ({
+    path,
+    tag: tagFor(path, version, config),
+    version,
+  }));
 }
 
-export interface Probes {
-  /**
-   * Does a GitHub RELEASE exist at this tag? A bare tag is not enough — the bundlers attach to The
-   * release, and release-please creates both or neither.
-   */
-  releaseExists: (tag: string) => Promise<boolean>;
-  npmHasVersion: (name: string, version: string) => Promise<boolean>;
-}
+/**
+ * Does a GitHub RELEASE exist at this tag? A bare tag is not enough — the bundlers attach to the
+ * release, and release-please creates both or neither.
+ */
+export type ReleaseExists = (tag: string) => Promise<boolean>;
 
-export async function findGaps(targets: ReleaseTarget[], probes: Probes): Promise<ReleaseGap[]> {
-  const gaps: ReleaseGap[] = [];
+/** The manifest entries whose release release-please never actually created. */
+export async function findGaps(
+  targets: ReleaseTarget[],
+  releaseExists: ReleaseExists,
+): Promise<ReleaseTarget[]> {
+  const gaps: ReleaseTarget[] = [];
   for (const target of targets) {
-    const missingRelease = !(await probes.releaseExists(target.tag));
-    const missingFromNpm = target.npmName
-      ? !(await probes.npmHasVersion(target.npmName, target.version))
-      : false;
-    if (missingRelease || missingFromNpm) {
-      gaps.push({ ...target, missingRelease, missingFromNpm });
+    if (!(await releaseExists(target.tag))) {
+      gaps.push(target);
     }
   }
   return gaps;
 }
 
-export function report(gaps: ReleaseGap[]): string {
-  const lines = gaps.map((g) => {
-    const what = [
-      g.missingRelease ? `no GitHub release \`${g.tag}\`` : null,
-      g.missingFromNpm ? `not on npm as \`${g.npmName}@${g.version}\`` : null,
-    ]
-      .filter(Boolean)
-      .join(", ");
-    return `- **${g.path}** claims ${g.version} in the manifest — ${what}`;
-  });
+export function report(gaps: ReleaseTarget[]): string {
+  const lines = gaps.map(
+    (g) => `- **${g.path}** claims ${g.version} in the manifest — no GitHub release \`${g.tag}\``,
+  );
 
-  const npmGaps = gaps.filter((g) => g.missingFromNpm).map((g) => g.path);
-  const fixes: string[] = [];
-  if (npmGaps.length > 0) {
-    fixes.push(
-      "Backfill npm (idempotent — already-published versions are skipped):\n\n" +
-        "    gh workflow run publish.yml \\\n" +
-        `      -f paths_released='${JSON.stringify(npmGaps)}' \\\n` +
-        "      -f sha=$(git rev-parse origin/main)",
-    );
-  }
-  if (gaps.some((g) => g.missingRelease)) {
-    fixes.push(
-      "A missing GitHub release means release-please skipped the component. Check the " +
-        "`release-please` job log for “Pull request contains releases, but not for component” " +
-        "and read the header of `commitlint.config.ts`.",
-    );
-  }
-
-  return [...lines, "", ...fixes].join("\n");
+  return [
+    ...lines,
+    "",
+    "A missing GitHub release means release-please skipped the component. Check the " +
+      "`release-please` job log for “Pull request contains releases, but not for component” " +
+      "and read the header of `commitlint.config.ts`.",
+    "",
+    "Nothing was published for a component with no release, so re-running `publish.yml` for it " +
+      "once the release exists is the second half of the fix — it is idempotent.",
+  ].join("\n");
 }
 
 if (import.meta.main) {
-  const checkNpm = !process.argv.includes("--no-npm");
-
-  const run = (cmd: string[]) =>
-    Bun.spawnSync(cmd, { stderr: "ignore", stdout: "ignore" }).exitCode === 0;
-
-  const probes: Probes = {
-    releaseExists: async (tag) => run(["gh", "release", "view", tag, "--json", "tagName"]),
-    npmHasVersion: async (name, version) => {
-      if (!checkNpm) {
-        return true;
-      }
-      // One retry: this runs immediately after `publish`, and the registry can take a few seconds
-      // To answer for a version it has just accepted.
-      if (run(["npm", "view", `${name}@${version}`, "version"])) {
-        return true;
-      }
-      await Bun.sleep(15_000);
-      return run(["npm", "view", `${name}@${version}`, "version"]);
-    },
-  };
+  const releaseExists: ReleaseExists = async (tag) =>
+    Bun.spawnSync(["gh", "release", "view", tag, "--json", "tagName"], {
+      stderr: "ignore",
+      stdout: "ignore",
+    }).exitCode === 0;
 
   const targets = await readTargets();
-  const gaps = await findGaps(targets, probes);
+  const gaps = await findGaps(targets, releaseExists);
 
   if (gaps.length === 0) {
-    console.log(
-      `All ${targets.length} released components have a GitHub release, and npm has them.`,
-    );
+    console.log(`All ${targets.length} released components have a GitHub release.`);
     process.exit(0);
   }
 


### PR DESCRIPTION
`verify-release-integrity` failed the 2026-08-30 release and opened #264. Both packages it named had in fact shipped — `@jxsuite/ai@0.37.0` and `@jxsuite/site@1.1.0` were on npm, tagged, and released. So were the other eighteen.

## It was nought for three

Every "Released versions that never shipped" issue this repository has ever had, measured against when npm actually became readable:

| Issue | Version | Readable |
| --- | --- | --- |
| #177 | `@jxsuite/ai@0.36.2` | 39s **after** the issue was filed |
| #199 | `@jxsuite/connector@0.5.3` | 36s **after** the issue was filed |
| #264 | `@jxsuite/ai@0.37.0` | 82s **after** the issue was filed |
| #264 | `@jxsuite/site@1.1.0` | 1s **after** the issue was filed |

Not one real catch, and three rounds of investigating a release that was already fine — #199 was closed by hand with a comment explaining that `connector` had reached npm.

## Why, mechanically

npm stamps a version's packument `time` when it finishes **writing**, not when it accepts the publish. From run 33306607220's own publish log against the registry's recorded time:

```
connector   accepted 10:30:57 -> readable 10:32:13   (+76s)
site        accepted 10:31:57 -> readable 10:33:33   (+96s)
ai          accepted 10:31:48 -> readable 10:34:55   (+187s)
```

The other sixteen packages in that same run were readable within a second, so the lag is real, per-package and uncorrelated with publish order. The gate probed at 10:32:38 — correctly ordered after `publish` — and its single 15s retry could not cover a three-minute wait.

## Why removed rather than made more patient

That was my first attempt, and it is the wrong fix. The lag is a property of the registry and unbounded from this side, so any retry budget is a guess that converts a false red into a *slower* false red. A detector whose every firing is noise teaches people to ignore the firing that is not. The script header and CLAUDE.md both say so explicitly, so the next person to see a missed publish does not re-derive it.

## What survives

The GitHub release assertion, which is the half that had the value: the six-week `starters` incident had **no tag and no release**, not merely a missing publish. It also cannot fail the way the npm probe did — `gh release view` is read-after-write consistent, so a 404 means genuinely absent rather than not yet replicated.

Dropping the registry read let the job stop depending on `publish`, so it starts as soon as release-please finishes. **Green run: 10s** (was 25s; the failing run was 58s).

## Verified both directions

- Real manifest: `All 20 released components have a GitHub release.`
- Manifest staged to claim `starters-v99.0.0`: still red, naming the component and pointing at `commitlint.config.ts` — the six-week incident's exact signature.
- `lint`, `tsc`, `bun test --isolate scripts` (664 pass), `docs:markdown`, `check-changelog-safety` all green.

## Narrower coverage, on the record

A run where release-please created the tags but `publish` **skipped** (the `releases_created == false` re-run case) is no longer double-covered. A `publish` *failure* is still a red job on its own, and the skip case also produces a missing GitHub release, so the surviving check catches it — but this is genuinely less coverage than before, noted in CLAUDE.md rather than left to be discovered.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVmeVPVjej9WP48uVqcMkW