### PR TITLE
fix(studio): a cloud recent project opens the project it names

### DIFF
--- a/packages/studio/src/platforms/cloud.ts
+++ b/packages/studio/src/platforms/cloud.ts
@@ -60,6 +60,15 @@ interface ProjectInfoWire {
   projectConfig: Record<string, unknown> | null;
 }
 
+/** One row of the platform's project catalogue (`GET /api/v1/projects`). */
+interface ProjectListWire {
+  fullName: string;
+  owner: string;
+  name: string;
+  defaultBranch: string;
+  permission: string;
+}
+
 interface SessionEventWire {
   kind: "fs" | "git";
   events?: FsEvent[];
@@ -304,6 +313,35 @@ export function parseRootKey(root: string): CloudProject | null {
   return { owner, repo, branch };
 }
 
+/** Every project this account can open, straight off the wire; [] when the catalogue is unreachable. */
+async function fetchProjects(): Promise<ProjectListWire[]> {
+  const res = await fetch("/api/v1/projects", { credentials: "include" });
+  return res.ok ? ((await res.json()) as ProjectListWire[]) : [];
+}
+
+/**
+ * The project a root key names, for the two members that navigate by one.
+ *
+ * Tolerates the branchless "owner/repo" keys older studios wrote into Recent: they cannot say which
+ * branch they meant, so the catalogue's default branch answers for them — the same branch that
+ * project's Projects row opens. Null when the key is neither form, or names nothing this account
+ * can reach.
+ */
+export async function resolveRootKey(rootKey: string): Promise<CloudProject | null> {
+  const parsed = parseRootKey(rootKey);
+  if (parsed) {
+    return parsed;
+  }
+  const legacy = /^([^/@]+)\/([^/@]+)$/.exec(rootKey);
+  if (!legacy) {
+    return null;
+  }
+  const [, owner, repo] = legacy;
+  const catalogue = await fetchProjects().catch(() => []);
+  const match = catalogue.find((p) => p.owner === owner && p.name === repo);
+  return match ? { owner: match.owner, repo: match.name, branch: match.defaultBranch } : null;
+}
+
 /**
  * Bound mode (project non-null) drives one repo+branch session; project-less mode (null, the
  * /studio route) exposes only the catalogue surface — listProjects/listStarters/createProject and
@@ -311,7 +349,17 @@ export function parseRootKey(root: string): CloudProject | null {
  */
 export function createCloudPlatform(project: CloudProject | null): StudioPlatform {
   const base = project ? sessionBase(project) : "";
-  const root = project ? `${project.owner}/${project.repo}` : "";
+  /* The ROOT KEY, branch included — not a bare "owner/repo". This value is the project's identity
+     everywhere the shell keeps one: `probeRootProject` hands it to the recent-projects list, and
+     `setWindowProject` reopens a project by parsing it back with `parseRootKey`, which answers null
+     for a branchless key. So every Recent row a bound session had written was a click that did
+     nothing — no navigation, no error, and `deduped: true` telling the caller the open had been
+     handled — while the SAME project opened fine from the Projects catalogue, whose entries carry
+     the branch (`listProjects` below builds them with `projectRootKey`). Agreeing with the catalogue
+     also restores the welcome screen's dedupe (it matches the two lists by root, so the project
+     stopped appearing in both) and gives a branch its own Recent row, which is what a root key that
+     names a branch is for. */
+  const root = project ? projectRootKey(project) : "";
   /**
    * One multiplexed collab socket per session; per-doc handles come from openDoc. Memoized as a
    * promise so concurrent first opens share the connection instead of racing two sockets.
@@ -928,17 +976,7 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
     // ─── Project catalogue & navigation (Studio welcome / New Project UI) ──
 
     async listProjects(): Promise<ProjectListEntry[]> {
-      const res = await fetch("/api/v1/projects", { credentials: "include" });
-      if (!res.ok) {
-        return [];
-      }
-      const entries = (await res.json()) as {
-        fullName: string;
-        owner: string;
-        name: string;
-        defaultBranch: string;
-        permission: string;
-      }[];
+      const entries = await fetchProjects();
       return entries.map((p) => ({
         name: p.fullName,
         root: projectRootKey({ owner: p.owner, repo: p.name, branch: p.defaultBranch }),
@@ -956,8 +994,15 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
 
     /** Welcome/recents open path: navigate this tab into the project's editor. */
     async setWindowProject(rootKey: string) {
-      const target = parseRootKey(rootKey);
-      if (target && typeof location !== "undefined") {
+      const target = await resolveRootKey(rootKey);
+      /* Throw rather than fall through: `deduped` tells the caller the open was handled, so an
+         unresolvable key answered "done" and left the user looking at the screen they clicked on.
+         The throw reaches `openRecentProject`'s catch, which reports the failure and drops the
+         entry — the right end for a row naming a project this account can no longer open. */
+      if (!target) {
+        throw new Error(`No project to open at ${rootKey}`);
+      }
+      if (typeof location !== "undefined") {
         location.assign(editUrl(target));
       }
       // Navigation unloads the page; deduped stops the caller's follow-up work.
@@ -965,8 +1010,13 @@ export function createCloudPlatform(project: CloudProject | null): StudioPlatfor
     },
 
     async openProjectInNewWindow(rootKey: string) {
-      const target = parseRootKey(rootKey);
-      if (target && typeof window !== "undefined") {
+      const target = await resolveRootKey(rootKey);
+      // Same contract as setWindowProject: the caller reports "Opened in another window" on any
+      // Resolved call, so a key that opens nothing has to fail rather than answer.
+      if (!target) {
+        throw new Error(`No project to open at ${rootKey}`);
+      }
+      if (typeof window !== "undefined") {
         window.open(editUrl(target), "_blank", "noopener");
       }
       // `_blank` always makes a tab; a browser tab already showing this project is not something

--- a/packages/studio/src/publish/publish-panel.ts
+++ b/packages/studio/src/publish/publish-panel.ts
@@ -65,10 +65,14 @@ function deriveSlug(name: string): string {
   );
 }
 
-/** Prefill owner/repo from cloud roots ("owner/repo"); blank elsewhere. */
+/**
+ * Prefill owner/repo from cloud root keys ("owner/repo@branch", or the older "owner/repo"); blank
+ * elsewhere. The branch is part of the key the cloud adapter reports as its `projectRoot` — without
+ * the optional suffix here, the whole key failed to match and the form opened empty.
+ */
 function prefillRepo(): { owner: string; repo: string } {
   const root = getPlatform().projectRoot;
-  const match = /^([\w.-]+)\/([\w.-]+)$/.exec(root);
+  const match = /^([\w.-]+)\/([\w.-]+)(?:@.+)?$/.exec(root);
   return match ? { owner: match[1]!, repo: match[2]! } : { owner: "", repo: "" };
 }
 

--- a/packages/studio/tests/cloud-platform.test.ts
+++ b/packages/studio/tests/cloud-platform.test.ts
@@ -105,7 +105,7 @@ describe("project binding", () => {
     const platform = createCloudPlatform(PROJECT);
     const opened = await platform.openProject();
     expect(opened?.config.name).toBe("My Site");
-    expect(opened?.handle.root).toBe("octocat/my-site");
+    expect(opened?.handle.root).toBe("octocat/my-site@main");
   });
 
   test("open-project picking routes through the studio repo picker in both modes", () => {
@@ -129,6 +129,28 @@ describe("project binding", () => {
     const probe = await platform.probeRootProject();
     expect(probe?.info.isSiteProject).toBe(false);
     expect(probe?.meta.name).toBe("my-site");
+  });
+
+  /* The Recent list is written from `probeRootProject`'s meta.root and re-opened by parsing it back
+     as a root key, so a branchless root here was a Recent row that did nothing when clicked while
+     the catalogue's row for the same project — built by `projectRootKey` — opened it. */
+  test("the bound project's root is the catalogue root key, branch included", async () => {
+    mockFetch({
+      "/project-info": {
+        body: {
+          root: "octocat/my-site",
+          name: "my-site",
+          defaultBranch: "main",
+          permission: "write",
+          projectConfig: { name: "My Site" },
+        },
+      },
+    });
+    const platform = createCloudPlatform(PROJECT);
+    expect(platform.projectRoot).toBe(projectRootKey(PROJECT));
+    const probe = await platform.probeRootProject();
+    expect(probe?.meta.root).toBe(projectRootKey(PROJECT));
+    expect(parseRootKey(platform.projectRoot)).toEqual(PROJECT);
   });
 });
 
@@ -421,6 +443,45 @@ describe("project-less mode (/studio)", () => {
       deduped: true,
       config: null,
     });
+  });
+
+  /* Recent rows written by studios that shipped before the root key carried a branch are still in
+     people's browsers. They name a project but not a branch, so the catalogue answers with the one
+     that project's Projects row opens. */
+  test("setWindowProject resolves a branchless recent through the catalogue", async () => {
+    const calls = mockFetch({
+      "/api/v1/projects": {
+        body: [
+          {
+            fullName: "octocat/site",
+            owner: "octocat",
+            name: "site",
+            defaultBranch: "trunk",
+            permission: "admin",
+          },
+        ],
+      },
+    });
+    const realAssign = location.assign;
+    const assigned: string[] = [];
+    (location as { assign: unknown }).assign = (url: string) => {
+      assigned.push(url);
+    };
+    try {
+      const p = createCloudPlatform(null);
+      expect(await p.setWindowProject?.("octocat/site")).toEqual({ deduped: true, config: null });
+      expect(calls.some((c) => c.url.includes("/api/v1/projects"))).toBe(true);
+      expect(assigned).toEqual([editUrl({ owner: "octocat", repo: "site", branch: "trunk" })]);
+    } finally {
+      (location as { assign: unknown }).assign = realAssign;
+    }
+  });
+
+  test("setWindowProject fails on a key that names nothing openable", async () => {
+    mockFetch({ "/api/v1/projects": { body: [] } });
+    const p = createCloudPlatform(null);
+    expect(p.setWindowProject?.("octocat/gone")).rejects.toThrow(/No project to open/);
+    expect(p.setWindowProject?.("not a root key")).rejects.toThrow(/No project to open/);
   });
 });
 
