### PR TITLE
fix(ci): silence FlakeHub login noise from nix-installer-action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -173,6 +173,13 @@ jobs:
           # An afternoon.
           extra-conf: |
             accept-flake-config = true
+          # `nixConfig` above is a plain-Nix feature — accepting a flake's own substituter needs
+          # no Determinate-only capability (FlakeHub substituters, lazy trees), so there is nothing
+          # this job loses by turning `determinate` off. Left at its `true` default,
+          # `determinate-nixd` tries to log into FlakeHub on every run and fails, because this repo
+          # isn't registered there — a failure annotation on green builds that this silences at
+          # the source rather than working around downstream.
+          determinate: false
 
       # Backs /nix/store with the GitHub Actions cache. cache.nixos.org already serves the nixpkgs
       # half of the closure; what it can never serve is the ~1000 fixed-output npm tarball
@@ -182,6 +189,9 @@ jobs:
         with:
           # Perf/diagnostic telemetry to Determinate Systems is on by default; "" disables it.
           diagnostic-endpoint: ""
+          # This lane doesn't use FlakeHub Cache; without this the action makes its own opportunistic
+          # FlakeHub probe and logs a second, separate authentication-failure annotation.
+          use-flakehub: false
 
       # Installs the `cachix` binary and adds https://jxsuite.cachix.org as a substituter. Pushing
       # is deliberately NOT delegated to this action: its default daemon mode pushes every path

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -322,6 +322,9 @@ jobs:
         with:
           extra-conf: |
             accept-flake-config = true
+          # See nix.yml: no Determinate-only capability is in play here, and leaving this at its
+          # `true` default just logs a FlakeHub-login-failure annotation on this job too.
+          determinate: false
 
       - name: A consumer substitutes instead of building
         env:


### PR DESCRIPTION
## Summary
- `nix-installer-action` defaults to installing Determinate Nix, which has `determinate-nixd` try to log into FlakeHub on every run — failing (and logging an annotation) because this repo isn't registered there.
- Neither `nix.yml` nor `release-please.yml`'s `verify-cache` job uses a Determinate-only capability (the `nixConfig` substituter both accept via `accept-flake-config` is a plain-Nix feature), so `determinate: false` costs nothing.
- Also sets `use-flakehub: false` on `magic-nix-cache-action`, which makes its own separate opportunistic FlakeHub probe and logs its own failure annotation.
- Same fix already applied and verified across three sibling repos (nixos-router, frappe-types, wordpress-nix) that hit the identical annotation.

## Test plan
- [x] `actionlint` clean on both changed workflow files (pre-existing shellcheck warning elsewhere in release-please.yml is unrelated and present on `main` too)
- [ ] `ci` (required status check) passes on this PR and the FlakeHub annotation is gone from the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)