### PR TITLE
fix(ci): a manifest 0.0.0 is release-please's "not yet released", and @jxsuite/ui starts at 0.1.0

### DIFF
--- a/docs/extending/contributing/monorepo.md
+++ b/docs/extending/contributing/monorepo.md
@@ -111,6 +111,8 @@ The checkout is sparse, keeping only the five directories the SDK's entry points
 
 Versions are release-please's job. Every publishable workspace is a component in `release-please-config.json` with a matching `.release-please-manifest.json` entry, and both lists are **derived-checked** by `scripts/release-config.test.ts`. A package that is publishable but unlisted is never versioned, tagged or published, and nothing else in the pipeline can notice. Two extensions sat in exactly that state before the check existed.
 
+A new package enters the manifest at `0.0.0`, which release-please reads as "no release yet", and names its first version with `initial-version` in its config entry (`0.1.0` for a pre-1.0 package; release-please's default is `1.0.0`). The integrity gate (`bun run release:integrity`) skips a `0.0.0` entry for the same reason: it claims nothing until the first release pull request lands. Seeding the manifest with a version that was never released is the other way round, and it is how `packages/catalog` came to claim a `0.1.0` no release ever shipped.
+
 Two branches:
 
 - **`main`** is the trunk. Every PR targets it, and it is the tip of development.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -144,7 +144,8 @@
     "packages/ui": {
       "release-type": "node",
       "component": "ui",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "initial-version": "0.1.0"
     }
   }
 }

--- a/scripts/check-release-integrity.test.ts
+++ b/scripts/check-release-integrity.test.ts
@@ -9,7 +9,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { findGaps, readTargets, report, tagFor } from "./check-release-integrity.ts";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { UNRELEASED, findGaps, readTargets, report, tagFor } from "./check-release-integrity.ts";
 import type { ReleaseTarget } from "./check-release-integrity.ts";
 
 const CONFIG = {
@@ -71,6 +75,29 @@ describe("readTargets", () => {
     // That is where the bundlers attach, and how desktop-v2.2.0 shipped with no installers.
     expect(targets.find((t) => t.path === "packages/desktop")).toBeDefined();
     expect(targets.find((t) => t.path === "packages/starters")).toBeDefined();
+  });
+
+  test("a component still at release-please's 0.0.0 sentinel claims nothing yet", async () => {
+    // `@jxsuite/ui` entered the manifest at 0.0.0 and the gate demanded `ui-v0.0.0` of it — a
+    // Release that release-please by its own rule never creates. The sentinel is not a claim.
+    const root = mkdtempSync(join(tmpdir(), "release-integrity-"));
+    writeFileSync(
+      join(root, "release-please-config.json"),
+      JSON.stringify({
+        "include-v-in-tag": true,
+        "include-component-in-tag": true,
+        packages: {
+          "packages/shipped": { component: "shipped" },
+          "packages/fresh": { component: "fresh" },
+        },
+      }),
+    );
+    writeFileSync(
+      join(root, ".release-please-manifest.json"),
+      JSON.stringify({ "packages/shipped": "1.2.0", "packages/fresh": UNRELEASED }),
+    );
+    const targets = await readTargets(root);
+    expect(targets.map((t) => t.tag)).toEqual(["shipped-v1.2.0"]);
   });
 });
 

--- a/scripts/check-release-integrity.ts
+++ b/scripts/check-release-integrity.ts
@@ -95,16 +95,29 @@ export function tagFor(path: string, version: string, config: Config): string {
   return `${prefix}${includeV ? "v" : ""}${version}`;
 }
 
+/**
+ * The version release-please reads as "no release yet". A new component enters the manifest at
+ * `0.0.0`, and release-please's own backfill (`manifest.js`, "backfill latest release tags from
+ * manifest") skips exactly that string, so the first release pull request starts the component at
+ * its `initial-version` rather than bumping from it. Such an entry CLAIMS nothing, and a gate that
+ * demanded `ui-v0.0.0` of it would be red from the day a package is added until the day it is first
+ * released — which is a red X that names no defect, the failure mode this script's header argues
+ * against.
+ */
+export const UNRELEASED = "0.0.0";
+
 /** What every manifest entry claims to have shipped. */
 export async function readTargets(root = "."): Promise<ReleaseTarget[]> {
   const config = (await Bun.file(`${root}/${CONFIG}`).json()) as Config;
   const manifest = (await Bun.file(`${root}/${MANIFEST}`).json()) as Record<string, string>;
 
-  return Object.entries(manifest).map(([path, version]) => ({
-    path,
-    tag: tagFor(path, version, config),
-    version,
-  }));
+  return Object.entries(manifest)
+    .filter(([, version]) => version !== UNRELEASED)
+    .map(([path, version]) => ({
+      path,
+      tag: tagFor(path, version, config),
+      version,
+    }));
 }
 
 /**


### PR DESCRIPTION
## What surfaced

The first `Release` run on `main` after #298 (`a31f63e1`) went red in `verify-release-integrity` with a second gap beside the standing `catalog` one (#280):

```
- **packages/ui** claims 0.0.0 in the manifest — no GitHub release `ui-v0.0.0`
```

And the release PR (#268) it refreshed was carrying **`ui: 1.0.0`**.

## Why

`0.0.0` is not a claim. It is the string release-please's own manifest backfill skips (`manifest.js`, "backfill latest release tags from manifest"): a component with no release yet, whose first release PR starts it at `initial-version`. The gate demanded a release release-please never creates, so it would have stayed red from the day `packages/ui` was added until the release PR merged — a red X naming no defect, the failure mode `check-release-integrity.ts`'s header argues against.

With no `initial-version`, release-please's default first version is `1.0.0`. The kit's spec is `ui.md` 0.1.x-draft and its standards decisions rest on being pre-1.0, so `1.0.0` was an accident of a default, not a decision.

## Change

- `scripts/check-release-integrity.ts`: `readTargets` skips the `0.0.0` sentinel (`UNRELEASED`), with a test over a fixture config + manifest.
- `release-please-config.json`: `initial-version: "0.1.0"` on `packages/ui`. release-please recomputes #268 on its next `push: main` run, so `@jxsuite/ui` ships first as **0.1.0**.
- `docs/extending/contributing/monorepo.md`: records the convention (enter at `0.0.0`, name the first version in config), and that seeding a never-released version by hand is how `catalog` came to claim `0.1.0` (#280, unchanged here).

No workspace is touched, so no package version moves from this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FKbRXZRttTmhV8dLmwASJ