@@ -888,7 +949,7 @@ describe("bound session surface", () => {
     expect(await p.locateFile("index.md")).toBe("pages/index.md");
     expect(await p.searchFiles("index", [".md"])).toHaveLength(1);
     const ctx = await p.resolveSiteContext("pages/index.md");
-    expect(ctx.sitePath).toBe("octocat/my-site");
+    expect(ctx.sitePath).toBe("octocat/my-site@main");
     expect(ctx.fileRelPath).toBe("pages/index.md");
   });
 
@@ -1131,7 +1192,9 @@ describe("navigation members under a DOM", () => {
       const p = createCloudPlatform(null);
       await p.openProjectInNewWindow?.("octocat/site@main");
       expect(openMock).toHaveBeenCalled();
-      await p.openProjectInNewWindow?.("malformed"); // Parse-fail path: no call.
+      // Unresolvable: it must fail rather than answer, because the caller reports "Opened in
+      // Another window" for any call that returns.
+      expect(p.openProjectInNewWindow?.("malformed")).rejects.toThrow(/No project to open/);
       expect(openMock).toHaveBeenCalledTimes(1);
     } finally {
       (window as { open: unknown }).open = realOpen;

--- a/packages/studio/tests/default-platform.test.ts
+++ b/packages/studio/tests/default-platform.test.ts
@@ -24,7 +24,8 @@ describe("resolveDefaultPlatform", () => {
     g.__jxCloud = { project: { owner: "acme", repo: "site", branch: "main" } };
     const platform = resolveDefaultPlatform();
     expect(platform.id).toBe("cloud");
-    expect(platform.projectRoot).toBe("acme/site");
+    // The root key, branch included — the identity Recent and the catalogue both address a project by.
+    expect(platform.projectRoot).toBe("acme/site@main");
   });
 
   test("returns the cloud adapter for the project-less hub (null project)", () => {

--- a/packages/studio/tests/publish-panel.test.ts
+++ b/packages/studio/tests/publish-panel.test.ts
@@ -293,6 +293,25 @@ describe("openPublishPanel — connect form", () => {
     expect(bodyText()).toContain("owner/repo are all required");
   });
 
+  /* The cloud adapter's projectRoot is the root key "owner/repo@branch". A prefill that only
+     matched the branchless form left both fields empty on the one host that can fill them. */
+  test("prefills owner and repo from a cloud root key", async () => {
+    resetStudioState({ projectConfig: { build: {}, name: "My Site" } });
+    installMockPlatform({
+      cfApi: cfApiMock({ "/accounts": [{ id: DEPLOY.accountId, name: "Acme" }] }),
+      cfConnection: () =>
+        Promise.resolve({ accountId: DEPLOY.accountId, accountName: "Acme", connected: true }),
+      projectRoot: "octocat/site@main",
+    });
+    openPublishPanel();
+    await flush();
+    const values = [...document.querySelectorAll("#layer-modal sp-textfield")].map((el) =>
+      el.getAttribute("value"),
+    );
+    expect(values).toContain("octocat");
+    expect(values).toContain("site");
+  });
+
   test("connects end-to-end and lands on the status view", async () => {
     resetStudioState({ projectConfig: { build: {}, name: "My Site" } });
     installMockPlatform({


### PR DESCRIPTION
On Jx Cloud, clicking a project in the Start pane's **Recent** list did nothing. The same project
opened normally from **Projects** — and appeared in both sections, which is the tell.

## What was wrong

A cloud project is addressed by a root key, `owner/repo@branch`: `listProjects` builds catalogue
entries with `projectRootKey`, and `setWindowProject` / `openProjectInNewWindow` turn a key back
into a project with `parseRootKey`, which requires the branch.

The adapter's own identity was missing it:

```ts
const root = project ? `${project.owner}/${project.repo}` : "";
```

That value is `platform.projectRoot`, and `probeRootProject` hands it to `addRecentProject` — so
every Recent row a bound editor session wrote was branchless. Clicking one parsed to null, nothing
navigated, and `setWindowProject` still answered `{ deduped: true }`, which tells `openRecentProject`
the open was handled. No navigation, no error, no complaint. The welcome screen dedupes Recent
against the catalogue by root, so the two spellings also kept the project listed twice.

## The fix

- `projectRoot` is the root key. Recent, the catalogue and the workspace now agree on one identity
  per project, and a branch gets its own Recent row — which is what a key that names a branch is for.
- Both navigation members resolve through a new `resolveRootKey`. It accepts the branchless keys
  already sitting in people's browsers, taking that project's default branch from the catalogue, and
  returns null when a key names nothing this account can open.
- On null they now throw. `openRecentProject` catches that, reports the failure and drops the stale
  row — better than an open that ends in silence while claiming it was handled.
- The publish panel's owner/repo prefill reads the same `projectRoot`, so its pattern accepts the
  branch suffix; without that it would have gone from matching to matching nothing.

## Testing

`bun test --isolate` in `packages/studio`: 9924 pass, 0 fail. Lint, oxfmt, `tsc` clean; per-file
coverage above the workspace gate for both changed sources; coverage manifest OK.

Verified end to end by building the bundle and staging it into the platform host with
`build-assets --link`: the Recent row navigates to `/edit/owner/repo@branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
